### PR TITLE
Standalone Build Mechanism for KRATool (pki-kratool rpm):

### DIFF
--- a/base/tools/build-kratool.sh
+++ b/base/tools/build-kratool.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Build script for standalone KRATool package
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_NAME="pki-kratool"
+
+# Extract version from spec file (single source of truth)
+PKG_VERSION=$(awk '$1=="Version:"{print $2; exit}' "${SCRIPT_DIR}/pki-kratool.spec")
+
+if [ -z "$PKG_VERSION" ]; then
+    echo "ERROR: Could not extract version from pki-kratool.spec"
+    exit 1
+fi
+
+BUILD_DIR="${HOME}/build/${PKG_NAME}"
+
+echo "=== Building Standalone KRATool Package ==="
+echo "Package: ${PKG_NAME}-${PKG_VERSION}"
+echo "Build directory: ${BUILD_DIR}"
+echo
+
+# Validate required files exist
+validate_file() {
+    if [ ! -f "$1" ]; then
+        echo "ERROR: $2 not found at $3"
+        exit 1
+    fi
+}
+
+echo "Validating required files..."
+validate_file "${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/KRATool.java" "KRATool.java" "${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/"
+validate_file "${SCRIPT_DIR}/kratool-pom.xml" "kratool-pom.xml" "${SCRIPT_DIR}/"
+validate_file "${SCRIPT_DIR}/pki-kratool.spec" "pki-kratool.spec" "${SCRIPT_DIR}/"
+
+# Create build directory structure
+echo "Creating build directories..."
+if [ -n "${BUILD_DIR}" ] && [ "${BUILD_DIR}" != "/" ]; then
+   rm -rf "${BUILD_DIR}"
+fi
+mkdir -p "${BUILD_DIR}/"{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
+# Create source tarball
+echo "Creating source tarball..."
+TARBALL_DIR="${BUILD_DIR}/SOURCES/${PKG_NAME}-${PKG_VERSION}"
+mkdir -p "${TARBALL_DIR}/src/main/java/com/netscape/cmstools"
+
+# Copy KRATool source file
+cp "${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/KRATool.java" \
+   "${TARBALL_DIR}/src/main/java/com/netscape/cmstools/"
+
+# Copy pom.xml and sync version from spec file (spec is single source of truth)
+cp "${SCRIPT_DIR}/kratool-pom.xml" "${TARBALL_DIR}/pom.xml"
+sed -i "/<artifactId>pki-kratool<\/artifactId>/,/<\/version>/ s|<version>.*</version>|<version>${PKG_VERSION}</version>|" "${TARBALL_DIR}/pom.xml"
+
+# Copy license file
+cp "${SCRIPT_DIR}/../../LICENSE" "${TARBALL_DIR}/"
+
+# Create tarball
+cd "${BUILD_DIR}/SOURCES"
+tar czf "${PKG_NAME}-${PKG_VERSION}.tar.gz" "${PKG_NAME}-${PKG_VERSION}"
+rm -rf "${PKG_NAME}-${PKG_VERSION}"
+
+# Copy spec file
+echo "Copying spec file..."
+cp "${SCRIPT_DIR}/pki-kratool.spec" "${BUILD_DIR}/SPECS/"
+
+# Build RPM
+echo "Building RPM..."
+cd "${BUILD_DIR}"
+rpmbuild --define "_topdir ${BUILD_DIR}" \
+         -ba SPECS/pki-kratool.spec
+
+echo
+echo "=== Build Complete ==="
+echo "RPMs in: ${BUILD_DIR}/RPMS/noarch/"
+ls -lh "${BUILD_DIR}/RPMS/noarch/"
+echo
+echo "To install:"
+echo "  sudo rpm -ivh ${BUILD_DIR}/RPMS/noarch/${PKG_NAME}-${PKG_VERSION}-*.rpm"
+echo "  # Or to upgrade existing:"
+echo "  sudo rpm -Uvh ${BUILD_DIR}/RPMS/noarch/${PKG_NAME}-${PKG_VERSION}-*.rpm"
+echo

--- a/base/tools/kratool-pom.xml
+++ b/base/tools/kratool-pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.dogtagpki.pki</groupId>
+    <artifactId>pki-kratool</artifactId>
+    <!-- IMPORTANT: Keep this version in sync with pki-kratool.spec -->
+    <version>11.10.0</version>
+    <packaging>jar</packaging>
+
+    <name>PKI KRATool</name>
+    <description>Standalone tool for KRA archived keys migration with cross-scheme support</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <!--
+        Note on dependency management approach:
+
+        This POM uses <scope>system</scope> with <systemPath> for several dependencies,
+        which is intentional for KRATool's specific use case:
+
+        1. STANDALONE MIGRATION TOOL: KRATool runs on production PKI systems where these
+           libraries are already installed by the OS package manager at known locations.
+
+        2. VERSION CONSISTENCY: Using the exact same JARs as the deployed PKI system
+           ensures cryptographic compatibility and avoids version conflicts during
+           security-sensitive key migration operations.
+
+        3. SECURITY & AUDITABILITY: OS-packaged libraries receive security updates through
+           standard system update mechanisms and are tracked by package management.
+
+        4. BUILD SUPPORT: Corresponding BuildRequires in pki-kratool.spec ensure these
+           packages are installed during RPM build in clean environments.
+
+        While <scope>provided</scope> would be cleaner from a Maven perspective, system
+        scope provides explicit path guarantees needed for a tool targeting specific
+        RHEL versions with known filesystem layouts.
+    -->
+
+    <dependencies>
+        <!-- JSS -->
+        <dependency>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
+            <version>5.5.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/lib/java/jss/jss-base.jar</systemPath>
+        </dependency>
+
+        <!-- PKI Common -->
+        <dependency>
+            <groupId>org.dogtagpki.pki</groupId>
+            <artifactId>pki-common</artifactId>
+            <version>11.10.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/pki/pki-common.jar</systemPath>
+        </dependency>
+
+        <!-- SLF4J -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/slf4j/slf4j-api.jar</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>1.7.36</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/slf4j/slf4j-jdk14.jar</systemPath>
+        </dependency>
+
+        <!-- LDAP SDK -->
+        <dependency>
+            <groupId>org.mozilla</groupId>
+            <artifactId>ldapjdk</artifactId>
+            <version>5.5.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/ldapjdk.jar</systemPath>
+        </dependency>
+
+        <!-- Apache Commons CLI -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.9.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/apache-commons-cli.jar</systemPath>
+        </dependency>
+
+        <!-- Apache Commons Lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.17.0</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/apache-commons-lang3.jar</systemPath>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <includes>
+                        <include>com/netscape/cmstools/KRATool.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.netscape.cmstools.KRATool</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/base/tools/pki-kratool.spec
+++ b/base/tools/pki-kratool.spec
@@ -1,0 +1,76 @@
+Name:           pki-kratool
+Version:        11.10.0
+Release:        1%{?dist}
+Summary:        KRATool - PKI KRA LDIF Migration Tool
+
+License:        GPLv2
+URL:            https://www.dogtagpki.org
+Source0:        %{name}-%{version}.tar.gz
+
+BuildArch:      noarch
+
+BuildRequires:  maven
+BuildRequires:  java-17-openjdk-devel
+BuildRequires:  jss >= 5.5.0
+BuildRequires:  pki-base >= 11.6.0
+BuildRequires:  slf4j
+BuildRequires:  apache-commons-cli
+BuildRequires:  apache-commons-lang3
+BuildRequires:  ldapjdk
+
+# Runtime dependencies - use file paths instead of package names to avoid forcing upgrades
+Requires:       java-17-openjdk-headless
+#Requires:       jss >= 5.5.0
+#Requires:       pki-base >= 11.6.0
+#Requires:       slf4j
+#Requires:       apache-commons-cli
+#Requires:       apache-commons-lang3
+#Requires:       ldapjdk
+Requires:       /usr/lib/java/jss/jss-base.jar
+Requires:       /usr/share/java/pki/pki-common.jar
+Requires:       /usr/share/java/ldapjdk.jar
+Requires:       /usr/share/java/slf4j/slf4j-api.jar
+Requires:       /usr/share/java/slf4j/slf4j-jdk14.jar
+Requires:       /usr/share/java/apache-commons-cli.jar
+Requires:       /usr/share/java/apache-commons-lang3.jar
+
+%description
+KRATool is a utility for migrating archived private keys between
+PKI Key Recovery Authority (KRA) instances, including support for
+cross-scheme cryptographic migration.
+
+Key features:
+- Separate control of source and target wrapping algorithms
+- Order-independent LDIF field parsing
+- Algorithm auto-detection and session key regeneration
+- Optional software token fallback for unsupported algorithms
+- Backward compatible with legacy KRATool usage
+
+%prep
+%setup -q
+
+%build
+mvn clean package
+
+%install
+install -d -m 755 %{buildroot}%{_javadir}
+install -m 644 target/%{name}-%{version}.jar %{buildroot}%{_javadir}/
+
+install -d -m 755 %{buildroot}%{_bindir}
+cat > %{buildroot}%{_bindir}/KRATool << EOF
+#!/bin/bash
+exec java -cp %{_javadir}/%{name}-%{version}.jar:/usr/share/java/pki/pki-common.jar:/usr/lib/java/jss/jss-base.jar:/usr/share/java/slf4j/slf4j-api.jar:/usr/share/java/slf4j/slf4j-jdk14.jar:/usr/share/java/ldapjdk.jar:/usr/share/java/apache-commons-cli.jar:/usr/share/java/apache-commons-lang3.jar com.netscape.cmstools.KRATool "\$@"
+EOF
+chmod 755 %{buildroot}%{_bindir}/KRATool
+
+install -d -m 755 %{buildroot}%{_defaultlicensedir}/%{name}
+install -m 644 LICENSE %{buildroot}%{_defaultlicensedir}/%{name}/
+
+%files
+%license LICENSE
+%{_javadir}/%{name}-%{version}.jar
+%{_bindir}/KRATool
+
+%changelog
+* Fri Mar 20 2026 Christina Fu <cfu@redhat.com> - 11.10.0-1
+- Make KRATool an independent RPM package


### PR DESCRIPTION
Added build-kratool.sh script and associated spec/pom.xml files to generate a standalone kratool RPM package. This allows administrators to install or update KRATool independently without overwriting existing PKI RPMs that may contain critical hotfixes.

  Build: ./base/tools/build-kratool.sh rpm
  Output: ~/build/kratool/

Assisted-by: Claude
IDM-5245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a standalone pki-kratool RPM (v11.10.0) providing an installable KRATool Java application and a system-wide KRATool launcher.

* **Chores**
  * Adds packaging and build tooling to produce the self-contained KRATool artifact and installer, plus example install commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->