### PR TITLE
Replace FormParam with a custom Param annotation

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/group/GroupData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/group/GroupData.java
@@ -18,14 +18,13 @@
 
 package com.netscape.certsrv.group;
 
-import javax.ws.rs.FormParam;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.common.Constants;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.certsrv.util.Param;
 
 /**
  * @author Endi S. Dewata
@@ -57,7 +56,7 @@ public class GroupData implements JSONSerializer {
         this.groupID = groupID;
     }
 
-    @FormParam(Constants.PR_GROUP_DESC)
+    @Param(Constants.PR_GROUP_DESC)
     @JsonProperty("Description")
     public String getDescription() {
         return description;

--- a/base/common/src/main/java/com/netscape/certsrv/group/GroupMemberData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/group/GroupMemberData.java
@@ -18,13 +18,12 @@
 
 package com.netscape.certsrv.group;
 
-import javax.ws.rs.FormParam;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.common.Constants;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.certsrv.util.Param;
 
 /**
  * @author Endi S. Dewata
@@ -36,7 +35,7 @@ public class GroupMemberData implements JSONSerializer {
     String id;
     String groupID;
 
-    @FormParam(Constants.PR_GROUP_USER)
+    @Param(Constants.PR_GROUP_USER)
     public String getID() {
         return id;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/user/UserCertData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/user/UserCertData.java
@@ -20,8 +20,6 @@ package com.netscape.certsrv.user;
 
 import java.util.StringTokenizer;
 
-import javax.ws.rs.FormParam;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -29,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.common.Constants;
 import com.netscape.certsrv.dbs.certdb.CertId;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.certsrv.util.Param;
 
 /**
  * @author Endi S. Dewata
@@ -105,7 +104,7 @@ public class UserCertData implements JSONSerializer {
         this.prettyPrint = prettyPrint;
     }
 
-    @FormParam(Constants.PR_USER_CERT)
+    @Param(Constants.PR_USER_CERT)
     @JsonProperty("Encoded")
     public String getEncoded() {
         return encoded;

--- a/base/common/src/main/java/com/netscape/certsrv/user/UserData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/user/UserData.java
@@ -23,14 +23,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.FormParam;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netscape.certsrv.common.Constants;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.certsrv.util.Param;
 
 /**
  * @author Endi S. Dewata
@@ -84,7 +83,7 @@ public class UserData implements JSONSerializer {
         this.userID = userID;
     }
 
-    @FormParam(Constants.PR_USER_FULLNAME)
+    @Param(Constants.PR_USER_FULLNAME)
     @JsonProperty("FullName")
     public String getFullName() {
         return fullName;
@@ -94,7 +93,7 @@ public class UserData implements JSONSerializer {
         this.fullName = fullName;
     }
 
-    @FormParam(Constants.PR_USER_EMAIL)
+    @Param(Constants.PR_USER_EMAIL)
     @JsonProperty("Email")
     public String getEmail() {
         return email;
@@ -104,7 +103,7 @@ public class UserData implements JSONSerializer {
         this.email = email;
     }
 
-    @FormParam(Constants.PR_USER_PASSWORD)
+    @Param(Constants.PR_USER_PASSWORD)
     public String getPassword() {
         return password;
     }
@@ -113,7 +112,7 @@ public class UserData implements JSONSerializer {
         this.password = password;
     }
 
-    @FormParam(Constants.PR_USER_PHONE)
+    @Param(Constants.PR_USER_PHONE)
     public String getPhone() {
         return phone;
     }
@@ -122,7 +121,7 @@ public class UserData implements JSONSerializer {
         this.phone = phone;
     }
 
-    @FormParam(Constants.PR_USER_TYPE)
+    @Param(Constants.PR_USER_TYPE)
     public String getType() {
         return type;
     }
@@ -131,7 +130,7 @@ public class UserData implements JSONSerializer {
         this.type = type;
     }
 
-    @FormParam(Constants.PR_USER_STATE)
+    @Param(Constants.PR_USER_STATE)
     public String getState() {
         return state;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/user/UserMembershipData.java
+++ b/base/common/src/main/java/com/netscape/certsrv/user/UserMembershipData.java
@@ -18,13 +18,12 @@
 
 package com.netscape.certsrv.user;
 
-import javax.ws.rs.FormParam;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.common.Constants;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.certsrv.util.Param;
 
 /**
  * @author Endi S. Dewata
@@ -36,7 +35,7 @@ public class UserMembershipData implements JSONSerializer {
     String id;
     String userID;
 
-    @FormParam(Constants.PR_GROUP_GROUP)
+    @Param(Constants.PR_GROUP_GROUP)
     public String getID() {
         return id;
     }

--- a/base/common/src/main/java/com/netscape/certsrv/util/Param.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/Param.java
@@ -1,0 +1,20 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.certsrv.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Marco Fargetta {@literal <mfargett@redhat.com>}
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Param {
+    String value();
+}

--- a/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/base/PKIService.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.EntityTag;
@@ -41,6 +40,7 @@ import javax.ws.rs.core.UriInfo;
 
 import com.netscape.certsrv.base.PKIException;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.certsrv.util.Param;
 import com.netscape.cmscore.apps.CMSEngine;
 
 /**
@@ -309,7 +309,7 @@ public class PKIService {
     }
 
     /**
-     * Get the values of the fields annotated with @FormParam.
+     * Get the values of the fields annotated with @Param.
      */
     public Map<String, String> getParams(Object object) {
 
@@ -317,7 +317,7 @@ public class PKIService {
 
         // for each fields in the object
         for (Method method : object.getClass().getMethods()) {
-            FormParam element = method.getAnnotation(FormParam.class);
+            Param element = method.getAnnotation(Param.class);
             if (element == null) continue;
 
             String name = element.value();

--- a/base/server/src/main/java/com/netscape/cms/servlet/processors/Processor.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/processors/Processor.java
@@ -5,10 +5,9 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.ws.rs.FormParam;
-
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.EPropertyNotFound;
+import com.netscape.certsrv.util.Param;
 import com.netscape.cmscore.apps.CMS;
 import com.netscape.cmscore.apps.CMSEngine;
 
@@ -41,7 +40,7 @@ public class Processor {
     }
 
     /**
-     * Get the values of the fields annotated with @FormParam.
+     * Get the values of the fields annotated with @Param.
      */
     public Map<String, String> getParams(Object object) {
 
@@ -49,7 +48,7 @@ public class Processor {
 
         // for each fields in the object
         for (Method method : object.getClass().getMethods()) {
-            FormParam element = method.getAnnotation(FormParam.class);
+            Param element = method.getAnnotation(Param.class);
             if (element == null) continue;
 
             String name = element.value();


### PR DESCRIPTION
FormParam is an annotation defined in javaee [1] for binding form parameter in request entity to method parameter but since all the APIs moved to XML first and json later the FormParam was not used for its original goal. It is used to identify some fields inside Json mapped objects.

Since the annotation is present in classes used by both v1 and v2 APIs preventing to remove the resteasy dependency it has been replaced with a custom annotation named "Param".

1. https://docs.oracle.com/javaee/7/api/javax/ws/rs/FormParam.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized internal parameter-binding annotation across user, group, membership, and certificate handling; introduced a unified annotation and updated usages for consistency.
  * No changes to public APIs or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->