### PR TITLE
Reorganize CA API test

### DIFF
--- a/.github/workflows/ca-api-test.yml
+++ b/.github/workflows/ca-api-test.yml
@@ -1,0 +1,324 @@
+name: CA API
+# This test will perform the following operations:
+# - install CA
+# - check pki info with default API
+# - check pki info with API v1
+# - check pki ca-cert-find with default API
+# - check pki ca-cert-find with API v1
+# - check pki ca-user-show with default API
+# - check pki ca-user-show with API v1
+# - check pki ca-cert-request-find with default API
+# - check pki ca-cert-request-find with API v1
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # docs/installation/ca/Installing_CA.md
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_audit_signing_nickname= \
+              -v
+
+      - name: Disable access log buffer
+        run: |
+          docker exec pki dnf install -y xmlstarlet
+
+          docker exec pki xmlstarlet edit --inplace \
+              -u "//Valve[@className='org.apache.catalina.valves.AccessLogValve']/@buffered" \
+              -v "false" \
+              -i "//Valve[@className='org.apache.catalina.valves.AccessLogValve' and not(@buffered)]" \
+              -t attr \
+              -n "buffered" \
+              -v "false" \
+              /etc/pki/pki-tomcat/server.xml
+
+      - name: Configure RESTEasy logging
+        run: |
+          docker exec -i pki tee /var/lib/pki/pki-tomcat/conf/ca/logging.properties << EOF
+          org.jboss.resteasy.level = INFO
+          EOF
+
+          docker exec pki chown pkiuser:pkiuser /var/lib/pki/pki-tomcat/conf/ca/logging.properties
+
+      - name: Restart PKI server
+        run: |
+          docker exec pki pki-server restart --wait
+
+      - name: Install CA signing cert
+        run: |
+          docker exec pki pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+      - name: Install CA admin cert
+        run: |
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Check pki info with default API
+        run: |
+          docker exec pki pki info
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -1 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check pki info with API v1
+        run: |
+          docker exec pki pki --api v1 info
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -1 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v1/info HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check pki ca-cert-find with default API
+        run: |
+          docker exec pki pki ca-cert-find | tee output
+
+          # get certs returned
+          grep "Serial Number:" output | wc -l > actual
+
+          # there should be 5 certs returned
+          echo "5" > expected
+          diff expected actual
+
+          # get total certs found
+          sed -n "s/^\(\S*\) entries found$/\1/p" output > actual
+
+          # there should be no total certs found
+          diff /dev/null actual
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -2 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          POST /ca/v2/certs/search HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check pki ca-cert-find with API v1
+        run: |
+          docker exec pki pki --api v1 ca-cert-find | tee output
+
+          # get certs returned
+          grep "Serial Number:" output | wc -l > actual
+
+          # there should be 5 certs returned
+          echo "5" > expected
+          diff expected actual
+
+          # get total certs found
+          sed -n "s/^\(\S*\) entries found$/\1/p" output > actual
+
+          # there should be 5 certs found
+          echo "5" > expected
+          diff expected actual
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -2 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v1/info HTTP/1.1 200 -
+          POST /ca/v1/certs/search HTTP/1.1 200 -
+          EOF
+
+          diff expected output
+
+      - name: Check pki ca-user-show with default API
+        run: |
+          docker exec pki pki -n caadmin ca-user-show caadmin
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /ca/v2/account/login HTTP/1.1 200 caadmin
+          GET /ca/v2/admin/users/caadmin HTTP/1.1 200 caadmin
+          GET /ca/v2/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      - name: Check pki ca-user-show with API v1
+        run: |
+          docker exec pki pki -n caadmin --api v1 ca-user-show caadmin
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v1/info HTTP/1.1 200 -
+          GET /ca/v1/account/login HTTP/1.1 200 caadmin
+          GET /ca/v1/admin/users/caadmin HTTP/1.1 200 caadmin
+          GET /ca/v1/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      - name: Check pki ca-cert-request-find with default API
+        run: |
+          docker exec pki pki -n caadmin ca-cert-request-find
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v2/info HTTP/1.1 200 -
+          GET /ca/v2/account/login HTTP/1.1 200 caadmin
+          GET /ca/v2/agent/certrequests HTTP/1.1 200 caadmin
+          GET /ca/v2/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      - name: Check pki ca-cert-request-find with API v1
+        run: |
+          docker exec pki pki -n caadmin --api v1 ca-cert-request-find
+
+          # check HTTP methods, paths, protocols, status, and authenticated users
+          docker exec pki find /var/log/pki/pki-tomcat \
+              -name "localhost_access_log.*" \
+              -exec cat {} \; \
+              | tail -4 \
+              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
+              | tee output
+
+          cat > expected << EOF
+          GET /pki/v1/info HTTP/1.1 200 -
+          GET /ca/v1/account/login HTTP/1.1 200 caadmin
+          GET /ca/v1/agent/certrequests HTTP/1.1 200 caadmin
+          GET /ca/v1/account/logout HTTP/1.1 204 caadmin
+          EOF
+
+          diff expected output
+
+      - name: Check DS server systemd journal
+        if: always()
+        run: |
+          docker exec ds journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check DS container logs
+        if: always()
+        run: |
+          docker logs ds
+
+      - name: Check for PKI core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check PKI server access log
+        if: always()
+        run: |
+          docker exec pki find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;

--- a/.github/workflows/ca-basic-test.yml
+++ b/.github/workflows/ca-basic-test.yml
@@ -1,4 +1,14 @@
 name: Basic CA
+# This test will perform the following operations:
+# - install CA
+# - check installed files and folders
+# - check system certs and keys in NSS database
+# - enable audit log signing
+# - check entries in DS
+# - check audit operations
+# - check profile operations
+# - remove CA
+# - check remaining files and folders
 
 on: workflow_call
 
@@ -519,20 +529,6 @@ jobs:
               --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
               --pkcs12-password Secret.123
 
-      - name: Update CA configuration
-        run: |
-          docker exec pki dnf install -y xmlstarlet
-
-          # disable access log buffer
-          docker exec pki xmlstarlet edit --inplace \
-              -u "//Valve[@className='org.apache.catalina.valves.AccessLogValve']/@buffered" \
-              -v "false" \
-              -i "//Valve[@className='org.apache.catalina.valves.AccessLogValve' and not(@buffered)]" \
-              -t attr \
-              -n "buffered" \
-              -v "false" \
-              /etc/pki/pki-tomcat/server.xml
-
       - name: Enable audit log signing
         run: |
           # https://github.com/dogtagpki/pki/wiki/Enabling-Audit-Log-Signing
@@ -574,53 +570,9 @@ jobs:
           docker exec pki pki-server ca-config-find | grep audit_signing
           docker exec pki pki-server ca-audit-config-show
 
-      - name: Configure RESTEasy logging
-        run: |
-          docker exec -i pki tee /var/lib/pki/pki-tomcat/conf/ca/logging.properties << EOF
-          org.jboss.resteasy.level = INFO
-          EOF
-
-          docker exec pki chown pkiuser:pkiuser /var/lib/pki/pki-tomcat/conf/ca/logging.properties
-
       - name: Restart PKI server
         run: |
           docker exec pki pki-server restart --wait
-
-      - name: Check pki info with default API
-        run: |
-          docker exec pki pki info
-
-          # check HTTP methods, paths, protocols, status, and authenticated users
-          docker exec pki find /var/log/pki/pki-tomcat \
-              -name "localhost_access_log.*" \
-              -exec cat {} \; \
-              | tail -1 \
-              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
-              | tee output
-
-          cat > expected << EOF
-          GET /pki/v2/info HTTP/1.1 200 -
-          EOF
-
-          diff expected output
-
-      - name: Check pki info with API v1
-        run: |
-          docker exec pki pki --api v1 info
-
-          # check HTTP methods, paths, protocols, status, and authenticated users
-          docker exec pki find /var/log/pki/pki-tomcat \
-              -name "localhost_access_log.*" \
-              -exec cat {} \; \
-              | tail -1 \
-              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
-              | tee output
-
-          cat > expected << EOF
-          GET /pki/v1/info HTTP/1.1 200 -
-          EOF
-
-          diff expected output
 
       - name: Test CA certs
         run: |
@@ -638,71 +590,6 @@ jobs:
               -o ldif_wrap=no \
               -LLL
 
-      - name: Check pki ca-cert-find with default API
-        run: |
-          docker exec pki pki ca-cert-find | tee output
-
-          # get certs returned
-          grep "Serial Number:" output | wc -l > actual
-
-          # there should be 6 certs returned
-          echo "6" > expected
-          diff expected actual
-
-          # get total certs found
-          sed -n "s/^\(\S*\) entries found$/\1/p" output > actual
-
-          # there should be no total certs found
-          diff /dev/null actual
-
-          # check HTTP methods, paths, protocols, status, and authenticated users
-          docker exec pki find /var/log/pki/pki-tomcat \
-              -name "localhost_access_log.*" \
-              -exec cat {} \; \
-              | tail -2 \
-              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
-              | tee output
-
-          cat > expected << EOF
-          GET /pki/v2/info HTTP/1.1 200 -
-          POST /ca/v2/certs/search HTTP/1.1 200 -
-          EOF
-
-          diff expected output
-
-      - name: Check pki ca-cert-find with API v1
-        run: |
-          docker exec pki pki --api v1 ca-cert-find | tee output
-
-          # get certs returned
-          grep "Serial Number:" output | wc -l > actual
-
-          # there should be 6 certs returned
-          echo "6" > expected
-          diff expected actual
-
-          # get total certs found
-          sed -n "s/^\(\S*\) entries found$/\1/p" output > actual
-
-          # there should be 6 certs found
-          echo "6" > expected
-          diff expected actual
-
-          # check HTTP methods, paths, protocols, status, and authenticated users
-          docker exec pki find /var/log/pki/pki-tomcat \
-              -name "localhost_access_log.*" \
-              -exec cat {} \; \
-              | tail -2 \
-              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
-              | tee output
-
-          cat > expected << EOF
-          GET /pki/v1/info HTTP/1.1 200 -
-          POST /ca/v1/certs/search HTTP/1.1 200 -
-          EOF
-
-          diff expected output
-
       - name: Check users in DS
         run: |
           docker exec ds ldapsearch \
@@ -714,48 +601,6 @@ jobs:
               -o ldif_wrap=no \
               -LLL
 
-      - name: Check pki ca-user-show with default API
-        run: |
-          docker exec pki pki -n caadmin ca-user-show caadmin
-
-          # check HTTP methods, paths, protocols, status, and authenticated users
-          docker exec pki find /var/log/pki/pki-tomcat \
-              -name "localhost_access_log.*" \
-              -exec cat {} \; \
-              | tail -4 \
-              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
-              | tee output
-
-          cat > expected << EOF
-          GET /pki/v2/info HTTP/1.1 200 -
-          GET /ca/v2/account/login HTTP/1.1 200 caadmin
-          GET /ca/v2/admin/users/caadmin HTTP/1.1 200 caadmin
-          GET /ca/v2/account/logout HTTP/1.1 204 caadmin
-          EOF
-
-          diff expected output
-
-      - name: Check pki ca-user-show with API v1
-        run: |
-          docker exec pki pki -n caadmin --api v1 ca-user-show caadmin
-
-          # check HTTP methods, paths, protocols, status, and authenticated users
-          docker exec pki find /var/log/pki/pki-tomcat \
-              -name "localhost_access_log.*" \
-              -exec cat {} \; \
-              | tail -4 \
-              | sed -e 's/^.* .* \(.*\) \[.*\] "\(.*\)" \(.*\) .*$/\2 \3 \1/' \
-              | tee output
-
-          cat > expected << EOF
-          GET /pki/v1/info HTTP/1.1 200 -
-          GET /ca/v1/account/login HTTP/1.1 200 caadmin
-          GET /ca/v1/admin/users/caadmin HTTP/1.1 200 caadmin
-          GET /ca/v1/account/logout HTTP/1.1 204 caadmin
-          EOF
-
-          diff expected output
-
       - name: Check cert requests in DS
         run: |
           docker exec ds ldapsearch \
@@ -766,10 +611,6 @@ jobs:
               -b "ou=requests,dc=ca,dc=pki,dc=example,dc=com" \
               -o ldif_wrap=no \
               -LLL
-
-      - name: Check cert requests in CA
-        run: |
-          docker exec pki pki -n caadmin ca-cert-request-find
 
       - name: Test CA auditor
         run: |

--- a/.github/workflows/ca-tests.yml
+++ b/.github/workflows/ca-tests.yml
@@ -95,12 +95,12 @@ jobs:
     needs: build
     uses: ./.github/workflows/ca-ssnv2-test.yml
 
-  ca-pruning-test:
-    name: CA database pruning
-    needs: build
-    uses: ./.github/workflows/ca-pruning-test.yml
-
   ca-admin-user-test:
     name: CA admin user
     needs: build
     uses: ./.github/workflows/ca-admin-user-test.yml
+
+  ca-api-test:
+    name: CA API
+    needs: build
+    uses: ./.github/workflows/ca-api-test.yml

--- a/.github/workflows/ca-tests2.yml
+++ b/.github/workflows/ca-tests2.yml
@@ -93,6 +93,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/ca-nuxwdog-test.yml
 
+  ca-pruning-test:
+    name: CA database pruning
+    needs: build
+    uses: ./.github/workflows/ca-pruning-test.yml
+
   scep-test:
     name: SCEP responder
     needs: build


### PR DESCRIPTION
The API test in CA basic test has been moved into a separate workflow to make it easier to investigate the `SIGSEGV` issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD testing infrastructure with new API and PKI integration test workflows to improve testing coverage and reliability.
  * Reorganized test workflow configuration for streamlined execution and diagnostics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->