### PR TITLE
Move or delete resteasy dependency

### DIFF
--- a/base/ca/src/main/java/com/netscape/cms/servlet/cert/CertReviewResponseFactory.java
+++ b/base/ca/src/main/java/com/netscape/cms/servlet/cert/CertReviewResponseFactory.java
@@ -21,8 +21,6 @@ import java.util.Enumeration;
 import java.util.Locale;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.UriInfo;
-
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.cert.CertReviewResponse;
 import com.netscape.certsrv.profile.EProfileException;
@@ -45,7 +43,7 @@ public class CertReviewResponseFactory {
 
     public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(CertReviewResponseFactory.class);
 
-    public static CertReviewResponse create(Request request, Profile profile, UriInfo uriInfo, Locale locale) throws EBaseException {
+    public static CertReviewResponse create(Request request, Profile profile, Locale locale) throws EBaseException {
         CertReviewResponse ret = new CertReviewResponse();
 
         if (request.getRequestType().equals("renewal")) {

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/CertRequestDAO.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/CertRequestDAO.java
@@ -165,7 +165,7 @@ public class CertRequestDAO extends CMSRequestDAO {
 
         CAEngine engine = CAEngine.getInstance();
         Profile profile = ps.getProfile(profileId);
-        CertReviewResponse info = CertReviewResponseFactory.create(request, profile, uriInfo, locale);
+        CertReviewResponse info = CertReviewResponseFactory.create(request, profile, locale);
 
         if (engine.getEnableNonces()) {
             // generate nonce

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/AgentCertRequestServlet.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v2/AgentCertRequestServlet.java
@@ -221,7 +221,7 @@ public class AgentCertRequestServlet extends CAServlet {
         String profileId = request.getExtDataInString(Request.PROFILE_ID);
 
         Profile profile = ps.getProfile(profileId);
-        info = CertReviewResponseFactory.create(request, profile, null, servletRequest.getLocale());
+        info = CertReviewResponseFactory.create(request, profile, servletRequest.getLocale());
 
         if (random != null) {
             // generate nonce

--- a/base/common/src/main/java/com/netscape/certsrv/cert/CertEnrollmentRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/cert/CertEnrollmentRequest.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 
-import javax.ws.rs.core.MultivaluedMap;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -92,15 +91,6 @@ public class CertEnrollmentRequest extends RESTMessage {
     protected Collection<ProfileOutput> outputs = new ArrayList<>();
 
     public CertEnrollmentRequest() {
-    }
-
-    public CertEnrollmentRequest(MultivaluedMap<String, String> form) {
-        profileId = form.getFirst(PROFILE_ID);
-        String renewalStr = form.getFirst(RENEWAL);
-        serialNum = new CertId(form.getFirst(SERIAL_NUM));
-        renewal = Boolean.valueOf(renewalStr);
-
-        serverSideKeygenP12Passwd = form.getFirst(SERVERSIDE_KEYGEN_P12_PASSWD);
     }
 
     /**

--- a/base/common/src/main/java/com/netscape/certsrv/key/AsymKeyGenerationRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/AsymKeyGenerationRequest.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.ws.rs.core.MultivaluedMap;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -52,21 +51,6 @@ public class AsymKeyGenerationRequest extends KeyGenerationRequest  {
     public static final String DERIVE = "derive";
 
     public AsymKeyGenerationRequest() {
-        setClassName(getClass().getName());
-    }
-
-    public AsymKeyGenerationRequest(MultivaluedMap<String, String> form) {
-        attributes.put(CLIENT_KEY_ID, form.getFirst(CLIENT_KEY_ID));
-        attributes.put(KEY_SIZE, form.getFirst(KEY_SIZE));
-        attributes.put(KEY_ALGORITHM, form.getFirst(KEY_ALGORITHM));
-        attributes.put(KEY_USAGE, form.getFirst(KEY_USAGE));
-        attributes.put(TRANS_WRAPPED_SESSION_KEY, form.getFirst(TRANS_WRAPPED_SESSION_KEY));
-        attributes.put(REALM,  form.getFirst(REALM));
-
-        String usageString = attributes.get(KEY_USAGE);
-        if (!StringUtils.isBlank(usageString)) {
-            setUsages(new ArrayList<>(Arrays.asList(usageString.split(","))));
-        }
         setClassName(getClass().getName());
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyRecoveryRequest.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyRecoveryRequest.java
@@ -23,8 +23,6 @@ package com.netscape.certsrv.key;
 
 import java.util.Map;
 
-import javax.ws.rs.core.MultivaluedMap;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -52,21 +50,6 @@ public class KeyRecoveryRequest extends RESTMessage {
     private static final String PAYLOAD_WRAPPING_NAME = "payloadWrappingName";
 
     public KeyRecoveryRequest() {
-        setClassName(getClass().getName());
-    }
-
-    public KeyRecoveryRequest(MultivaluedMap<String, String> form) {
-        if (form.containsKey(KEY_ID)) {
-            attributes.put(KEY_ID, form.getFirst(KEY_ID));
-        }
-        if (form.containsKey(REQUEST_ID)) {
-            attributes.put(REQUEST_ID, form.getFirst(REQUEST_ID));
-        }
-        attributes.put(TRANS_WRAPPED_SESSION_KEY, form.getFirst(TRANS_WRAPPED_SESSION_KEY));
-        attributes.put(SESSION_WRAPPED_PASSPHRASE, form.getFirst(SESSION_WRAPPED_PASSPHRASE));
-        attributes.put(NONCE_DATA, form.getFirst(NONCE_DATA));
-        attributes.put(CERTIFICATE, form.getFirst(CERTIFICATE));
-        attributes.put(PASSPHRASE, form.getFirst(PASSPHRASE));
         setClassName(getClass().getName());
     }
 

--- a/base/common/src/main/java/com/netscape/certsrv/system/KRAConnectorInfo.java
+++ b/base/common/src/main/java/com/netscape/certsrv/system/KRAConnectorInfo.java
@@ -17,8 +17,6 @@
 // --- END COPYRIGHT BLOCK ---
 package com.netscape.certsrv.system;
 
-import javax.ws.rs.core.MultivaluedMap;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -52,18 +50,6 @@ public class KRAConnectorInfo implements JSONSerializer {
     String enable;
 
     public KRAConnectorInfo() {
-    }
-
-    public KRAConnectorInfo(MultivaluedMap<String, String> form) {
-        host = form.getFirst(HOST);
-        port = form.getFirst(PORT);
-        subsystemCert = form.getFirst(SUBSYSTEM_CERT);
-        transportCert = form.getFirst(TRANSPORT_CERT);
-        uri = form.getFirst(URI);
-        timeout = form.getFirst(TIMEOUT);
-        local = form.getFirst(LOCAL);
-        enable = form.getFirst(ENABLE);
-        transportCertNickname = form.getFirst(TRANSPORT_CERT_NICKNAME);
     }
 
     public String getHost() {

--- a/base/common/src/main/java/org/dogtagpki/ca/CASystemCertClient.java
+++ b/base/common/src/main/java/org/dogtagpki/ca/CASystemCertClient.java
@@ -20,7 +20,7 @@ package org.dogtagpki.ca;
 import java.io.ByteArrayInputStream;
 import java.security.cert.X509Certificate;
 
-import javax.ws.rs.core.Response;
+import org.apache.http.HttpStatus;
 
 import org.mozilla.jss.netscape.security.pkcs.ContentInfo;
 import org.mozilla.jss.netscape.security.pkcs.PKCS7;
@@ -57,7 +57,7 @@ public class CASystemCertClient extends Client {
             certData = get("signing", CertData.class);
 
         } catch (PKIException e) {
-            if (e.getCode() != Response.Status.NOT_FOUND.getStatusCode()) {
+            if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
                 throw e;
             }
             logger.warn("Unable to get CA signing certificate: " + e.getMessage());

--- a/base/common/src/main/java/org/dogtagpki/common/CAInfoClient.java
+++ b/base/common/src/main/java/org/dogtagpki/common/CAInfoClient.java
@@ -28,6 +28,7 @@ import com.netscape.certsrv.client.PKIClient;
  * @author Ade Lee
  */
 public class CAInfoClient extends Client {
+    public static final String KEYWRAP_MECHANISM = "keywrap";
 
     public CAInfoClient(PKIClient client, String subsystem) throws Exception {
         super(client, subsystem, "v2", "info");
@@ -39,7 +40,7 @@ public class CAInfoClient extends Client {
 
     public String getKeyWrapAlgotihm() throws Exception {
 
-        String archivalMechanism = KRAInfoResource.KEYWRAP_MECHANISM;
+        String archivalMechanism = KEYWRAP_MECHANISM;
         String kwAlg = null;
 
         try {
@@ -50,7 +51,7 @@ public class CAInfoClient extends Client {
         } catch (PKIException e) {
             if (e.getCode() == 404) {
                 // assume this is an older server
-                archivalMechanism = KRAInfoResource.KEYWRAP_MECHANISM;
+                archivalMechanism = KEYWRAP_MECHANISM;
                 kwAlg = KeyWrapAlgorithm.DES3_CBC_PAD.toString();
 
             } else {
@@ -61,7 +62,7 @@ public class CAInfoClient extends Client {
             throw new Exception("Failed to retrieve archive wrapping information from the CA: " + e, e);
         }
 
-        if (!archivalMechanism.equals(KRAInfoResource.KEYWRAP_MECHANISM)) {
+        if (!archivalMechanism.equals(KEYWRAP_MECHANISM)) {
             // new server with encryption set.  Use something we know will
             // work.  AES-128-CBC
             kwAlg = KeyWrapAlgorithm.AES_CBC_PAD.toString();

--- a/base/common/src/main/java/org/dogtagpki/common/ConfigClient.java
+++ b/base/common/src/main/java/org/dogtagpki/common/ConfigClient.java
@@ -43,7 +43,10 @@ import com.netscape.cmsutil.xml.XMLObject;
  */
 public class ConfigClient extends Client {
 
-    public final static Logger logger = LoggerFactory.getLogger(ConfigClient.class);
+    public static final String SUCCESS = "0";
+    public static final String FAILURE = "1";
+    public static final String AUTH_FAILURE = "2";
+    public static final Logger logger = LoggerFactory.getLogger(ConfigClient.class);
 
     public ConfigClient(PKIClient client, String subsystem) throws Exception {
         super(client, subsystem, "config");
@@ -84,11 +87,11 @@ public class ConfigClient extends Client {
         String status = parser.getValue("Status");
         logger.debug("Status: " + status);
 
-        if (status.equals(ConfigResource.AUTH_FAILURE)) {
+        if (AUTH_FAILURE.equals(status)) {
             throw new EAuthException("Authentication failed");
         }
 
-        if (!status.equals(ConfigResource.SUCCESS)) {
+        if (!SUCCESS.equals(status)) {
             String error = parser.getValue("Error");
             throw new IOException(error);
         }

--- a/base/common/src/test/java/com/netscape/certsrv/base/DataTest.java
+++ b/base/common/src/test/java/com/netscape/certsrv/base/DataTest.java
@@ -2,7 +2,7 @@ package com.netscape.certsrv.base;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import javax.ws.rs.core.Response;
+import org.apache.http.HttpStatus;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -17,7 +17,7 @@ public class DataTest {
     @BeforeAll
     public static void setUpBefore() {
         before.className = PKIException.class.getName();
-        before.code = Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+        before.code = HttpStatus.SC_INTERNAL_SERVER_ERROR;
         before.message = "An error has occured";
         before.setAttribute("attr1", "value1");
         before.setAttribute("attr2", "value2");

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v1/KeyService.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v1/KeyService.java
@@ -25,8 +25,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MultivaluedMap;
@@ -302,7 +304,17 @@ public class KeyService extends SubsystemService implements KeyResource {
     @Override
     public Response retrieveKey(MultivaluedMap<String, String> form) {
         logger.debug("KeyService.retrieveKey with form: begins.");
-        KeyRecoveryRequest data = new KeyRecoveryRequest(form);
+        if (form == null) {
+            throw new BadRequestException("Missing key recovery request");
+        }
+        Map<String, String[]> formMap = new HashMap<>(form.size());
+        form.forEach((k, v) -> {
+                String[] s = (v == null || v.isEmpty()) ?
+                    new String[] {null} :
+                    v.toArray(new String[0]);
+                formMap.put(k, s);
+            });
+        KeyRecoveryRequest data = new KeyRecoveryRequest(formMap);
         return retrieveKey(data);
     }
 

--- a/base/server/src/main/java/com/netscape/cms/servlet/admin/GroupMemberProcessor.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/admin/GroupMemberProcessor.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.ws.rs.core.UriInfo;
-
 import com.netscape.certsrv.base.BadRequestException;
 import com.netscape.certsrv.base.ConflictingOperationException;
 import com.netscape.certsrv.base.PKIException;
@@ -59,18 +57,8 @@ public class GroupMemberProcessor extends Processor {
 
     public static String[] multiRoleGroupEnforceList;
 
-    protected UriInfo uriInfo;
-
     public GroupMemberProcessor(Locale locale) {
         super("group", locale);
-    }
-
-    public UriInfo getUriInfo() {
-        return uriInfo;
-    }
-
-    public void setUriInfo(UriInfo uriInfo) {
-        this.uriInfo = uriInfo;
     }
 
     public GroupMemberData createGroupMemberData(String groupID, String memberID) throws Exception {

--- a/base/server/src/main/java/org/dogtagpki/server/cli/PKIServerCLI.java
+++ b/base/server/src/main/java/org/dogtagpki/server/cli/PKIServerCLI.java
@@ -18,8 +18,6 @@
 
 package org.dogtagpki.server.cli;
 
-import javax.ws.rs.ProcessingException;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.UnrecognizedOptionException;
@@ -135,11 +133,6 @@ public class PKIServerCLI extends CLI {
         } else if (t instanceof UnrecognizedOptionException) {
             // display only the error message
             System.err.println(t.getMessage());
-
-        } else if (t instanceof ProcessingException) {
-            // display the cause of the exception
-            t = t.getCause();
-            System.err.println(t.getClass().getSimpleName() + ": " + t.getMessage());
 
         } else {
             // display the actual Exception

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v1/GroupService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v1/GroupService.java
@@ -346,7 +346,6 @@ public class GroupService extends SubsystemService implements GroupResource {
             processor.setCMSEngine(getCMSEngine());
             processor.init();
 
-            processor.setUriInfo(uriInfo);
             return createOKResponse(processor.findGroupMembers(groupID, filter, start, size));
 
         } catch (PKIException e) {
@@ -369,7 +368,6 @@ public class GroupService extends SubsystemService implements GroupResource {
             processor.setCMSEngine(getCMSEngine());
             processor.init();
 
-            processor.setUriInfo(uriInfo);
             return createOKResponse(processor.getGroupMember(groupID, memberID));
 
         } catch (PKIException e) {
@@ -392,7 +390,6 @@ public class GroupService extends SubsystemService implements GroupResource {
             processor.setCMSEngine(getCMSEngine());
             processor.init();
 
-            processor.setUriInfo(uriInfo);
             groupMemberData = processor.addGroupMember(groupMemberData);
 
             String encodedGroupID = URLEncoder.encode(groupID, "UTF-8");
@@ -423,7 +420,6 @@ public class GroupService extends SubsystemService implements GroupResource {
             processor.setCMSEngine(getCMSEngine());
             processor.init();
 
-            processor.setUriInfo(uriInfo);
             processor.removeGroupMember(groupID, memberID);
 
             return createNoContentResponse();

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v1/UserService.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v1/UserService.java
@@ -1072,7 +1072,6 @@ public class UserService extends SubsystemService implements UserResource {
             processor.setCMSEngine(engine);
             processor.init();
 
-            processor.setUriInfo(uriInfo);
             processor.addGroupMember(groupMemberData);
 
             UserMembershipData userMembershipData = createUserMembershipData(userID, groupID);
@@ -1105,7 +1104,6 @@ public class UserService extends SubsystemService implements UserResource {
             processor.setCMSEngine(getCMSEngine());
             processor.init();
 
-            processor.setUriInfo(uriInfo);
             processor.removeGroupMember(groupID, userID);
 
             return createNoContentResponse();

--- a/base/tomcat-10.1/src/main/java/com/netscape/cms/tomcat/AbstractPKIAuthenticator.java
+++ b/base/tomcat-10.1/src/main/java/com/netscape/cms/tomcat/AbstractPKIAuthenticator.java
@@ -21,6 +21,8 @@ package com.netscape.cms.tomcat;
 import java.io.IOException;
 import java.security.cert.X509Certificate;
 
+import com.netscape.certsrv.base.PKIException;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
@@ -90,8 +92,13 @@ public abstract class AbstractPKIAuthenticator extends AuthenticatorBase {
                     logger.debug("PKIAuthenticator: SSL auth return code: " + code);
                 }
             };
-            result = doSubAuthenticate(sslAuthenticator, request, wrapper);
-
+            try {
+                result = doSubAuthenticate(sslAuthenticator, request, wrapper);
+            } catch (PKIException e) {
+                response.sendError(e.getCode(), e.getMessage());
+                logger.error("Authentication service problem" + e.getMessage(), e);
+                return false;
+            }
         } else {
             logger.info("PKIAuthenticator: Authenticating with " + fallbackMethod + " authentication");
             HttpServletResponseWrapper wrapper = new HttpServletResponseWrapper(response) {
@@ -104,7 +111,13 @@ public abstract class AbstractPKIAuthenticator extends AuthenticatorBase {
                     logger.debug("PKIAuthenticator: Fallback auth return code: " + code);
                 }
             };
-            result = doSubAuthenticate(fallbackAuthenticator, request, wrapper);
+            try {
+                result = doSubAuthenticate(fallbackAuthenticator, request, wrapper);
+            } catch (PKIException e) {
+                response.sendError(e.getCode(), e.getMessage());
+                logger.error("Authentication service problem" + e.getMessage(), e);
+                return false;
+            }
         }
 
         if (result)

--- a/base/tomcat-10.1/src/main/java/com/netscape/cms/tomcat/ProxyRealm.java
+++ b/base/tomcat-10.1/src/main/java/com/netscape/cms/tomcat/ProxyRealm.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.x500.X500Principal;
-import jakarta.ws.rs.ServiceUnavailableException;
 
 import org.apache.catalina.Container;
 import org.apache.catalina.Context;
@@ -27,6 +26,7 @@ import org.mozilla.jss.netscape.security.x509.CertificateChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.netscape.certsrv.base.ServiceUnavailableException;
 import com.netscape.certsrv.dbs.certdb.CertId;
 
 /**

--- a/base/tomcat-9.0/src/main/java/com/netscape/cms/tomcat/AbstractPKIAuthenticator.java
+++ b/base/tomcat-9.0/src/main/java/com/netscape/cms/tomcat/AbstractPKIAuthenticator.java
@@ -25,6 +25,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
+import com.netscape.certsrv.base.PKIException;
+
 import org.apache.catalina.Authenticator;
 import org.apache.catalina.Container;
 import org.apache.catalina.Globals;
@@ -90,8 +92,13 @@ public abstract class AbstractPKIAuthenticator extends AuthenticatorBase {
                     logger.debug("PKIAuthenticator: SSL auth return code: " + code);
                 }
             };
-            result = doSubAuthenticate(sslAuthenticator, request, wrapper);
-
+            try {
+                result = doSubAuthenticate(sslAuthenticator, request, wrapper);
+            } catch (PKIException e) {
+                response.sendError(e.getCode(), e.getMessage());
+                logger.error("Authentication service problem: " + e.getMessage(), e);
+                return false;
+            }
         } else {
             logger.info("PKIAuthenticator: Authenticating with " + fallbackMethod + " authentication");
             HttpServletResponseWrapper wrapper = new HttpServletResponseWrapper(response) {
@@ -104,7 +111,13 @@ public abstract class AbstractPKIAuthenticator extends AuthenticatorBase {
                     logger.debug("PKIAuthenticator: Fallback auth return code: " + code);
                 }
             };
-            result = doSubAuthenticate(fallbackAuthenticator, request, wrapper);
+            try {
+                result = doSubAuthenticate(fallbackAuthenticator, request, wrapper);
+            } catch (PKIException e) {
+                response.sendError(e.getCode(), e.getMessage());
+                logger.error("Authentication service problem: " + e.getMessage(), e);
+                return false;
+            }
         }
 
         if (result)

--- a/base/tomcat-9.0/src/main/java/com/netscape/cms/tomcat/ProxyRealm.java
+++ b/base/tomcat-9.0/src/main/java/com/netscape/cms/tomcat/ProxyRealm.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.x500.X500Principal;
-import javax.ws.rs.ServiceUnavailableException;
 
 import org.apache.catalina.Container;
 import org.apache.catalina.Context;
@@ -25,6 +24,7 @@ import org.mozilla.jss.netscape.security.x509.CertificateChain;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.netscape.certsrv.base.ServiceUnavailableException;
 import com.netscape.certsrv.dbs.certdb.CertId;
 
 /**

--- a/base/tools/src/main/java/com/netscape/cmstools/acme/ACMEInfoCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/acme/ACMEInfoCLI.java
@@ -5,9 +5,8 @@
 //
 package com.netscape.cmstools.acme;
 
-import javax.ws.rs.core.Response;
-
 import org.apache.commons.cli.CommandLine;
+import org.apache.http.HttpStatus;
 import org.dogtagpki.acme.ACMEClient;
 import org.dogtagpki.acme.ACMEDirectory;
 import org.dogtagpki.acme.ACMEMetadata;
@@ -53,7 +52,7 @@ public class ACMEInfoCLI extends CommandCLI {
             System.out.println("  External Account Required: " + metadata.getExternalAccountRequired());
 
         } catch (PKIException e) {
-            if (e.getCode() != Response.Status.SERVICE_UNAVAILABLE.getStatusCode()) {
+            if (e.getCode() != HttpStatus.SC_SERVICE_UNAVAILABLE) {
                 throw e;
             }
             System.out.println("  Status: Unavailable");

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -36,14 +36,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.core.Response;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.MissingArgumentException;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.UnrecognizedOptionException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.dogtagpki.cli.CLI;
 import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.cli.CLIModule;
@@ -671,7 +669,7 @@ public class MainCLI extends CLI {
             }
 
         } catch (PKIException e) {
-            if (e.getCode() != Response.Status.NOT_FOUND.getStatusCode()) {
+            if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
                 throw e;
             }
             logger.warn("Unable to get server info: " + e.getMessage());
@@ -779,7 +777,7 @@ public class MainCLI extends CLI {
             // display only the error message
             System.err.println(t.getMessage());
 
-        } else if (t instanceof ProcessingException || t instanceof ClientConnectionException) {
+        } else if (t instanceof ClientConnectionException) {
             // display the cause of the exception (if available)
             Throwable e = t.getCause();
             if (e == null) e = t;

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/cms/ConnectionManager.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/cms/ConnectionManager.java
@@ -23,14 +23,13 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.List;
 
-import javax.ws.rs.core.MediaType;
-
 import org.dogtagpki.server.tps.TPSConfig;
 import org.dogtagpki.server.tps.TPSEngine;
 import org.dogtagpki.server.tps.TPSSubsystem;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.EPropertyNotFound;
+import com.netscape.certsrv.base.MimeType;
 import com.netscape.certsrv.connector.Connector;
 import com.netscape.certsrv.connector.ConnectorConfig;
 import com.netscape.certsrv.connector.ConnectorsConfig;
@@ -195,7 +194,7 @@ public class ConnectionManager
         int resendInterval = -1;
         int timeout = conf.getTimeout();
         RemoteAuthority remauthority =
-                new RemoteAuthority(host, port, uris, timeout, MediaType.APPLICATION_FORM_URLENCODED);
+                new RemoteAuthority(host, port, uris, timeout, MimeType.APPLICATION_FORM_URLENCODED);
 
         logger.debug("ConnectionManager: createConnector(): establishing HttpConnector");
         if (timeout == 0) {


### PR DESCRIPTION
Remove the use of MultivaluedMap and UriInfo because they were not actually used outside of v1 APIs. Replace Response status with HttpStatus in the check and resteasy MediaType with internal MimeType. Finally some static values have been duplicated outside of Resource classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed reliance on JAX-RS form/URI context plumbing and consolidated request/object initialization paths.
  * Simplified public APIs by dropping unused request-context parameters and centralizing status-constant usage.

* **Bug Fixes**
  * Added explicit validation for missing request data and clearer service/authentication error responses.
  * Made HTTP status comparisons and error handling more consistent across tools and clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->