### PR TITLE
Update tests to check for core dumps

### DIFF
--- a/.github/workflows/est-ds-realm-separate-test.yml
+++ b/.github/workflows/est-ds-realm-separate-test.yml
@@ -513,15 +513,21 @@ jobs:
         run: |
           docker exec ca journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
 
-      - name: Check EST PKI server systemd journal
-        if: always()
-        run: |
-          docker exec est journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
-
       - name: Check CA debug log
         if: always()
         run: |
           docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check for EST core dumps
+        if: failure()
+        run: |
+          docker exec est ls -l
+          docker exec est find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
+      - name: Check EST PKI server systemd journal
+        if: always()
+        run: |
+          docker exec est journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
 
       - name: Check EST debug log
         if: always()

--- a/.github/workflows/kra-clone-failover-test.yml
+++ b/.github/workflows/kra-clone-failover-test.yml
@@ -449,6 +449,12 @@ jobs:
       - name: Remove CA
         run: docker exec ca pkidestroy -s CA -v
 
+      - name: Check for CA core dumps
+        if: failure()
+        run: |
+          docker exec ca ls -l
+          docker exec ca find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check CA systemd journal
         if: always()
         run: |
@@ -464,6 +470,12 @@ jobs:
         run: |
           docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
+      - name: Check for primary KRA core dumps
+        if: failure()
+        run: |
+          docker exec primarykra ls -l
+          docker exec primarykra find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check primary KRA systemd journal
         if: always()
         run: |
@@ -478,6 +490,12 @@ jobs:
         if: always()
         run: |
           docker exec primarykra find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Check for secondary KRA core dumps
+        if: failure()
+        run: |
+          docker exec secondarykra ls -l
+          docker exec secondarykra find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
 
       - name: Check secondary KRA systemd journal
         if: always()

--- a/.github/workflows/kra-clone-hsm-test.yml
+++ b/.github/workflows/kra-clone-hsm-test.yml
@@ -570,6 +570,12 @@ jobs:
       - name: Remove CA from primary PKI container
         run: docker exec primary pkidestroy -s CA -v
 
+      - name: Check for primary PKI core dumps
+        if: failure()
+        run: |
+          docker exec primary ls -l
+          docker exec primary find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal in primary container
         if: always()
         run: |
@@ -585,6 +591,12 @@ jobs:
         run: |
           docker exec primary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
 
+      - name: Check for secondary PKI core dumps
+        if: failure()
+        run: |
+          docker exec secondary ls -l
+          docker exec secondary find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal in secondary container
         if: always()
         run: |
@@ -599,6 +611,12 @@ jobs:
         if: always()
         run: |
           docker exec secondary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Check for tertiary PKI core dumps
+        if: failure()
+        run: |
+          docker exec tertiary ls -l
+          docker exec tertiary find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
 
       - name: Check PKI server systemd journal in tertiary container
         if: always()

--- a/.github/workflows/kra-clone-replicated-ds-test.yml
+++ b/.github/workflows/kra-clone-replicated-ds-test.yml
@@ -590,6 +590,12 @@ jobs:
       - name: Remove CA from primary PKI container
         run: docker exec primary pkidestroy -s CA -v
 
+      - name: Check for primary PKI core dumps
+        if: failure()
+        run: |
+          docker exec primary ls -l
+          docker exec primary find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal in primary container
         if: always()
         run: |
@@ -604,6 +610,12 @@ jobs:
         if: always()
         run: |
           docker exec primary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Check for secondary PKI core dumps
+        if: failure()
+        run: |
+          docker exec secondary ls -l
+          docker exec secondary find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
 
       - name: Check PKI server systemd journal in secondary container
         if: always()

--- a/.github/workflows/kra-clone-shared-ds-test.yml
+++ b/.github/workflows/kra-clone-shared-ds-test.yml
@@ -245,6 +245,12 @@ jobs:
       - name: Remove CA from primary PKI container
         run: docker exec primary pkidestroy -s CA -v
 
+      - name: Check for primary PKI core dumps
+        if: failure()
+        run: |
+          docker exec primary ls -l
+          docker exec primary find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal in primary container
         if: always()
         run: |
@@ -259,6 +265,12 @@ jobs:
         if: always()
         run: |
           docker exec primary find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Check for secondary container core dump
+        if: failure()
+        run: |
+          docker exec secondary ls -l
+          docker exec secondary find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
 
       - name: Check PKI server systemd journal in secondary container
         if: always()

--- a/.github/workflows/kra-hsm-test.yml
+++ b/.github/workflows/kra-hsm-test.yml
@@ -238,6 +238,12 @@ jobs:
           docker exec pki ls -laR /var/lib/softhsm/tokens
           docker exec pki runuser -u pkiuser -- softhsm2-util --delete-token --token HSM
 
+      - name: Check for PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal
         if: always()
         run: |

--- a/.github/workflows/kra-migration-test.yml
+++ b/.github/workflows/kra-migration-test.yml
@@ -408,6 +408,12 @@ jobs:
       - name: Remove second CA
         run: docker exec pki2 pkidestroy -s CA -v
 
+      - name: Check for first PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki1 ls -l
+          docker exec pki1 find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check first CA debug log
         if: always()
         run: |
@@ -417,6 +423,12 @@ jobs:
         if: always()
         run: |
           docker exec pki1 find /var/lib/pki/pki-tomcat/logs/kra -name "debug.*" -exec cat {} \;
+
+      - name: Check for second PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki2 ls -l
+          docker exec pki2 find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
 
       - name: Check second CA debug log
         if: always()

--- a/.github/workflows/kra-oaep-test.yml
+++ b/.github/workflows/kra-oaep-test.yml
@@ -154,6 +154,12 @@ jobs:
       - name: Remove CA
         run: docker exec pki pkidestroy -s CA -v
 
+      - name: Check for PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal
         if: always()
         run: |

--- a/.github/workflows/kra-separate-test.yml
+++ b/.github/workflows/kra-separate-test.yml
@@ -361,6 +361,12 @@ jobs:
       - name: Remove root CA
         run: docker exec rootca pkidestroy -s CA -v
 
+      - name: Check for root CA core dumps
+        if: failure()
+        run: |
+          docker exec rootca ls -l
+          docker exec rootca find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal in root CA container
         if: always()
         run: |
@@ -371,6 +377,12 @@ jobs:
         run: |
           docker exec rootca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
 
+      - name: Check for sub CA core dumps
+        if: failure()
+        run: |
+          docker exec subca ls -l
+          docker exec subca find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal in sub CA container
         if: always()
         run: |
@@ -380,6 +392,12 @@ jobs:
         if: always()
         run: |
           docker exec subca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check for KRA core dumps
+        if: failure()
+        run: |
+          docker exec kra ls -l
+          docker exec kra find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
 
       - name: Check PKI server systemd journal in KRA container
         if: always()

--- a/.github/workflows/kra-sskg-test.yml
+++ b/.github/workflows/kra-sskg-test.yml
@@ -274,6 +274,12 @@ jobs:
       - name: Remove CA
         run: docker exec pki pkidestroy -s CA -v
 
+      - name: Check for PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal
         if: always()
         run: |

--- a/.github/workflows/kra-standalone-test.yml
+++ b/.github/workflows/kra-standalone-test.yml
@@ -466,6 +466,18 @@ jobs:
       - name: Remove CA
         run: docker exec ca pkidestroy -s CA -v
 
+      - name: Check for client core dumps
+        if: failure()
+        run: |
+          docker exec client ls -l
+          docker exec client find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
+      - name: Check for CA core dumps
+        if: failure()
+        run: |
+          docker exec ca ls -l
+          docker exec ca find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check CA systemd journal
         if: always()
         run: |
@@ -480,6 +492,12 @@ jobs:
         if: always()
         run: |
           docker exec ca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check for KRA core dumps
+        if: failure()
+        run: |
+          docker exec kra ls -l
+          docker exec kra find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
 
       - name: Check KRA systemd journal
         if: always()

--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -1180,6 +1180,12 @@ jobs:
         run: |
           docker logs ds
 
+      - name: Check for PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal
         if: always()
         run: |

--- a/.github/workflows/tps-existing-config-test.yml
+++ b/.github/workflows/tps-existing-config-test.yml
@@ -454,6 +454,12 @@ jobs:
         run: |
           docker logs ds
 
+      - name: Check for PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
       - name: Check PKI server systemd journal
         if: always()
         run: |


### PR DESCRIPTION
The tests that sometimes crash due to `SIGSEGV` have been updated to check for core dumps to help the investigation.

For example, the following KRA installation failed when executing `pki ca-cert-issue` command:
https://github.com/dogtagpki/pki/actions/runs/22981134067/job/66721652573#step:11:251

It generated the following core dump:
https://github.com/dogtagpki/pki/actions/runs/22981134067/job/66721652573#step:50:34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI diagnostic steps to capture and print core-dump/Java crash logs for PKI, KRA, CA and client components (most run only on failure).
  * Preserved a few unconditional diagnostics where needed.
  * Reordered and augmented EST/CA diagnostics so CA debug logs and EST core-dump checks run earlier, improving failure visibility after teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->