### PR TITLE
Move key parameters in KeyParameters class

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyClient.java
@@ -281,8 +281,8 @@ public class KeyClient extends Client {
         if (id == null || status == null) {
             throw new IllegalArgumentException("Key Id and status must be specified.");
         }
-        if (!status.equalsIgnoreCase(KeyResource.KEY_STATUS_ACTIVE)
-                && !status.equalsIgnoreCase(KeyResource.KEY_STATUS_INACTIVE)) {
+        if (!status.equalsIgnoreCase(KeyParameters.KEY_STATUS_ACTIVE)
+                && !status.equalsIgnoreCase(KeyParameters.KEY_STATUS_INACTIVE)) {
             throw new IllegalArgumentException("Invalid status value.");
         }
         Map<String, Object> params = new HashMap<>();
@@ -447,7 +447,7 @@ public class KeyClient extends Client {
         // data was key-wrapped and is a private or symmetric key
         byte[] bytes = null;
 
-        if (data.getType().equalsIgnoreCase(KeyRequestResource.SYMMETRIC_KEY_TYPE)) {
+        if (data.getType().equalsIgnoreCase(KeyParameters.SYMMETRIC_KEY_TYPE)) {
             bytes = crypto.unwrapSymmetricKeyWithSessionKey(
                     data.getEncryptedData(),
                     sessionKey,
@@ -649,7 +649,7 @@ public class KeyClient extends Client {
         }
 
         // Need to pass the sessionWrappedPassphrase and transWrappedSessionKey when the
-        // both request and recovery are done at the same time. So the KeyRequestResounse itself
+        // both request and recovery are done at the same time. So the  KeyRequestResponse itself
         // contains the KeyData
         RequestId requestId = recoverKey(keyId, null, null, null, null).getRequestId();
         approveRequest(requestId);
@@ -737,7 +737,7 @@ public class KeyClient extends Client {
                 sessionKey,
                 encryptAlgorithm);
 
-        return archiveEncryptedData(clientKeyId, KeyRequestResource.PASS_PHRASE_TYPE, null, null, algorithmOID,
+        return archiveEncryptedData(clientKeyId, KeyParameters.PASS_PHRASE_TYPE, null, null, algorithmOID,
                 nonceData, encryptedData, transWrappedSessionKey, realm);
     }
 
@@ -797,7 +797,7 @@ public class KeyClient extends Client {
         byte[] encryptedData = crypto.wrapWithSessionKey(secret, sessionKey, nonceData, wrapAlgorithm);
         byte[] transWrappedSessionKey = crypto.wrapSymmetricKey(sessionKey, transportCert.getPublicKey(),alg);
 
-        return archiveEncryptedData(clientKeyId, KeyRequestResource.SYMMETRIC_KEY_TYPE, keyAlgorithm, keySize,
+        return archiveEncryptedData(clientKeyId, KeyParameters.SYMMETRIC_KEY_TYPE, keyAlgorithm, keySize,
                 algorithmOID, nonceData, encryptedData, transWrappedSessionKey, realm);
     }
 
@@ -844,7 +844,7 @@ public class KeyClient extends Client {
             throw new IllegalArgumentException("Client key id and data type must be specified.");
         }
 
-        if (dataType == KeyRequestResource.SYMMETRIC_KEY_TYPE) {
+        if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE)) {
             if (keyAlgorithm == null || keySize < 0) {
                 throw new IllegalArgumentException(
                         "Key algorithm and key size must be specified for a symmetric key type request.");
@@ -898,7 +898,7 @@ public class KeyClient extends Client {
         if (clientKeyId == null || dataType == null) {
             throw new IllegalArgumentException("Client key id and data type must be specified.");
         }
-        if (dataType == KeyRequestResource.SYMMETRIC_KEY_TYPE) {
+        if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE)) {
             if (keyAlgorithm == null || keySize < 0) {
                 throw new IllegalArgumentException(
                         "Key algorithm and key size must be specified for a symmetric key type request.");
@@ -1002,8 +1002,9 @@ public class KeyClient extends Client {
                 }
             }
         }
-        if (!(keyAlgorithm.equals(KeyRequestResource.RSA_ALGORITHM) || keyAlgorithm
-                .equals(KeyRequestResource.DSA_ALGORITHM))) {
+        if (keyAlgorithm == null || 
+                !(keyAlgorithm.equals(KeyParameters.RSA_ALGORITHM) ||
+                keyAlgorithm.equals(KeyParameters.DSA_ALGORITHM))) {
             throw new IllegalArgumentException("Unsupported algorithm specified.");
         }
 
@@ -1013,7 +1014,7 @@ public class KeyClient extends Client {
          *
          * For DSA, JSS accepts key sizes 512, 768, 1024 only, when there are no p,q,g params specified.
          */
-        if (keyAlgorithm.equals(KeyRequestResource.RSA_ALGORITHM)) {
+        if (keyAlgorithm.equals(KeyParameters.RSA_ALGORITHM)) {
             if (keySize >= 256) {
                 if ((keySize - 256) % 16 != 0) {
                     throw new IllegalArgumentException("Invalid key size specified.");
@@ -1021,7 +1022,7 @@ public class KeyClient extends Client {
             } else {
                 throw new IllegalArgumentException("Invalid key size specified.");
             }
-        } else if (keyAlgorithm.equals(KeyRequestResource.DSA_ALGORITHM)) {
+        } else if (keyAlgorithm.equals(KeyParameters.DSA_ALGORITHM)) {
             if (keySize != 512 && keySize != 768 && keySize != 1024) {
                 throw new IllegalArgumentException("Invalid key size specified.");
             }

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyParameters.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyParameters.java
@@ -1,0 +1,34 @@
+//
+// Copyright Red Hat, Inc.
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+package com.netscape.certsrv.key;
+
+/**
+ *
+ * @author Marco Fargetta {@literal <mfargett@redhat.com>}
+ */
+public final class KeyParameters {
+    public static final String KEY_STATUS_ACTIVE = "active";
+    public static final String KEY_STATUS_INACTIVE = "inactive";
+    
+    /* Data types */
+    public static final String SYMMETRIC_KEY_TYPE = "symmetricKey";
+    public static final String PASS_PHRASE_TYPE = "passPhrase";
+    public static final String ASYMMETRIC_KEY_TYPE = "asymmetricKey";
+
+    /* Symmetric Key Algorithms */
+    public static final String DES_ALGORITHM = "DES";
+    public static final String DESEDE_ALGORITHM = "DESede";
+    public static final String DES3_ALGORITHM = "DES3";
+    public static final String RC2_ALGORITHM = "RC2";
+    public static final String RC4_ALGORITHM = "RC4";
+    public static final String AES_ALGORITHM = "AES";
+
+    // Asymmetric Key algorithms
+    public static final String RSA_ALGORITHM = "RSA";
+    public static final String DSA_ALGORITHM = "DSA";
+    public static final String EC_ALGORITHM = "EC"; // Not supported yet.
+
+}

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRequestResource.java
@@ -20,24 +20,6 @@ import com.netscape.certsrv.request.RequestId;
 @AuthMethodMapping("keyrequests")
 public interface KeyRequestResource {
 
-    /* Data types */
-    public static final String SYMMETRIC_KEY_TYPE = "symmetricKey";
-    public static final String PASS_PHRASE_TYPE = "passPhrase";
-    public static final String ASYMMETRIC_KEY_TYPE = "asymmetricKey";
-
-    /* Symmetric Key Algorithms */
-    public static final String DES_ALGORITHM = "DES";
-    public static final String DESEDE_ALGORITHM = "DESede";
-    public static final String DES3_ALGORITHM = "DES3";
-    public static final String RC2_ALGORITHM = "RC2";
-    public static final String RC4_ALGORITHM = "RC4";
-    public static final String AES_ALGORITHM = "AES";
-
-    // Asymmetric Key algorithms
-    public final static String RSA_ALGORITHM = "RSA";
-    public final static String DSA_ALGORITHM = "DSA";
-    public final static String EC_ALGORITHM = "EC"; // Not supported yet.
-
     /**
      * Used to generate list of key requests based on the search parameters
      */

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyResource.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyResource.java
@@ -20,9 +20,6 @@ import com.netscape.certsrv.dbs.keydb.KeyId;
 @AuthMethodMapping("keys")
 public interface KeyResource {
 
-    public static final String KEY_STATUS_ACTIVE = "active";
-    public static final String KEY_STATUS_INACTIVE = "inactive";
-
     @GET
     public Response listKeys(@QueryParam("clientKeyID") String clientKeyID,
                                  @QueryParam("status") String status,

--- a/base/common/src/main/java/com/netscape/certsrv/util/NSSCryptoProvider.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/NSSCryptoProvider.java
@@ -19,7 +19,7 @@ import org.mozilla.jss.util.IncorrectPasswordException;
 import org.mozilla.jss.util.Password;
 
 import com.netscape.certsrv.client.ClientConfig;
-import com.netscape.certsrv.key.KeyRequestResource;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.cmsutil.crypto.CryptoUtil;
 
 public class NSSCryptoProvider extends CryptoProvider {
@@ -101,7 +101,7 @@ public class NSSCryptoProvider extends CryptoProvider {
 
     @Override
     public SymmetricKey generateSessionKey() throws Exception {
-        return generateSymmetricKey(KeyRequestResource.AES_ALGORITHM, 128);
+        return generateSymmetricKey(KeyParameters.AES_ALGORITHM, 128);
     }
 
     @Override
@@ -218,22 +218,22 @@ public class NSSCryptoProvider extends CryptoProvider {
         }
         KeyGenAlgorithm alg = null;
         switch (keyAlgorithm) {
-        case KeyRequestResource.AES_ALGORITHM:
+        case KeyParameters.AES_ALGORITHM:
             alg = KeyGenAlgorithm.AES;
             break;
-        case KeyRequestResource.DES_ALGORITHM:
+        case KeyParameters.DES_ALGORITHM:
             alg = KeyGenAlgorithm.DES;
             break;
-        case KeyRequestResource.DESEDE_ALGORITHM:
+        case KeyParameters.DESEDE_ALGORITHM:
             alg = KeyGenAlgorithm.DESede;
             break;
-        case KeyRequestResource.RC2_ALGORITHM:
+        case KeyParameters.RC2_ALGORITHM:
             alg = KeyGenAlgorithm.RC2;
             break;
-        case KeyRequestResource.RC4_ALGORITHM:
+        case KeyParameters.RC4_ALGORITHM:
             alg = KeyGenAlgorithm.RC4;
             break;
-        case KeyRequestResource.DES3_ALGORITHM:
+        case KeyParameters.DES3_ALGORITHM:
             alg = KeyGenAlgorithm.DES3;
             break;
         default:
@@ -248,19 +248,19 @@ public class NSSCryptoProvider extends CryptoProvider {
         }
         EncryptionAlgorithm alg = null;
         switch (encryptionAlgorithm) {
-        case KeyRequestResource.AES_ALGORITHM:
+        case KeyParameters.AES_ALGORITHM:
             alg = EncryptionAlgorithm.AES_CBC_PAD;
             break;
-        case KeyRequestResource.DES_ALGORITHM:
+        case KeyParameters.DES_ALGORITHM:
             alg = EncryptionAlgorithm.DES_CBC_PAD;
             break;
-        case KeyRequestResource.RC2_ALGORITHM:
+        case KeyParameters.RC2_ALGORITHM:
             alg = EncryptionAlgorithm.RC2_CBC_PAD;
             break;
-        case KeyRequestResource.RC4_ALGORITHM:
+        case KeyParameters.RC4_ALGORITHM:
             alg = EncryptionAlgorithm.RC4;
             break;
-        case KeyRequestResource.DES3_ALGORITHM:
+        case KeyParameters.DES3_ALGORITHM:
             alg = EncryptionAlgorithm.DES3_CBC_PAD;
             break;
         default:

--- a/base/common/src/test/java/com/netscape/certsrv/key/AsymKeyGenerationRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/AsymKeyGenerationRequestTest.java
@@ -16,7 +16,7 @@ public class AsymKeyGenerationRequestTest {
 
     @BeforeAll
     public static void setUpBefore() {
-        before.setKeyAlgorithm(KeyRequestResource.RSA_ALGORITHM);
+        before.setKeyAlgorithm(KeyParameters.RSA_ALGORITHM);
         before.setKeySize(1024);
         before.setClientKeyId("vek12345");
         List<String> usages = new ArrayList<>();

--- a/base/common/src/test/java/com/netscape/certsrv/key/KeyArchivalRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/KeyArchivalRequestTest.java
@@ -14,9 +14,9 @@ public class KeyArchivalRequestTest {
     @BeforeAll
     public static void setUpBefore() {
         before.setClientKeyId("vek 12345");
-        before.setDataType(KeyRequestResource.SYMMETRIC_KEY_TYPE);
+        before.setDataType(KeyParameters.SYMMETRIC_KEY_TYPE);
         before.setWrappedPrivateData("XXXXABCDEFXXX");
-        before.setKeyAlgorithm(KeyRequestResource.AES_ALGORITHM);
+        before.setKeyAlgorithm(KeyParameters.AES_ALGORITHM);
         before.setRealm("ipa-vault");
         before.setKeySize(128);
     }

--- a/base/common/src/test/java/com/netscape/certsrv/key/SymKeyGenerationRequestTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/key/SymKeyGenerationRequestTest.java
@@ -14,7 +14,7 @@ public class SymKeyGenerationRequestTest {
     @BeforeAll
     public static void setUpBefore() {
         before.setClientKeyId("vek 12345");
-        before.setKeyAlgorithm(KeyRequestResource.AES_ALGORITHM);
+        before.setKeyAlgorithm(KeyParameters.AES_ALGORITHM);
         before.setKeySize(128);
         before.addUsage(SymKeyGenerationRequest.DECRYPT_USAGE);
         before.addUsage(SymKeyGenerationRequest.ENCRYPT_USAGE);

--- a/base/kra/src/main/java/com/netscape/cms/servlet/key/KeyRequestDAO.java
+++ b/base/kra/src/main/java/com/netscape/cms/servlet/key/KeyRequestDAO.java
@@ -52,6 +52,7 @@ import com.netscape.certsrv.key.AsymKeyGenerationRequest;
 import com.netscape.certsrv.key.KeyArchivalRequest;
 import com.netscape.certsrv.key.KeyData;
 import com.netscape.certsrv.key.KeyNotFoundException;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.certsrv.key.KeyRecoveryRequest;
 import com.netscape.certsrv.key.KeyRequestInfo;
 import com.netscape.certsrv.key.KeyRequestInfoCollection;
@@ -83,16 +84,16 @@ public class KeyRequestDAO extends CMSRequestDAO {
 
     static {
         SYMKEY_GEN_ALGORITHMS = new HashMap<>();
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.DES_ALGORITHM, KeyGenAlgorithm.DES);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.DESEDE_ALGORITHM, KeyGenAlgorithm.DESede);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.DES3_ALGORITHM, KeyGenAlgorithm.DES3);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.RC2_ALGORITHM, KeyGenAlgorithm.RC2);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.RC4_ALGORITHM, KeyGenAlgorithm.RC4);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.AES_ALGORITHM, KeyGenAlgorithm.AES);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.DES_ALGORITHM, KeyGenAlgorithm.DES);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.DESEDE_ALGORITHM, KeyGenAlgorithm.DESede);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.DES3_ALGORITHM, KeyGenAlgorithm.DES3);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.RC2_ALGORITHM, KeyGenAlgorithm.RC2);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.RC4_ALGORITHM, KeyGenAlgorithm.RC4);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.AES_ALGORITHM, KeyGenAlgorithm.AES);
 
         ASYMKEY_GEN_ALGORITHMS = new HashMap<>();
-        ASYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.RSA_ALGORITHM, KeyPairAlgorithm.RSA);
-        ASYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.DSA_ALGORITHM, KeyPairAlgorithm.DSA);
+        ASYMKEY_GEN_ALGORITHMS.put(KeyParameters.RSA_ALGORITHM, KeyPairAlgorithm.RSA);
+        ASYMKEY_GEN_ALGORITHMS.put(KeyParameters.DSA_ALGORITHM, KeyPairAlgorithm.DSA);
     }
 
     private static String REQUEST_ARCHIVE_OPTIONS = Request.REQUEST_ARCHIVE_OPTIONS;
@@ -206,7 +207,7 @@ public class KeyRequestDAO extends CMSRequestDAO {
         String pkiArchiveOptions = data.getPKIArchiveOptions();
         String dataType = data.getDataType();
         String keyAlgorithm = data.getKeyAlgorithm();
-        int keyStrength = dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE) ?
+        int keyStrength = dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE) ?
                 data.getKeySize(): 0;
         String realm = data.getRealm();
 
@@ -459,7 +460,7 @@ public class KeyRequestDAO extends CMSRequestDAO {
                 throw new BadRequestException(
                         "Invalid request.  Must specify key algorithm if size is specified");
             }
-            algName = KeyRequestResource.AES_ALGORITHM;
+            algName = KeyParameters.AES_ALGORITHM;
             keySize = Integer.valueOf(128);
         }
 
@@ -534,13 +535,13 @@ public class KeyRequestDAO extends CMSRequestDAO {
         }
 
         if (keySize == null) {
-            if (algName.equalsIgnoreCase(KeyRequestResource.RSA_ALGORITHM)
-                    || algName.equalsIgnoreCase(KeyRequestResource.DSA_ALGORITHM)) {
+            if (algName.equalsIgnoreCase(KeyParameters.RSA_ALGORITHM)
+                    || algName.equalsIgnoreCase(KeyParameters.DSA_ALGORITHM)) {
                 throw new BadRequestException("Key size must be specified.");
             }
         } else {
             //Validate key size
-            if (algName.equalsIgnoreCase(KeyRequestResource.RSA_ALGORITHM)) {
+            if (algName.equalsIgnoreCase(KeyParameters.RSA_ALGORITHM)) {
                 int size = Integer.valueOf(keySize);
                 int minSize = Integer.valueOf(cs.getInteger("keys.rsa.min.size", 256));
                 int maxSize = Integer.valueOf(cs.getInteger("keys.rsa.max.size", 8192));
@@ -554,7 +555,7 @@ public class KeyRequestDAO extends CMSRequestDAO {
                 if (((size - 256) % 16) != 0) {
                     throw new BadRequestException("Invalid key size specified.");
                 }
-            } else if (algName.equalsIgnoreCase(KeyRequestResource.DSA_ALGORITHM)) {
+            } else if (algName.equalsIgnoreCase(KeyParameters.DSA_ALGORITHM)) {
                 // Without the PQGParams, JSS can create DSA keys of size 512, 768, 1024 only.
                 String[] sizes = engine.getConfig().getString("keys.dsa.list", "512,768,1024").split(",");
                 if (!Arrays.asList(sizes).contains(String.valueOf(keySize))) {

--- a/base/kra/src/main/java/com/netscape/kra/AsymKeyGenService.java
+++ b/base/kra/src/main/java/com/netscape/kra/AsymKeyGenService.java
@@ -29,7 +29,7 @@ import org.mozilla.jss.netscape.security.util.WrappingParams;
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.dbs.keydb.KeyId;
 import com.netscape.certsrv.key.AsymKeyGenerationRequest;
-import com.netscape.certsrv.key.KeyRequestResource;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.logging.event.AsymKeyGenerationProcessedEvent;
 import com.netscape.certsrv.logging.event.ServerSideKeygenEnrollKeygenProcessedEvent;
@@ -312,7 +312,7 @@ public class AsymKeyGenService implements IService {
         record.set(KeyRecord.ATTR_CLIENT_ID, clientKeyId);
         record.setSerialNumber(serialNo);
         record.set(KeyRecord.ATTR_ID, serialNo);
-        record.set(KeyRecord.ATTR_DATA_TYPE, KeyRequestResource.ASYMMETRIC_KEY_TYPE);
+        record.set(KeyRecord.ATTR_DATA_TYPE, KeyParameters.ASYMMETRIC_KEY_TYPE);
         record.set(KeyRecord.ATTR_STATUS, STATUS_ACTIVE);
         record.set(KeyRecord.ATTR_KEY_SIZE, keySize);
         request.setExtData(ATTR_KEY_RECORD, serialNo);

--- a/base/kra/src/main/java/com/netscape/kra/SecurityDataProcessor.java
+++ b/base/kra/src/main/java/com/netscape/kra/SecurityDataProcessor.java
@@ -38,7 +38,7 @@ import org.mozilla.jss.util.Password;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.dbs.keydb.KeyId;
-import com.netscape.certsrv.key.KeyRequestResource;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.certsrv.kra.EKRAException;
 import com.netscape.certsrv.logging.event.SecurityDataArchivalProcessedEvent;
 import com.netscape.certsrv.request.RequestId;
@@ -174,9 +174,9 @@ public class SecurityDataProcessor {
         String keyType = null;
         byte [] tmp_unwrapped = null;
         byte [] unwrapped = null;
-        if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE)) {
+        if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE)) {
             // Symmetric Key
-            keyType = KeyRequestResource.SYMMETRIC_KEY_TYPE;
+            keyType = KeyParameters.SYMMETRIC_KEY_TYPE;
 
             if (allowEncDecrypt_archival) {
                 try {
@@ -214,8 +214,8 @@ public class SecurityDataProcessor {
                 }
             }
 
-        } else if (dataType.equals(KeyRequestResource.PASS_PHRASE_TYPE)) {
-            keyType = KeyRequestResource.PASS_PHRASE_TYPE;
+        } else if (dataType.equals(KeyParameters.PASS_PHRASE_TYPE)) {
+            keyType = KeyParameters.PASS_PHRASE_TYPE;
             try {
                 securityData = transportUnit.decryptExternalPrivate(
                         wrappedSessionKey,
@@ -325,7 +325,7 @@ public class SecurityDataProcessor {
         rec.set(KeyRecord.ATTR_DATA_TYPE, keyType);
         rec.set(KeyRecord.ATTR_STATUS, STATUS_ACTIVE);
 
-        if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE)) {
+        if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE)) {
             rec.set(KeyRecord.ATTR_ALGORITHM, algorithm);
             rec.set(KeyRecord.ATTR_KEY_SIZE, strength);
         }
@@ -417,7 +417,7 @@ public class SecurityDataProcessor {
         KeyRecord keyRecord = keyRepository.readKeyRecord(keyId.toBigInteger());
 
         String dataType = (String) keyRecord.get(KeyRecord.ATTR_DATA_TYPE);
-        if (dataType == null) dataType = KeyRequestResource.ASYMMETRIC_KEY_TYPE;
+        if (dataType == null) dataType = KeyParameters.ASYMMETRIC_KEY_TYPE;
 
         SymmetricKey unwrappedSess = null;
         SymmetricKey symKey = null;
@@ -431,7 +431,7 @@ public class SecurityDataProcessor {
             encrypted = allowEncDecrypt_recovery;
         }
 
-        if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE)) {
+        if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE)) {
             if (encrypted) {
                 logger.debug("Recover symmetric key by decrypting as per allowEncDecrypt_recovery: true.");
                 unwrappedSecData = recoverSecurityData(keyRecord);
@@ -439,9 +439,9 @@ public class SecurityDataProcessor {
                 symKey = recoverSymKey(keyRecord);
             }
 
-        } else if (dataType.equals(KeyRequestResource.PASS_PHRASE_TYPE)) {
+        } else if (dataType.equals(KeyParameters.PASS_PHRASE_TYPE)) {
             unwrappedSecData = recoverSecurityData(keyRecord);
-        } else if (dataType.equals(KeyRequestResource.ASYMMETRIC_KEY_TYPE)) {
+        } else if (dataType.equals(KeyParameters.ASYMMETRIC_KEY_TYPE)) {
             try {
                 if (encrypted) {
                     logger.debug("Recover asymmetric key by decrypting as per allowEncDecrypt_recovery: true.");
@@ -559,7 +559,7 @@ public class SecurityDataProcessor {
                 jssSubsystem.obscureChars(passChars);
 
 
-                if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE)) {
+                if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE)) {
 
                     logger.debug("SecurityDataProcessor.recover(): wrap or encrypt stored symmetric key with transport passphrase");
                     if (encrypted) {
@@ -569,11 +569,11 @@ public class SecurityDataProcessor {
                         pbeWrappedData = createEncryptedContentInfo(ct, symKey, null, null, pass);
                     }
 
-                } else if (dataType.equals(KeyRequestResource.PASS_PHRASE_TYPE)) {
+                } else if (dataType.equals(KeyParameters.PASS_PHRASE_TYPE)) {
 
                     logger.debug("SecurityDataProcessor.recover(): encrypt stored passphrase with transport passphrase");
                     pbeWrappedData = createEncryptedContentInfo(ct, null, unwrappedSecData, null, pass);
-                } else if (dataType.equals(KeyRequestResource.ASYMMETRIC_KEY_TYPE)) {
+                } else if (dataType.equals(KeyParameters.ASYMMETRIC_KEY_TYPE)) {
                     if (encrypted) {
                         logger.debug("SecurityDataProcessor.recover(): allowEncDecyypt_recovery: true, asymmetric key:  create blob with unwrapped key.");
                         pbeWrappedData = createEncryptedContentInfo(ct, null, unwrappedSecData, null, pass);
@@ -601,7 +601,7 @@ public class SecurityDataProcessor {
         } else {
             logger.debug("SecurityDataProcessor.recover(): secure retrieved data with session key");
 
-            if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE)) {
+            if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE)) {
                 logger.debug("SecurityDataProcessor.recover(): wrap or encrypt stored symmetric key with session key");
                 try {
                     if (encrypted) {
@@ -630,7 +630,7 @@ public class SecurityDataProcessor {
                     throw new EBaseException("Cannot wrap symmetric key: " + e, e);
                 }
 
-            } else if (dataType.equals(KeyRequestResource.PASS_PHRASE_TYPE)) {
+            } else if (dataType.equals(KeyParameters.PASS_PHRASE_TYPE)) {
                 logger.debug("SecurityDataProcessor.recover(): encrypt stored passphrase with session key");
                 try {
                     unwrappedSess = transportUnit.unwrap_session_key(ct, wrappedSessKey,
@@ -647,7 +647,7 @@ public class SecurityDataProcessor {
                     throw new EBaseException("Cannot encrypt passphrase: " + e, e);
                 }
 
-            } else if (dataType.equals(KeyRequestResource.ASYMMETRIC_KEY_TYPE)) {
+            } else if (dataType.equals(KeyParameters.ASYMMETRIC_KEY_TYPE)) {
                 logger.debug("SecurityDataProcessor.recover(): wrap or encrypt stored private key with session key");
                 try {
                     if (encrypted) {
@@ -689,7 +689,7 @@ public class SecurityDataProcessor {
         params.put(Request.SECURITY_DATA_PL_WRAPPING_NAME,
                 wrapParams.getPayloadWrapAlgorithm().toString());
 
-        if (encrypted || dataType.equals(KeyRequestResource.PASS_PHRASE_TYPE)) {
+        if (encrypted || dataType.equals(KeyParameters.PASS_PHRASE_TYPE)) {
             params.put(Request.SECURITY_DATA_PL_WRAPPED, Boolean.toString(false));
             if (wrapParams.getPayloadEncryptionIV() != null) {
                 params.put(Request.SECURITY_DATA_IV_STRING_OUT, ivStr);

--- a/base/kra/src/main/java/com/netscape/kra/SymKeyGenService.java
+++ b/base/kra/src/main/java/com/netscape/kra/SymKeyGenService.java
@@ -32,7 +32,7 @@ import org.mozilla.jss.netscape.security.util.WrappingParams;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.dbs.keydb.KeyId;
-import com.netscape.certsrv.key.KeyRequestResource;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.certsrv.key.SymKeyGenerationRequest;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.logging.event.SymKeyGenerationProcessedEvent;
@@ -266,7 +266,7 @@ public class SymKeyGenService implements IService {
         }
 
         rec.set(KeyRecord.ATTR_ID, serialNo);
-        rec.set(KeyRecord.ATTR_DATA_TYPE, KeyRequestResource.SYMMETRIC_KEY_TYPE);
+        rec.set(KeyRecord.ATTR_DATA_TYPE, KeyParameters.SYMMETRIC_KEY_TYPE);
         rec.set(KeyRecord.ATTR_STATUS, STATUS_ACTIVE);
         rec.set(KeyRecord.ATTR_KEY_SIZE, keySize);
         request.setExtData(ATTR_KEY_RECORD, serialNo);

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/base/KeyProcessor.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/base/KeyProcessor.java
@@ -39,6 +39,7 @@ import com.netscape.certsrv.key.KeyData;
 import com.netscape.certsrv.key.KeyInfo;
 import com.netscape.certsrv.key.KeyInfoCollection;
 import com.netscape.certsrv.key.KeyNotFoundException;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.certsrv.key.KeyRecoveryRequest;
 import com.netscape.certsrv.logging.ILogger;
 import com.netscape.certsrv.logging.event.SecurityDataExportEvent;
@@ -64,8 +65,6 @@ import com.netscape.kra.KeyRecoveryAuthority;
  * @author alee
  */
 public class KeyProcessor {
-    public static final String KEY_STATUS_ACTIVE = "active";
-    public static final String KEY_STATUS_INACTIVE = "inactive";
     public static final String ATTR_SERIALNO = "serialNumber";
 
     private static final Logger logger = LoggerFactory.getLogger(KeyProcessor.class);
@@ -190,7 +189,7 @@ public class KeyProcessor {
                 principal,
                 baseUrl,
                 clientKeyID,
-                KEY_STATUS_ACTIVE,
+                KeyParameters.KEY_STATUS_ACTIVE,
                 KRAServlet.DEFAULT_MAXRESULTS,
                 PKIServlet.DEFAULT_MAXTIME,
                 0,

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/base/KeyRequestProcessor.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/base/KeyRequestProcessor.java
@@ -44,10 +44,10 @@ import com.netscape.certsrv.key.AsymKeyGenerationRequest;
 import com.netscape.certsrv.key.KeyArchivalRequest;
 import com.netscape.certsrv.key.KeyData;
 import com.netscape.certsrv.key.KeyNotFoundException;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.certsrv.key.KeyRecoveryRequest;
 import com.netscape.certsrv.key.KeyRequestInfo;
 import com.netscape.certsrv.key.KeyRequestInfoCollection;
-import com.netscape.certsrv.key.KeyRequestResource;
 import com.netscape.certsrv.key.KeyRequestResponse;
 import com.netscape.certsrv.key.SymKeyGenerationRequest;
 import com.netscape.certsrv.logging.ILogger;
@@ -91,28 +91,28 @@ public class KeyRequestProcessor {
     private static final Map<String, SymmetricKey.Type> SYMKEY_TYPES;
     static {
         SYMKEY_TYPES = new HashMap<>();
-        SYMKEY_TYPES.put(KeyRequestResource.DES_ALGORITHM, SymmetricKey.DES);
-        SYMKEY_TYPES.put(KeyRequestResource.DESEDE_ALGORITHM, SymmetricKey.DES3);
-        SYMKEY_TYPES.put(KeyRequestResource.DES3_ALGORITHM, SymmetricKey.DES3);
-        SYMKEY_TYPES.put(KeyRequestResource.RC2_ALGORITHM, SymmetricKey.RC2);
-        SYMKEY_TYPES.put(KeyRequestResource.RC4_ALGORITHM, SymmetricKey.RC4);
-        SYMKEY_TYPES.put(KeyRequestResource.AES_ALGORITHM, SymmetricKey.AES);
+        SYMKEY_TYPES.put(KeyParameters.DES_ALGORITHM, SymmetricKey.DES);
+        SYMKEY_TYPES.put(KeyParameters.DESEDE_ALGORITHM, SymmetricKey.DES3);
+        SYMKEY_TYPES.put(KeyParameters.DES3_ALGORITHM, SymmetricKey.DES3);
+        SYMKEY_TYPES.put(KeyParameters.RC2_ALGORITHM, SymmetricKey.RC2);
+        SYMKEY_TYPES.put(KeyParameters.RC4_ALGORITHM, SymmetricKey.RC4);
+        SYMKEY_TYPES.put(KeyParameters.AES_ALGORITHM, SymmetricKey.AES);
     }
     private static final Map<String, KeyGenAlgorithm> SYMKEY_GEN_ALGORITHMS;
     private static final Map<String, KeyPairAlgorithm> ASYMKEY_GEN_ALGORITHMS;
 
     static {
         SYMKEY_GEN_ALGORITHMS = new HashMap<>();
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.DES_ALGORITHM, KeyGenAlgorithm.DES);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.DESEDE_ALGORITHM, KeyGenAlgorithm.DESede);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.DES3_ALGORITHM, KeyGenAlgorithm.DES3);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.RC2_ALGORITHM, KeyGenAlgorithm.RC2);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.RC4_ALGORITHM, KeyGenAlgorithm.RC4);
-        SYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.AES_ALGORITHM, KeyGenAlgorithm.AES);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.DES_ALGORITHM, KeyGenAlgorithm.DES);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.DESEDE_ALGORITHM, KeyGenAlgorithm.DESede);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.DES3_ALGORITHM, KeyGenAlgorithm.DES3);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.RC2_ALGORITHM, KeyGenAlgorithm.RC2);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.RC4_ALGORITHM, KeyGenAlgorithm.RC4);
+        SYMKEY_GEN_ALGORITHMS.put(KeyParameters.AES_ALGORITHM, KeyGenAlgorithm.AES);
 
         ASYMKEY_GEN_ALGORITHMS = new HashMap<>();
-        ASYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.RSA_ALGORITHM, KeyPairAlgorithm.RSA);
-        ASYMKEY_GEN_ALGORITHMS.put(KeyRequestResource.DSA_ALGORITHM, KeyPairAlgorithm.DSA);
+        ASYMKEY_GEN_ALGORITHMS.put(KeyParameters.RSA_ALGORITHM, KeyPairAlgorithm.RSA);
+        ASYMKEY_GEN_ALGORITHMS.put(KeyParameters.DSA_ALGORITHM, KeyPairAlgorithm.DSA);
     }
     private static final String ATTR_SERIALNO = "serialNumber";
 
@@ -495,7 +495,7 @@ public class KeyRequestProcessor {
         String keyAlgorithm = data.getKeyAlgorithm();
         logger.info("KeyRequestProcessor: key algorithm: " + keyAlgorithm);
 
-        if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE) &&
+        if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE) &&
                 (keyAlgorithm == null || !SYMKEY_TYPES.containsKey(keyAlgorithm))) {
             throw new BadRequestException("Invalid symmetric key algorithm: " + keyAlgorithm);
         }
@@ -664,7 +664,7 @@ public class KeyRequestProcessor {
         String pkiArchiveOptions = data.getPKIArchiveOptions();
         String dataType = data.getDataType();
         String keyAlgorithm = data.getKeyAlgorithm();
-        int keyStrength = dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE) ?
+        int keyStrength = dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE) ?
                 data.getKeySize(): 0;
         String realm = data.getRealm();
 
@@ -790,7 +790,7 @@ public class KeyRequestProcessor {
                 throw new BadRequestException(
                         "Invalid request.  Must specify key algorithm if size is specified");
             }
-            algName = KeyRequestResource.AES_ALGORITHM;
+            algName = KeyParameters.AES_ALGORITHM;
             keySize = Integer.valueOf(128);
         }
 
@@ -857,13 +857,13 @@ public class KeyRequestProcessor {
         }
 
         if (keySize == null) {
-            if (algName.equalsIgnoreCase(KeyRequestResource.RSA_ALGORITHM)
-                    || algName.equalsIgnoreCase(KeyRequestResource.DSA_ALGORITHM)) {
+            if (algName.equalsIgnoreCase(KeyParameters.RSA_ALGORITHM)
+                    || algName.equalsIgnoreCase(KeyParameters.DSA_ALGORITHM)) {
                 throw new BadRequestException("Key size must be specified.");
             }
         } else {
             //Validate key size
-            if (algName.equalsIgnoreCase(KeyRequestResource.RSA_ALGORITHM)) {
+            if (algName.equalsIgnoreCase(KeyParameters.RSA_ALGORITHM)) {
                 int size = keySize;
                 int minSize = cs.getInteger("keys.rsa.min.size", 256);
                 int maxSize = cs.getInteger("keys.rsa.max.size", 8192);
@@ -877,7 +877,7 @@ public class KeyRequestProcessor {
                 if (((size - 256) % 16) != 0) {
                     throw new BadRequestException("Invalid key size specified.");
                 }
-            } else if (algName.equalsIgnoreCase(KeyRequestResource.DSA_ALGORITHM)) {
+            } else if (algName.equalsIgnoreCase(KeyParameters.DSA_ALGORITHM)) {
                 // Without the PQGParams, JSS can create DSA keys of size 512, 768, 1024 only.
                 String[] sizes = engine.getConfig().getString("keys.dsa.list", "512,768,1024").split(",");
                 if (!Arrays.asList(sizes).contains(String.valueOf(keySize))) {

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v1/KeyRequestService.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v1/KeyRequestService.java
@@ -42,6 +42,7 @@ import com.netscape.certsrv.base.UnauthorizedException;
 import com.netscape.certsrv.dbs.keydb.KeyId;
 import com.netscape.certsrv.key.AsymKeyGenerationRequest;
 import com.netscape.certsrv.key.KeyArchivalRequest;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.certsrv.key.KeyRecoveryRequest;
 import com.netscape.certsrv.key.KeyRequestInfo;
 import com.netscape.certsrv.key.KeyRequestInfoCollection;
@@ -79,12 +80,12 @@ public class KeyRequestService extends SubsystemService implements KeyRequestRes
     public static final Map<String, SymmetricKey.Type> SYMKEY_TYPES;
     static {
         SYMKEY_TYPES = new HashMap<>();
-        SYMKEY_TYPES.put(KeyRequestResource.DES_ALGORITHM, SymmetricKey.DES);
-        SYMKEY_TYPES.put(KeyRequestResource.DESEDE_ALGORITHM, SymmetricKey.DES3);
-        SYMKEY_TYPES.put(KeyRequestResource.DES3_ALGORITHM, SymmetricKey.DES3);
-        SYMKEY_TYPES.put(KeyRequestResource.RC2_ALGORITHM, SymmetricKey.RC2);
-        SYMKEY_TYPES.put(KeyRequestResource.RC4_ALGORITHM, SymmetricKey.RC4);
-        SYMKEY_TYPES.put(KeyRequestResource.AES_ALGORITHM, SymmetricKey.AES);
+        SYMKEY_TYPES.put(KeyParameters.DES_ALGORITHM, SymmetricKey.DES);
+        SYMKEY_TYPES.put(KeyParameters.DESEDE_ALGORITHM, SymmetricKey.DES3);
+        SYMKEY_TYPES.put(KeyParameters.DES3_ALGORITHM, SymmetricKey.DES3);
+        SYMKEY_TYPES.put(KeyParameters.RC2_ALGORITHM, SymmetricKey.RC2);
+        SYMKEY_TYPES.put(KeyParameters.RC4_ALGORITHM, SymmetricKey.RC4);
+        SYMKEY_TYPES.put(KeyParameters.AES_ALGORITHM, SymmetricKey.AES);
     }
 
     /**
@@ -151,7 +152,7 @@ public class KeyRequestService extends SubsystemService implements KeyRequestRes
         String keyAlgorithm = data.getKeyAlgorithm();
         logger.info("KeyRequestService: key algorithm: " + keyAlgorithm);
 
-        if (dataType.equals(KeyRequestResource.SYMMETRIC_KEY_TYPE) &&
+        if (dataType.equals(KeyParameters.SYMMETRIC_KEY_TYPE) &&
                 (keyAlgorithm == null || !SYMKEY_TYPES.containsKey(keyAlgorithm))) {
             throw new BadRequestException("Invalid symmetric key algorithm: " + keyAlgorithm);
         }

--- a/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyGenerateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/kra/KRAKeyGenerateCLI.java
@@ -8,7 +8,7 @@ import org.apache.commons.cli.Option;
 
 import com.netscape.certsrv.client.PKIClient;
 import com.netscape.certsrv.key.KeyClient;
-import com.netscape.certsrv.key.KeyRequestResource;
+import com.netscape.certsrv.key.KeyParameters;
 import com.netscape.certsrv.key.KeyRequestResponse;
 import com.netscape.cmstools.cli.MainCLI;
 import com.netscape.cmstools.cli.SubsystemCommandCLI;
@@ -84,18 +84,18 @@ public class KRAKeyGenerateCLI extends SubsystemCommandCLI {
 
         if (keySize == null) {
             switch (keyAlgorithm) {
-            case KeyRequestResource.DES3_ALGORITHM:
-            case KeyRequestResource.DESEDE_ALGORITHM:
+            case KeyParameters.DES3_ALGORITHM:
+            case KeyParameters.DESEDE_ALGORITHM:
                 keySize = "168";
                 break;
-            case KeyRequestResource.DES_ALGORITHM:
+            case KeyParameters.DES_ALGORITHM:
                 keySize = "56";
                 break;
-            case KeyRequestResource.RC4_ALGORITHM:
-            case KeyRequestResource.AES_ALGORITHM:
-            case KeyRequestResource.RC2_ALGORITHM:
-            case KeyRequestResource.RSA_ALGORITHM:
-            case KeyRequestResource.DSA_ALGORITHM:
+            case KeyParameters.RC4_ALGORITHM:
+            case KeyParameters.AES_ALGORITHM:
+            case KeyParameters.RC2_ALGORITHM:
+            case KeyParameters.RSA_ALGORITHM:
+            case KeyParameters.DSA_ALGORITHM:
                 throw new Exception("Key size must be specified for the algorithm used.");
             default:
                 throw new Exception("Algorithm not supported.");
@@ -123,17 +123,17 @@ public class KRAKeyGenerateCLI extends SubsystemCommandCLI {
 
         KeyRequestResponse response = null;
         switch (keyAlgorithm) {
-        case KeyRequestResource.DES3_ALGORITHM:
-        case KeyRequestResource.DESEDE_ALGORITHM:
-        case KeyRequestResource.DES_ALGORITHM:
-        case KeyRequestResource.RC4_ALGORITHM:
-        case KeyRequestResource.AES_ALGORITHM:
-        case KeyRequestResource.RC2_ALGORITHM:
+        case KeyParameters.DES3_ALGORITHM:
+        case KeyParameters.DESEDE_ALGORITHM:
+        case KeyParameters.DES_ALGORITHM:
+        case KeyParameters.RC4_ALGORITHM:
+        case KeyParameters.AES_ALGORITHM:
+        case KeyParameters.RC2_ALGORITHM:
             response = keyClient.generateSymmetricKey(
                     clientKeyId, keyAlgorithm, size, usages, null, realm);
             break;
-        case KeyRequestResource.RSA_ALGORITHM:
-        case KeyRequestResource.DSA_ALGORITHM:
+        case KeyParameters.RSA_ALGORITHM:
+        case KeyParameters.DSA_ALGORITHM:
             response = keyClient.generateAsymmetricKey(
                     clientKeyId, keyAlgorithm, size, usages, null, realm);
             break;


### PR DESCRIPTION
Static KeyParameter where defined in the Key*Resource classes. Since the resource classes are associated to v1 APIs and can be removed in future releases the parameters have been moved to a class defined only for them.

Note: There are still reference to Resource classes but for different purpose and will be addressed in following PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized cryptographic algorithm and key-status constants into a single shared definition and updated all key-management components to use it, standardizing AES, DES variants, RC2, RC4, RSA, DSA, EC and active/inactive handling.

* **Tests**
  * Updated test fixtures to use the new shared constants.

* **Chores**
  * Fixed typographical errors in comments/messages; no public APIs or behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->