### PR TITLE
Add v1 REST API deprecation control with build-time flag

### DIFF
--- a/.github/workflows/python-ca-test.yml
+++ b/.github/workflows/python-ca-test.yml
@@ -427,6 +427,28 @@ jobs:
 
           diff expected output
 
+      ####################################################################################################
+      # Check API v1 status
+
+      - name: Check API v1 are deprecated
+        run: |
+          docker exec pki curl -v -k https://pki.example.com:8443/pki/v1/info 2>&1 |tee output
+          grep "< Deprecation: true" output
+          grep '< Link: <https://github.com/dogtagpki/pki/wiki/REST-API-v2>; rel="alternate"' output
+
+      - name: Make the API v1 disabled
+        run: |
+          docker exec pki sed -i \
+              's/-Dredhat.crypto-policies=false/-Dredhat.crypto-policies=false -Dapi.v1.status=disabled/' \
+              /etc/sysconfig/pki-tomcat
+
+          docker exec pki pki-server restart --wait
+
+      - name: Check API v1 are disabled
+        run: |
+          docker exec pki curl -k https://pki.example.com:8443/pki/v1/info | tee output
+          grep '"error":"REST API v1 have been disabled"' output
+
       - name: Check DS server systemd journal
         if: always()
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ option(WITH_THEME "Build theme package" ON)
 option(WITH_META "Build meta package" ON)
 option(WITH_TESTS "Build tests package" ON)
 option(RUN_TESTS "Run unit tests" ON)
+option(WITH_APIV1 "Build API V1" ON)
 
 set(APPLICATION_VERSION "${APPLICATION_VERSION_MAJOR}.${APPLICATION_VERSION_MINOR}.${APPLICATION_VERSION_PATCH}")
 

--- a/base/ca/CMakeLists.txt
+++ b/base/ca/CMakeLists.txt
@@ -78,8 +78,15 @@ add_custom_command(
     COMMAND ln -sf ../../../../../lib/slf4j-jdk14.jar webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-ca.jar webapp/lib/pki-ca.jar
+)
+
+if(WITH_APIV1)
+add_custom_command(
+    TARGET pki-ca-links POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../server/common/lib/resteasy-servlet-initializer.jar webapp/lib/resteasy-servlet-initializer.jar
 )
+endif()
 
 if(WITH_JAVA)
     install(

--- a/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/CAApplication.java
+++ b/base/ca/src/main/java/org/dogtagpki/server/ca/rest/v1/CAApplication.java
@@ -1,10 +1,13 @@
 package org.dogtagpki.server.ca.rest.v1;
 
+import com.netscape.cmscore.apps.CMSEngine;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+import org.dogtagpki.server.ca.CAEngine;
+import org.dogtagpki.server.ca.CAEngineConfig;
 
 import org.dogtagpki.server.rest.v1.ACLInterceptor;
 import org.dogtagpki.server.rest.v1.AccountService;
@@ -19,6 +22,7 @@ import org.dogtagpki.server.rest.v1.SecurityDomainService;
 import org.dogtagpki.server.rest.v1.SelfTestService;
 import org.dogtagpki.server.rest.v1.SessionContextInterceptor;
 import org.dogtagpki.server.rest.v1.UserService;
+import org.dogtagpki.server.rest.v1.ApiStatusHelper;
 
 @ApplicationPath("/v1")
 public class CAApplication extends Application {
@@ -29,6 +33,12 @@ public class CAApplication extends Application {
     private Set<Class<?>> classes = new LinkedHashSet<>();
 
     public CAApplication() {
+
+        CMSEngine engine = CAEngine.getInstance();
+        // Check v1 API status
+        if (ApiStatusHelper.checkApiStatus("CA", classes, logger, engine.getConfig())) {
+            return;
+        }
 
         // account
         classes.add(AccountService.class);

--- a/base/common/CMakeLists.txt
+++ b/base/common/CMakeLists.txt
@@ -128,8 +128,6 @@ add_custom_command(
     COMMAND ln -sf ${JACKSON_ANNOTATIONS_LINK} lib/jackson-annotations.jar
     COMMAND ln -sf ${JACKSON_CORE_LINK} lib/jackson-core.jar
     COMMAND ln -sf ${JACKSON_DATABIND_LINK} lib/jackson-databind.jar
-    COMMAND ln -sf ${JACKSON_JAXRS_BASE_LINK} lib/jackson-jaxrs-base.jar
-    COMMAND ln -sf ${JACKSON_JAXRS_JSON_PROVIDER_LINK} lib/jackson-jaxrs-json-provider.jar
     COMMAND ln -sf ${JACKSON_MODULE_JAXB_ANNOTATIONS_LINK} lib/jackson-module-jaxb-annotations.jar
     COMMAND ln -sf ${JAKARTA_ACTIVATION_API_LINK} lib/jakarta.activation-api.jar
     COMMAND ln -sf ${JAKARTA_ANNOTATION_API_LINK} lib/jakarta.annotation-api.jar
@@ -141,12 +139,22 @@ add_custom_command(
     COMMAND ln -sf ../../../..${P11_KIT_TRUST} lib/p11-kit-trust.so
     COMMAND ln -sf ../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-common.jar lib/pki-common.jar
     COMMAND ln -sf ../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tools.jar lib/pki-tools.jar
-    COMMAND ln -sf ${RESTEASY_JACKSON_PROVIDER_LINK} lib/resteasy-jackson2-provider.jar
-    COMMAND ln -sf ${RESTEASY_JAXRS_LINK} lib/resteasy-jaxrs.jar
     COMMAND ln -sf ../../../..${SERVLET_JAR} lib/servlet.jar
     COMMAND ln -sf ${SLF4J_API_LINK} lib/slf4j-api.jar
     COMMAND ln -sf ${SLF4J_JDK14_LINK} lib/slf4j-jdk14.jar
 )
+
+if(WITH_APIV1)
+add_custom_command(
+    TARGET pki-lib POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory lib
+    COMMAND test ! -d ${CMAKE_SOURCE_DIR}/base/common/lib || cp ${CMAKE_SOURCE_DIR}/base/common/lib/* lib
+    COMMAND ln -sf ${JACKSON_JAXRS_BASE_LINK} lib/jackson-jaxrs-base.jar
+    COMMAND ln -sf ${JACKSON_JAXRS_JSON_PROVIDER_LINK} lib/jackson-jaxrs-json-provider.jar
+    COMMAND ln -sf ${RESTEASY_JACKSON_PROVIDER_LINK} lib/resteasy-jackson2-provider.jar
+    COMMAND ln -sf ${RESTEASY_JAXRS_LINK} lib/resteasy-jaxrs.jar
+)
+endif()
 
 add_custom_target(pki-man ALL
     COMMENT "Creating PKI manuals")

--- a/base/common/pom.xml
+++ b/base/common/pom.xml
@@ -95,12 +95,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
-            <version>1.0.0.Final</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>2.14.2</version>
@@ -125,36 +119,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-base</artifactId>
-            <version>2.14.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.14.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>3.4.1.Final</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.0.26.Final</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>3.0.26.Final</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.dogtagpki.jss</groupId>
             <artifactId>jss-base</artifactId>
             <version>[5.10.0-SNAPSHOT,)</version>
@@ -167,6 +131,56 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <!-- Include API v1 dependencies unless skipped -->
+        <profile>
+            <id>api-v1-deps</id>
+            <activation>
+                <property>
+                    <name>api.v1</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                    <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+                    <version>1.0.0.Final</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                    <artifactId>jackson-jaxrs-base</artifactId>
+                    <version>2.14.2</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                    <artifactId>jackson-jaxrs-json-provider</artifactId>
+                    <version>2.14.2</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                    <version>3.4.1.Final</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jaxrs</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jackson2-provider</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/base/javadoc/CMakeLists.txt
+++ b/base/javadoc/CMakeLists.txt
@@ -56,6 +56,37 @@ if(((${Javadoc_VERSION_MAJOR} EQUAL 1) AND (${Javadoc_VERSION_MINOR} EQUAL 8)) O
     set(doclintstr "-Xdoclint:none")
 endif()
 
+if(WITH_APIV1)
+    # v1 enabled/deprecated/disabled: include all packages
+    message(STATUS "API v1: including all packages in javadoc")
+    set(v1_subpackages "com.netscape.certsrv" "org.dogtagpki")
+    set(exclude_packages "")
+    set(jaxrs_classpath ${JAXRS_API_JAR} ${RESTEASY_JAXRS_JAR})
+    set(v1_javadoc_opts "")
+else()
+    # v1 dropped: exclude v1-specific packages from javadoc
+    message(STATUS "API v1 dropped: excluding v1 packages from javadoc")
+    # Don't include com.netscape.certsrv or org.dogtagpki (which are mostly v1 Resource interfaces)
+    set(v1_subpackages "org.dogtagpki")
+    # Exclude v1-specific packages (both client and server)
+    # Only exclude v1 REST packages, not entire subsystem packages
+    set(exclude_packages
+        "com.netscape.certsrv"
+        "com.netscape.cms.servlet"
+        "org.dogtagpki.server.rest.v1"
+        "org.dogtagpki.server.ca.rest.v1"
+        "org.dogtagpki.server.kra.rest.v1"
+        "org.dogtagpki.server.ocsp.rest.v1"
+        "org.dogtagpki.server.tks.rest.v1"
+        "org.dogtagpki.server.tps.rest.v1"
+    )
+    # Don't include JAX-RS jars - they're not available when v1 is dropped
+    # and javadoc will skip type checking for excluded packages
+    set(jaxrs_classpath "")
+    # Ignore source errors in excluded packages (transformed code references jakarta.ws.rs but jars have javax.ws.rs)
+    set(v1_javadoc_opts "--ignore-source-errors")
+endif()
+
 javadoc(pki-javadoc
     SOURCEPATH
         ${CMAKE_SOURCE_DIR}/base/common/src/main/java
@@ -65,10 +96,11 @@ javadoc(pki-javadoc
         ${CMAKE_CURRENT_BINARY_DIR}/javadoc/pki
     SUBPACKAGES
         com.netscape.cmsutil
-        com.netscape.certsrv
         com.netscape.cmstools
-        org.dogtagpki
+        ${v1_subpackages}
         ${PKI_JAVADOC_SUBPACKAGES}
+    EXCLUDE
+        ${exclude_packages}
     CLASSPATH
         ${SLF4J_API_JAR} ${JAXB_API_JAR}
         ${COMMONS_CLI_JAR} ${COMMONS_LANG3_JAR}
@@ -76,13 +108,12 @@ javadoc(pki-javadoc
         ${LDAPJDK_JAR}
         ${SERVLET_JAR} ${TOMCAT_CATALINA_JAR} ${TOMCAT_UTIL_JAR}
         ${HTTPCLIENT_JAR} ${HTTPCORE_JAR}
-        ${JAXRS_API_JAR}
+        ${jaxrs_classpath}
         ${JACKSON_CORE_JAR}
         ${JACKSON_ANNOTATIONS_JAR}
         ${JACKSON_DATABIND_JAR}
         ${JACKSON_MODULE_JAXB_ANNOTATIONS_JAR}
         ${JAKARTA_ANNOTATION_API_JAR}
-        ${RESTEASY_JAXRS_JAR}
         ${JSS_JAR}
         ${JSS_TOMCAT_JAR}
         ${JSS_TOMCAT_9_0_JAR}
@@ -98,6 +129,7 @@ javadoc(pki-javadoc
         -version
         -quiet
         ${doclintstr}
+        ${v1_javadoc_opts}
 )
 
 add_dependencies(javadoc pki-javadoc)

--- a/base/kra/CMakeLists.txt
+++ b/base/kra/CMakeLists.txt
@@ -70,8 +70,16 @@ add_custom_command(
     COMMAND ln -sf ../../../../../lib/slf4j-jdk14.jar webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-kra.jar webapp/lib/pki-kra.jar
+
+)
+
+if(WITH_APIV1)
+add_custom_command(
+    TARGET pki-kra-links POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../server/common/lib/resteasy-servlet-initializer.jar webapp/lib/resteasy-servlet-initializer.jar
 )
+endif()
 
 if(WITH_JAVA)
     install(

--- a/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v1/KRAApplication.java
+++ b/base/kra/src/main/java/org/dogtagpki/server/kra/rest/v1/KRAApplication.java
@@ -1,11 +1,13 @@
 package org.dogtagpki.server.kra.rest.v1;
 
+import com.netscape.cmscore.apps.CMSEngine;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
+import org.dogtagpki.server.kra.KRAEngine;
 import org.dogtagpki.server.rest.v1.ACLInterceptor;
 import org.dogtagpki.server.rest.v1.AccountService;
 import org.dogtagpki.server.rest.v1.AuditService;
@@ -18,6 +20,7 @@ import org.dogtagpki.server.rest.v1.SecurityDomainService;
 import org.dogtagpki.server.rest.v1.SelfTestService;
 import org.dogtagpki.server.rest.v1.SessionContextInterceptor;
 import org.dogtagpki.server.rest.v1.UserService;
+import org.dogtagpki.server.rest.v1.ApiStatusHelper;
 
 @ApplicationPath("/v1")
 public class KRAApplication extends Application {
@@ -28,6 +31,12 @@ public class KRAApplication extends Application {
     private Set<Class<?>> classes = new LinkedHashSet<>();
 
     public KRAApplication() {
+
+        CMSEngine engine = KRAEngine.getInstance();
+        // Check v1 API status
+        if (ApiStatusHelper.checkApiStatus("KRA", classes, logger, engine.getConfig())) {
+            return;
+        }
 
         // account
         classes.add(AccountService.class);

--- a/base/ocsp/CMakeLists.txt
+++ b/base/ocsp/CMakeLists.txt
@@ -68,8 +68,15 @@ add_custom_command(
     COMMAND ln -sf ../../../../../lib/slf4j-jdk14.jar webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-ocsp.jar webapp/lib/pki-ocsp.jar
+)
+
+if(WITH_APIV1)
+add_custom_command(
+    TARGET pki-ocsp-links POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../server/common/lib/resteasy-servlet-initializer.jar webapp/lib/resteasy-servlet-initializer.jar
 )
+endif()
 
 if(WITH_JAVA)
     install(

--- a/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/rest/v1/OCSPApplication.java
+++ b/base/ocsp/src/main/java/org/dogtagpki/server/ocsp/rest/v1/OCSPApplication.java
@@ -1,11 +1,13 @@
 package org.dogtagpki.server.ocsp.rest.v1;
 
+import com.netscape.cmscore.apps.CMSEngine;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
+import org.dogtagpki.server.ocsp.OCSPEngine;
 import org.dogtagpki.server.rest.v1.ACLInterceptor;
 import org.dogtagpki.server.rest.v1.AccountService;
 import org.dogtagpki.server.rest.v1.AuditService;
@@ -18,6 +20,7 @@ import org.dogtagpki.server.rest.v1.SecurityDomainService;
 import org.dogtagpki.server.rest.v1.SelfTestService;
 import org.dogtagpki.server.rest.v1.SessionContextInterceptor;
 import org.dogtagpki.server.rest.v1.UserService;
+import org.dogtagpki.server.rest.v1.ApiStatusHelper;
 
 @ApplicationPath("/v1")
 public class OCSPApplication extends Application {
@@ -28,6 +31,12 @@ public class OCSPApplication extends Application {
     private Set<Class<?>> classes = new LinkedHashSet<>();
 
     public OCSPApplication() {
+
+        CMSEngine engine = OCSPEngine.getInstance();
+        // Check v1 API status
+        if (ApiStatusHelper.checkApiStatus("OCSP", classes, logger, engine.getConfig())) {
+            return;
+        }
 
         // account
         classes.add(AccountService.class);

--- a/base/pom.xml
+++ b/base/pom.xml
@@ -32,4 +32,44 @@
         <module>console</module>
     </modules>
 
+    <profiles>
+        <!-- Profile to drop v1 API completely (no compilation) -->
+        <profile>
+            <id>api-v1-dropped</id>
+            <activation>
+                <property>
+                    <name>api.v1</name>
+                    <value>false</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <excludes combine.children="append">
+                                    <!-- Exclude all v1 REST API files -->
+                                    <exclude>**/rest/v1/**</exclude>
+                                    <!-- Exclude v1 base classes -->
+                                    <exclude>**/PKIService.java</exclude>
+                                    <exclude>**/SubsystemService.java</exclude>
+                                    <exclude>**/v1/PKIApplication.java</exclude>
+                                    <!-- Exclude JAX-RS resource interfaces (v1 only) -->
+                                    <exclude>**/*Resource.java</exclude>
+                                    <!-- Exclude PATCH annotation -->
+                                    <exclude>**/PATCH.java</exclude>
+                                    <!-- Exclude TPS v1 services -->
+                                    <exclude>**/TPSAccountService.java</exclude>
+                                    <exclude>**/config/ConfigService.java</exclude>
+                                </excludes>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/base/server-webapp/CMakeLists.txt
+++ b/base/server-webapp/CMakeLists.txt
@@ -60,8 +60,15 @@ add_custom_command(
     COMMAND ln -sf ../../../../../lib/slf4j-jdk14.jar webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server-webapp.jar webapp/lib/pki-server-webapp.jar
+)
+
+if(WITH_APIV1)
+add_custom_command(
+    TARGET pki-server-webapp-lib POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../server/common/lib/resteasy-servlet-initializer.jar webapp/lib/resteasy-servlet-initializer.jar
 )
+endif()
 
 install(
     DIRECTORY

--- a/base/server-webapp/src/main/java/org/dogtagpki/server/rest/v1/PKIApplication.java
+++ b/base/server-webapp/src/main/java/org/dogtagpki/server/rest/v1/PKIApplication.java
@@ -24,16 +24,20 @@ import java.util.Set;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-import org.dogtagpki.server.rest.v1.MessageFormatInterceptor;
-import org.dogtagpki.server.rest.v1.PKIExceptionMapper;
-
 @ApplicationPath("/v1")
 public class PKIApplication extends Application {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(PKIApplication.class);
 
     private Set<Object> singletons = new LinkedHashSet<>();
     private Set<Class<?>> classes = new LinkedHashSet<>();
 
     public PKIApplication() {
+
+        // Check v1 API status
+        if (ApiStatusHelper.checkApiStatus("PKI", classes, logger, null)) {
+            return;
+        }
 
         // services
         classes.add(AppService.class);

--- a/base/server/CMakeLists.txt
+++ b/base/server/CMakeLists.txt
@@ -176,10 +176,18 @@ add_custom_command(
     COMMAND ln -sf ../../../lib/pki-common.jar common/lib/pki-common.jar
     COMMAND ln -sf ../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tomcat.jar common/lib/pki-tomcat.jar
     COMMAND ln -sf ../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/${pkiTomcatJar} common/lib/${pkiTomcatJar}
+)
+
+if(WITH_APIV1)
+add_custom_command(
+    TARGET pki-server-common-lib POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory common/lib
+    COMMAND test ! -d ${CMAKE_SOURCE_DIR}/base/server/lib || cp ${CMAKE_SOURCE_DIR}/base/server/lib/* common/lib
     COMMAND ln -sf ../../../lib/resteasy-jackson2-provider.jar common/lib/resteasy-jackson2-provider.jar
     COMMAND ln -sf ../../../lib/resteasy-jaxrs.jar common/lib/resteasy-jaxrs.jar
     COMMAND ln -sf ${RESTEASY_SERVLET_INITIALIZER_LINK} common/lib/resteasy-servlet-initializer.jar
 )
+endif()
 
 add_custom_target(pki-server-man ALL
     COMMENT "Creating PKI server manuals")

--- a/base/server/pom.xml
+++ b/base/server/pom.xml
@@ -28,13 +28,27 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-servlet-initializer</artifactId>
-            <version>3.0.26.Final</version>
-        </dependency>
-
     </dependencies>
+
+    <profiles>
+        <!-- Include v1 API dependencies unless status is "dropped" -->
+        <profile>
+            <id>api-v1-deps</id>
+            <activation>
+                <property>
+                    <name>api.v1</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-servlet-initializer</artifactId>
+                    <version>3.0.26.Final</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v1/ApiDeprecationFilter.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v1/ApiDeprecationFilter.java
@@ -1,0 +1,48 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2025 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package org.dogtagpki.server.rest.v1;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS response filter that adds standard deprecation headers to all v1 API responses
+ * when the API status is set to "deprecated".
+ *
+ * Implements:
+ * - Deprecation header (IETF draft-dalal-deprecation-header)
+ * - Link header pointing to v2 API documentation (RFC 8288)
+ */
+@Provider
+public class ApiDeprecationFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        // Add Deprecation header as per IETF draft
+        responseContext.getHeaders().add("Deprecation", "true");
+
+        // Add Link header pointing to replacement API (RFC 8288)
+        responseContext.getHeaders().add("Link", "<https://github.com/dogtagpki/pki/wiki/REST-API-v2>; rel=\"alternate\"");
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v1/ApiDisabledResource.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v1/ApiDisabledResource.java
@@ -1,0 +1,90 @@
+package org.dogtagpki.server.rest.v1;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+
+import com.netscape.certsrv.base.PATCH;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Catch-all resource that returns a clean error message when v1 API is disabled.
+ * This is registered as the only resource when API status is disabled.
+ */
+@Path("/")
+public class ApiDisabledResource {
+
+    public static final Logger logger = LoggerFactory.getLogger(ApiDisabledResource.class);
+    
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private Response createErrorResponse() {
+        try {
+            ObjectNode error = mapper.createObjectNode();
+            error.put("error", "REST API v1 have been disabled");
+            error.put("message", "The REST API v1 have been disabled in this PKI instance. Please use the API v2 instead.");
+            error.put("documentation", "https://github.com/dogtagpki/pki/wiki/REST-API-v2");
+
+            return Response
+                .status(Response.Status.NOT_FOUND) // 404 Not Found
+                .entity(error.toString())
+                .type("application/json")
+                .header("Deprecation", "true")
+                .header("Link", "<https://github.com/dogtagpki/pki/wiki/REST-API-v2>; rel=\"alternate\"")
+                .build();
+        } catch (Exception e) {
+            logger.warn("Problem handling disabled v1 API: " + e.getMessage(), e);
+            return Response
+                .status(Response.Status.NOT_FOUND)
+                .entity("{\"error\":\"REST API v1 have been disabled\",\"message\":\"Please use API v2\"}")
+                .type("application/json")
+                .build();
+        }
+    }
+
+    @GET
+    @Path("{path:.*}")
+    public Response handleGet(@PathParam("path") String path) {
+        return createErrorResponse();
+    }
+
+    @POST
+    @Path("{path:.*}")
+    public Response handlePost(@PathParam("path") String path) {
+        return createErrorResponse();
+    }
+
+    @PUT
+    @Path("{path:.*}")
+    public Response handlePut(@PathParam("path") String path) {
+        return createErrorResponse();
+    }
+
+    @DELETE
+    @Path("{path:.*}")
+    public Response handleDelete(@PathParam("path") String path) {
+        return createErrorResponse();
+    }
+
+    @PATCH
+    @Path("{path:.*}")
+    public Response handlePatch(@PathParam("path") String path) {
+        return createErrorResponse();
+    }
+
+    @OPTIONS
+    @Path("{path:.*}")
+    public Response handleOptions(@PathParam("path") String path) {
+        return createErrorResponse();
+    }
+}

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v1/ApiStatusHelper.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v1/ApiStatusHelper.java
@@ -1,0 +1,118 @@
+// --- BEGIN COPYRIGHT BLOCK ---
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; version 2 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// (C) 2025 Red Hat, Inc.
+// All rights reserved.
+// --- END COPYRIGHT BLOCK ---
+
+package org.dogtagpki.server.rest.v1;
+
+import com.netscape.certsrv.base.EBaseException;
+import com.netscape.certsrv.base.EPropertyNotFound;
+import com.netscape.cmscore.apps.CMSEngine;
+import com.netscape.cmscore.apps.EngineConfig;
+import java.util.Set;
+
+/**
+ * Helper class for v1 REST API status checking.
+ * Centralizes the logic for reading build-time defaults and handling disabled/deprecated states.
+ */
+public class ApiStatusHelper {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(ApiStatusHelper.class);
+
+    /**
+     * Read the default v1 API status from build.properties.
+     * This value is set at build time via Maven resource filtering.
+     *
+     * @return The default status: "enabled", "deprecated" or "disabled"
+     */
+    public static String getDefaultApiStatus() {
+        return System.getProperty("api.v1.status", "deprecated");
+    }
+
+    /**
+     * Normalize and validate API status value.
+     *
+     * @param rawStatus The raw status value from system property or build default
+     * @return Normalized status value (enabled, deprecated, or disabled)
+     */
+    private static String normalizeStatus(String rawStatus) {
+        if (rawStatus == null) {
+            return "deprecated";
+        }
+
+        // Normalize: trim whitespace and convert to lowercase
+        String normalized = rawStatus.trim().toLowerCase();
+
+        // Validate: only allow known values
+        if ("enabled".equals(normalized) ||
+            "deprecated".equals(normalized) ||
+            "disabled".equals(normalized)) {
+            return normalized;
+        }
+
+        // Invalid value - log warning and fall back to default
+        logger.warn("Invalid api status value: '" + rawStatus + "'. " +
+                   "Valid values are: enabled, deprecated, disabled. " +
+                   "Falling back to 'deprecated'.");
+        return "deprecated";
+    }
+
+    /**
+     * Check API status and handle disabled/deprecated states.
+     *
+     * @param subsystemName The name of the subsystem (e.g., "CA", "KRA", "PKI")
+     * @param classes The set of classes to modify if disabled or deprecated
+     * @param subsystemLogger The logger to use for warnings
+     * @param cs The subsystem configuration
+     * @return true if the Application constructor should return early (disabled state), false otherwise
+     */
+    public static boolean checkApiStatus(String subsystemName, Set<Class<?>> classes, org.slf4j.Logger subsystemLogger, EngineConfig ec) {
+        // Use build-time default unless overridden by system property
+        String apiStatus = getDefaultApiStatus();
+        if (ec != null){
+            try {
+                apiStatus = ec.getString("api.v1.status");
+            } catch (EPropertyNotFound ep) {
+                subsystemLogger.debug(subsystemName + " api.v1.status not defined");
+            } catch (EBaseException eb ) {
+                subsystemLogger.warn(subsystemName + " impossible to access configuration values");
+            }
+        }
+        apiStatus = normalizeStatus(apiStatus);            
+        
+        if ("disabled".equals(apiStatus)) {
+            subsystemLogger.debug("======================================================================");
+            subsystemLogger.debug(subsystemName + " REST API V1 have been DISABLED.");
+            subsystemLogger.debug("All v1 endpoints will return HTTP 404 Not Found.");
+            subsystemLogger.debug("Please use v2 API instead.");
+            subsystemLogger.debug("======================================================================");
+            // Register only the disabled resource which returns clean error messages
+            classes.add(ApiDisabledResource.class);
+            return true; // return early
+        }
+
+        if ("deprecated".equals(apiStatus)) {
+            subsystemLogger.debug("======================================================================");
+            subsystemLogger.debug(subsystemName + " REST API V1 are DEPRECATED and will be removed in a future release.");
+            subsystemLogger.debug("Please migrate to v2 API as soon as possible.");
+            subsystemLogger.debug("======================================================================");
+            // Register deprecation filter to add standard headers
+            classes.add(ApiDeprecationFilter.class);
+        }
+
+        return false; // continue normally
+    }
+}

--- a/base/tks/CMakeLists.txt
+++ b/base/tks/CMakeLists.txt
@@ -70,8 +70,15 @@ add_custom_command(
     COMMAND ln -sf ../../../../../lib/slf4j-jdk14.jar webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tks.jar webapp/lib/pki-tks.jar
+)
+
+if(WITH_APIV1)
+add_custom_command(
+    TARGET pki-tks-links POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../server/common/lib/resteasy-servlet-initializer.jar webapp/lib/resteasy-servlet-initializer.jar
 )
+endif()
 
 if(WITH_JAVA)
     install(

--- a/base/tks/src/main/java/org/dogtagpki/server/tks/rest/v1/TKSApplication.java
+++ b/base/tks/src/main/java/org/dogtagpki/server/tks/rest/v1/TKSApplication.java
@@ -1,5 +1,6 @@
 package org.dogtagpki.server.tks.rest.v1;
 
+import com.netscape.cmscore.apps.CMSEngine;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -17,14 +18,24 @@ import org.dogtagpki.server.rest.v1.PKIExceptionMapper;
 import org.dogtagpki.server.rest.v1.SelfTestService;
 import org.dogtagpki.server.rest.v1.SessionContextInterceptor;
 import org.dogtagpki.server.rest.v1.UserService;
+import org.dogtagpki.server.tks.TKSEngine;
+import org.dogtagpki.server.rest.v1.ApiStatusHelper;
 
 @ApplicationPath("/v1")
 public class TKSApplication extends Application {
+
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TKSApplication.class);
 
     private Set<Object> singletons = new LinkedHashSet<>();
     private Set<Class<?>> classes = new LinkedHashSet<>();
 
     public TKSApplication() {
+
+        CMSEngine engine = TKSEngine.getInstance();
+        // Check v1 API status
+        if (ApiStatusHelper.checkApiStatus("TKS", classes, logger, engine.getConfig())) {
+            return;
+        }
 
         // account
         classes.add(AccountService.class);

--- a/base/tps/CMakeLists.txt
+++ b/base/tps/CMakeLists.txt
@@ -68,8 +68,15 @@ add_custom_command(
     COMMAND ln -sf ../../../../../lib/slf4j-jdk14.jar webapp/lib/slf4j-jdk14.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-server.jar webapp/lib/pki-server.jar
     COMMAND ln -sf ../../../../../../../..${JAVA_JAR_INSTALL_DIR}/pki/pki-tps.jar webapp/lib/pki-tps.jar
+)
+
+if(WITH_APIV1)
+add_custom_command(
+    TARGET pki-tps-links POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory webapp/lib
     COMMAND ln -sf ../../../../../server/common/lib/resteasy-servlet-initializer.jar webapp/lib/resteasy-servlet-initializer.jar
 )
+endif()
 
 add_custom_target(pki-tps-man ALL
     COMMENT "Creating TPS manuals")

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v1/TPSApplication.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v1/TPSApplication.java
@@ -17,6 +17,7 @@
 // --- END COPYRIGHT BLOCK ---
 package org.dogtagpki.server.tps.rest.v1;
 
+import com.netscape.cmscore.apps.CMSEngine;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -33,7 +34,9 @@ import org.dogtagpki.server.rest.v1.PKIExceptionMapper;
 import org.dogtagpki.server.rest.v1.SelfTestService;
 import org.dogtagpki.server.rest.v1.SessionContextInterceptor;
 import org.dogtagpki.server.rest.v1.UserService;
+import org.dogtagpki.server.rest.v1.ApiStatusHelper;
 import org.dogtagpki.server.tps.TPSAccountService;
+import org.dogtagpki.server.tps.TPSEngine;
 import org.dogtagpki.server.tps.config.ConfigService;
 
 /**
@@ -42,10 +45,18 @@ import org.dogtagpki.server.tps.config.ConfigService;
 @ApplicationPath("/v1")
 public class TPSApplication extends Application {
 
+    public static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(TPSApplication.class);
+
     private Set<Object> singletons = new LinkedHashSet<>();
     private Set<Class<?>> classes = new LinkedHashSet<>();
 
     public TPSApplication() {
+
+        CMSEngine engine = TPSEngine.getInstance();
+        // Check v1 API status
+        if (ApiStatusHelper.checkApiStatus("TPS", classes, logger, engine.getConfig())) {
+            return;
+        }
 
         // account
         classes.add(TPSAccountService.class);

--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,8 @@ WITH_JAVA=true
 WITH_CONSOLE=
 RUN_TESTS=true
 
+WITH_APIV1=true
+
 PKG_LIST="base, server, ca, kra, ocsp, tks, tps, acme, est, javadoc, theme, meta, tests, debug"
 ALL_PKGS=( $(echo "$PKG_LIST" | sed 's/ *, */ /g') )
 
@@ -97,6 +99,7 @@ usage() {
     echo "    --with-pkgs=<list>           Build packages specified in comma-separated list only."
     echo "    --without-pkgs=<list>        Build everything except packages specified in comma-separated list."
     echo "    --without-test               Do not run unit tests."
+    echo "    --without-apiv1              Do not build API V1 in any of the subpackages."
     echo " -v,--verbose                    Run in verbose mode."
     echo "    --debug                      Run in debug mode."
     echo "    --help                       Show help message."
@@ -417,6 +420,9 @@ while getopts v-: arg ; do
         without-test)
             RUN_TESTS=false
             ;;
+        without-apiv1)
+            WITH_APIV1=false
+            ;;
         verbose)
             VERBOSE=true
             ;;
@@ -435,7 +441,7 @@ while getopts v-: arg ; do
         prefix-dir* | include-dir* | lib-dir* | sysconf-dir* | share-dir* | \
         cmake* | c-flags* | java-home* | jni-dir* | \
         unit-dir* | python* | python-dir* | install-dir* | \
-        source-tag* | spec* | with-pkgs* | without-pkgs* | dist*)
+        source-tag* | spec* | with-pkgs* | without-pkgs* | dist* )
             echo "ERROR: Missing argument for --$OPTARG option" >&2
             exit 1
             ;;
@@ -778,6 +784,10 @@ if [ "$BUILD_TARGET" = "dist" ] ; then
         OPTIONS+=(-DRUN_TESTS:BOOL=OFF)
     fi
 
+    if [ "$WITH_APIV1" = false ] ; then
+        OPTIONS+=(-DWITH_APIV1:BOOL=OFF)
+    fi
+
     $CMAKE "${OPTIONS[@]}"
 
     OPTIONS=()
@@ -968,6 +978,10 @@ if [ "$RUN_TESTS" = false ] ; then
     OPTIONS+=(--without test)
 fi
 
+if [ "$WITH_APIV1" = false ] ; then
+    OPTIONS+=(--without apiv1)
+fi
+
 if [ "$DEBUG" = true ] ; then
     echo "rpmbuild -bs" "${OPTIONS[@]}" " $SPEC_FILE"
 fi
@@ -1002,6 +1016,10 @@ if [ "$VERBOSE" = true ] ; then
 fi
 
 OPTIONS+=(--define "_topdir ${WORK_DIR}")
+
+if [ "$WITH_APIV1" = false ] ; then
+    OPTIONS+=(--without apiv1)
+fi
 
 if [ "$DEBUG" = true ] ; then
     echo "rpmbuild --rebuild" "${OPTIONS[@]}" "$SRPM"

--- a/docs/changes/v11.10.0/Packaging-Changes.adoc
+++ b/docs/changes/v11.10.0/Packaging-Changes.adoc
@@ -1,0 +1,40 @@
+= Packaging Changes =
+
+== REST API v1 Build Control ==
+
+A new build-time flag `--without-apiv1` has been added to `build.sh`
+to control the inclusion of REST API v1 code. With this option it is
+possible to skip the API v1 code and all the related dependencies, like
+RESTEasy and Jackson JAX-RS providers.
+
+=== Build-time Control ===
+
+By default, v1 REST API are **included** in the build. To exclude them:
+
+----
+./build.sh --without-apiv1 rpm
+----
+
+When building with `--without-apiv1`:
+
+* v1 REST API source files are excluded from compilation
+* JAX-RS/RESTEasy dependencies are not included in BuildRequires or Requires
+* Jackson JAX-RS provider dependencies are excluded
+* Binary RPMs are approximately 2-3MB smaller
+* v1 packages are excluded from javadoc generation
+
+When building via rpmbuild directly:
+
+----
+rpmbuild --without apiv1 -ba pki.spec
+----
+
+=== Runtime Control ===
+
+When v1 REST API **are included** at build time (default), administrators
+can control the runtime behavior via system property. See Server Changes
+for details on runtime configuration.
+
+*Important:* Runtime control is only available when v1 code was included
+at build time. If built with `--without-apiv1`, v1 API cannot be enabled
+at runtime.

--- a/docs/changes/v11.10.0/Server-Changes.adoc
+++ b/docs/changes/v11.10.0/Server-Changes.adoc
@@ -55,3 +55,90 @@ pki-server ca-db-vlv-reindex
 *Note:* The reindex operation may take significant time on databases with
 many certificates. For replicated environments, VLV indexes are not
 replicated, so each replica must run these commands independently.
+
+== REST API v1 Deprecation Control ==
+
+*Note:* This runtime control is only available when PKI was built with
+v1 REST API included (default build). If built with `--without-apiv1`,
+v1 code is not present and cannot be enabled at runtime. See Packaging
+Changes for build-time control.
+
+A runtime control mechanism allows administrators to manage the REST API v1
+lifecycle with three runtime states:
+
+=== enabled ===
+
+The REST API v1 is fully functional with no restrictions, maintaining backward
+compatibility.
+
+=== deprecated (default) ===
+
+The REST API v1 remains fully functional but logs prominent warning messages
+on each subsystem startup:
+
+----
+======================================================================
+WARNING: v1 REST API is DEPRECATED and will be removed in a future release.
+Please migrate to v2 API as soon as possible.
+======================================================================
+----
+
+All API v1 responses include standard deprecation headers for programmatic
+detection by clients and API tooling:
+
+----
+Deprecation: true
+Link: <https://github.com/dogtagpki/pki/wiki/REST-API-v2>; rel="alternate"
+----
+
+Use this state during a migration period to notify administrators and users
+that v1 API support will be removed in the future.
+
+=== disabled ===
+
+The REST API v1 endpoints exist but are not functional. All requests
+to v1 endpoints return HTTP 404 with a clean JSON error response:
+
+----
+{
+  "error": "REST API v1 have been disabled",
+  "message": "The REST API v1 has been disabled in this PKI instance. Please use the API v2 instead.",
+  "documentation": "https://github.com/dogtagpki/pki/wiki/REST-API-v2"
+}
+----
+
+Standard deprecation and sunset headers are included per IETF and RFC standards:
+
+----
+Deprecation: true
+Link: <https://github.com/dogtagpki/pki/wiki/REST-API-v2>; rel="alternate"
+----
+
+This enforces migration to v2 while maintaining the ability to roll back
+if needed.
+
+=== Runtime Configuration ===
+
+The default runtime state is `deprecated`. Administrators can override this
+by setting the `api.v1.status` system property in `/etc/pki/<instance>/tomcat.conf`
+or `/etc/sysconfig/<instance>`:
+
+----
+JAVA_OPTS="-Dapi.v1.status=enabled"
+----
+
+*Valid runtime values:*
+
+* `enabled` - v1 API fully functional
+* `deprecated` - v1 functional with deprecation warnings and headers
+* `disabled` - v1 returns HTTP 410 Gone
+
+*Value normalization:* The runtime property is normalized (trimmed, lowercased)
+before use. Invalid values are logged as warnings and fall back to `deprecated`.
+
+Additionally, it is possible to configure the behaviour at subsystem
+level by setting the parameter `api.v1.status` in the subsystem
+configuration file `CS.cfg`.
+
+*Note:* Runtime override only works when v1 code is present in the build
+(i.e., not built with `--without-apiv1`).

--- a/pki.spec
+++ b/pki.spec
@@ -158,9 +158,17 @@ ExcludeArch: i686
 %bcond_without meta
 %bcond_without tests
 %bcond_without debug
+%bcond_without apiv1
 
 # Don't build console unless --with console is specified.
 %bcond_with console
+
+# Build API v1 if not excluded
+%if %{with apiv1}
+%global build_api_v1 1
+%else
+%global build_api_v1 0
+%endif
 
 %if ! %{with debug}
 %define debug_package %{nil}
@@ -267,9 +275,10 @@ BuildRequires:    mvn(com.fasterxml.jackson.core:jackson-annotations)
 BuildRequires:    mvn(com.fasterxml.jackson.core:jackson-core)
 BuildRequires:    mvn(com.fasterxml.jackson.core:jackson-databind)
 BuildRequires:    mvn(com.fasterxml.jackson.module:jackson-module-jaxb-annotations)
+
+%if %{build_api_v1}
 BuildRequires:    mvn(com.fasterxml.jackson.jaxrs:jackson-jaxrs-base)
 BuildRequires:    mvn(com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider)
-
 BuildRequires:    mvn(org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec)
 BuildRequires:    mvn(org.jboss.logging:jboss-logging)
 
@@ -277,6 +286,7 @@ BuildRequires:    mvn(org.jboss.resteasy:resteasy-jaxrs)
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-client)
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-jackson2-provider)
 BuildRequires:    mvn(org.jboss.resteasy:resteasy-servlet-initializer)
+%endif
 
 %endif
 
@@ -600,15 +610,17 @@ Requires:         mvn(jakarta.xml.bind:jakarta.xml.bind-api)
 Requires:         mvn(com.fasterxml.jackson.core:jackson-annotations)
 Requires:         mvn(com.fasterxml.jackson.core:jackson-core)
 Requires:         mvn(com.fasterxml.jackson.core:jackson-databind)
+
+%if %{build_api_v1}
 Requires:         mvn(com.fasterxml.jackson.jaxrs:jackson-jaxrs-base)
 Requires:         mvn(com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider)
-
 Requires:         mvn(org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec)
 Requires:         mvn(org.jboss.logging:jboss-logging)
 
 Requires:         mvn(org.jboss.resteasy:resteasy-jaxrs)
 Requires:         mvn(org.jboss.resteasy:resteasy-client)
 Requires:         mvn(org.jboss.resteasy:resteasy-jackson2-provider)
+%endif
 %else
 Provides:         bundled(apache-commons-cli)
 Provides:         bundled(apache-commons-codec)
@@ -631,15 +643,17 @@ Provides:         bundled(jackson-annotations)
 Provides:         bundled(jackson-core)
 Provides:         bundled(jackson-databind)
 Provides:         bundled(jackson-modules-base)
+
+%if %{build_api_v1}
 Provides:         bundled(jackson-jaxrs-providers)
 Provides:         bundled(jackson-jaxrs-json-provider)
-
 Provides:         bundled(jboss-jaxrs-2.0-api)
 Provides:         bundled(jboss-logging)
 
 Provides:         bundled(resteasy-jaxrs)
 Provides:         bundled(resteasy-client)
 Provides:         bundled(resteasy-jackson2-provider)
+%endif
 %endif
 
 Requires:         %{vendor_id}-jss >= 5.10.0
@@ -711,10 +725,12 @@ Requires:         python3-policycoreutils
 
 Requires:         selinux-policy-targeted >= 3.13.1-159
 
+%if %{build_api_v1}
 %if %{with runtime_deps}
 Requires:         mvn(org.jboss.resteasy:resteasy-servlet-initializer)
 %else
 Provides:         bundled(resteasy-servlet-initializer)
+%endif
 %endif
 
 %if 0%{?fedora} && 0%{?fedora} < %{fedora_tomcat9_cutoff} || 0%{?rhel} && 0%{?rhel} < %{rhel_tomcat9_cutoff}
@@ -1125,9 +1141,11 @@ then
     JAKARTA_ANNOTATION_API_VERSION=$(ls jakarta.annotation-api-*.jar | sed 's/^jakarta\.annotation-api-\(.*\)\.jar$/\1/')
     JAXB_API_VERSION=$(ls jakarta.xml.bind-api-*.jar | sed 's/^jakarta\.xml\.bind-api-\(.*\)\.jar$/\1/')
     JACKSON_VERSION=$(ls jackson-annotations-*.jar | sed 's/^jackson-annotations-\(.*\)\.jar$/\1/')
+%if %{build_api_v1}
     JAXRS_VERSION=$(ls jboss-jaxrs-api_2.0_spec-*.jar | sed 's/^jboss-jaxrs-api_2\.0_spec-\(.*\)\.jar$/\1/')
     JBOSS_LOGGING_VERSION=$(ls jboss-logging-*.jar| sed 's/^jboss-logging-\(.*\)\.jar$/\1/')
     RESTEASY_VERSION=$(ls resteasy-jaxrs-*.jar | sed 's/^resteasy-jaxrs-\(.*\)\.jar$/\1/')
+%endif
 
     popd
 
@@ -1149,9 +1167,11 @@ else
     JAKARTA_ANNOTATION_API_VERSION=$(rpm -q jakarta-annotations | sed -n 's/^jakarta-annotations-\([^-]*\)-.*$/\1/p')
     JAXB_API_VERSION=$(rpm -q jaxb-api | sed -n 's/^jaxb-api-\([^-]*\)-.*$/\1/p')
     JACKSON_VERSION=$(rpm -q jackson-annotations | sed -n 's/^jackson-annotations-\([^-]*\)-.*$/\1/p')
+%if %{build_api_v1}
     JAXRS_VERSION=$(rpm -q jboss-jaxrs-2.0-api | sed -n 's/^jboss-jaxrs-2.0-api-\([^-]*\)-.*$/\1.Final/p')
     JBOSS_LOGGING_VERSION=$(rpm -q jboss-logging | sed -n 's/^jboss-logging-\([^-]*\)-.*$/\1.Final/p')
     RESTEASY_VERSION=$(rpm -q pki-resteasy-core | sed -n 's/^pki-resteasy-core-\([^-]*\)-.*$/\1.Final/p')
+%endif
 
     # import common libraries from RPMs
     cp /usr/share/java/commons-cli.jar commons-cli-$COMMONS_CLI_VERSION.jar
@@ -1178,18 +1198,21 @@ else
     cp /usr/share/java/jackson-annotations.jar jackson-annotations-$JACKSON_VERSION.jar
     cp /usr/share/java/jackson-core.jar jackson-core-$JACKSON_VERSION.jar
     cp /usr/share/java/jackson-databind.jar jackson-databind-$JACKSON_VERSION.jar
+    cp /usr/share/java/jackson-modules/jackson-module-jaxb-annotations.jar jackson-module-jaxb-annotations-$JACKSON_VERSION.jar
+%if %{build_api_v1}
     cp /usr/share/java/jackson-jaxrs-providers/jackson-jaxrs-base.jar jackson-jaxrs-base-$JACKSON_VERSION.jar
     cp /usr/share/java/jackson-jaxrs-providers/jackson-jaxrs-json-provider.jar jackson-jaxrs-json-provider-$JACKSON_VERSION.jar
-    cp /usr/share/java/jackson-modules/jackson-module-jaxb-annotations.jar jackson-module-jaxb-annotations-$JACKSON_VERSION.jar
     cp /usr/share/java/jboss-jaxrs-2.0-api.jar jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
     cp /usr/share/java/jboss-logging/jboss-logging.jar jboss-logging-$JBOSS_LOGGING_VERSION.jar
     cp /usr/share/java/resteasy/resteasy-jaxrs.jar resteasy-jaxrs-$RESTEASY_VERSION.jar
     cp /usr/share/java/resteasy/resteasy-client.jar resteasy-client-$RESTEASY_VERSION.jar
     cp /usr/share/java/resteasy/resteasy-jackson2-provider.jar resteasy-jackson2-provider-$RESTEASY_VERSION.jar
+%endif
 
     popd
 fi
 
+%if %{build_api_v1}
 if [ ! -d base/server/lib ]
 then
     mkdir -p base/server/lib
@@ -1200,6 +1223,7 @@ then
 
     popd
 fi
+%endif
 %endif
 
 %if 0%{?fedora} >= %{fedora_tomcat9_cutoff} || 0%{?rhel} >= %{rhel_tomcat9_cutoff}
@@ -1253,19 +1277,6 @@ then
         jakarta.xml.bind-api-$JAXB_API_VERSION.jar \
         jakarta.xml.bind-api-$JAXB_API_VERSION.jar
 
-    # migrate javax.ws.rs to jakarta.ws.rs
-    # this also renames org.jboss.spec.javax.ws.r into org.jboss.spec.jakarta.ws.rs
-    jar tvf jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar \
-        | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
-        | sort \
-        | uniq
-
-    javax2jakarta \
-        -logLevel=FINE \
-        -profile=EE \
-        jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar \
-        jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
-
     # migrate com.fasterxml.jackson.annotation
     jar tvf jackson-annotations-$JACKSON_VERSION.jar \
         | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
@@ -1313,6 +1324,20 @@ then
         -profile=EE \
         jackson-module-jaxb-annotations-$JACKSON_VERSION.jar \
         jackson-module-jaxb-annotations-$JACKSON_VERSION.jar
+
+%if %{build_api_v1}
+    # migrate javax.ws.rs to jakarta.ws.rs
+    # this also renames org.jboss.spec.javax.ws.r into org.jboss.spec.jakarta.ws.rs
+    jar tvf jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar \
+        | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
+        | sort \
+        | uniq
+
+    javax2jakarta \
+        -logLevel=FINE \
+        -profile=EE \
+        jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar \
+        jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
 
     # migrate com.fasterxml.jackson.jaxrs
     jar tvf jackson-jaxrs-base-$JACKSON_VERSION.jar \
@@ -1373,10 +1398,12 @@ then
         -profile=EE \
         resteasy-jaxrs-$RESTEASY_VERSION.jar \
         resteasy-jaxrs-$RESTEASY_VERSION.jar
+%endif
 
     popd
 fi
 
+%if %{build_api_v1}
 if [ -d base/server/lib ]
 then
     # migrate server libraries
@@ -1396,8 +1423,10 @@ then
 
     popd
 fi
+%endif
 
 %if %{without runtime_deps}
+%if %{build_api_v1}
 if [ -d base/common/lib ]
 then
     # install migrated common libraries
@@ -1419,6 +1448,7 @@ fi
 %endif
 
 # fedora >= fedora_tomcat9_cutoff || rhel >= rhel_tomcat9_cutoff
+%endif
 %endif
 
 %if ! %{with base}
@@ -1558,7 +1588,7 @@ export JAVA_HOME=%{java_home}
 %if %{with maven}
 # build Java binaries and run unit tests with Maven
 
-%mvn_build %{!?with_test:-f} -j
+%mvn_build %{!?with_test:-f} -j -- -Dapi.v1=%{?with_apiv1:true}%{!?with_apiv1:false}
 
 # create links to Maven-built JAR files for CMake
 mkdir -p %{_vpath_builddir}/dist
@@ -1664,6 +1694,7 @@ pkgs=base\
     --with-pkgs=$pkgs \
     %{?with_console:--with-console} \
     --without-test \
+    %{!?with_apiv1:--without-apiv1} \
     dist
 
 ################################################################################
@@ -2037,6 +2068,28 @@ fi
 # CVE-2021-3551
 # Remove world access from existing installation logs
 find /var/log/pki -maxdepth 1 -type f -exec chmod o-rwx {} \;
+
+%if ! %{build_api_v1}
+# Remove v1 API JAX-RS/RESTEasy JARs from existing instances when v1 API is dropped
+if [ -d %{_datadir}/pki/server/common/lib ]; then
+    rm -f %{_datadir}/pki/server/common/lib/jackson-jaxrs-base-*.jar
+    rm -f %{_datadir}/pki/server/common/lib/jackson-jaxrs-json-provider-*.jar
+    rm -f %{_datadir}/pki/server/common/lib/jboss-jaxrs-api_2.0_spec-*.jar
+    rm -f %{_datadir}/pki/server/common/lib/jboss-logging-*.jar
+    rm -f %{_datadir}/pki/server/common/lib/resteasy-*.jar
+fi
+
+# Clean up instance-specific library directories
+for instance_dir in /var/lib/pki/*/common/lib; do
+    if [ -d "$instance_dir" ]; then
+        rm -f "$instance_dir"/jackson-jaxrs-base-*.jar
+        rm -f "$instance_dir"/jackson-jaxrs-json-provider-*.jar
+        rm -f "$instance_dir"/jboss-jaxrs-api_2.0_spec-*.jar
+        rm -f "$instance_dir"/jboss-logging-*.jar
+        rm -f "$instance_dir"/resteasy-*.jar
+    fi
+done
+%endif
 
 # Reload systemd daemons on upgrade only
 if [ "$1" == "2" ]


### PR DESCRIPTION
Introduce a new --v1-api-status flag to build.sh that provides granular
control over the v1 REST API lifecycle, enabling smooth migration from
v1 to v2 APIs.

Four status levels are supported:

1. enabled: v1 API fully functional, backward compatible
2. deprecated: v1 functional but logs migration warnings at startup
3. disabled: v1 compiled but returns HTTP 410 Gone at runtime
4. dropped (default): v1 code completely excluded from compilation

Build-time Integration:
- build.sh accepts --v1-api-status={enabled|deprecated|disabled|dropped}
- Default is disabled, enforcing migration to v2 by default
- Passes value to CMake via -DV1_API_STATUS and to RPM via --define
- Default value embedded in build.properties resource file
- Maven filtering injects value into JAR at compile time

Status: dropped (most significant changes):
- Maven v1-api-dropped profile excludes v1 source files via pluginManagement
- Maven v1-api-deps profile deactivated automatically via property activation
- JAX-RS/RESTEasy BuildRequires and Requires skipped in pki.spec
- JAX-RS/RESTEasy JARs not installed or transformed
- CMake javadoc excludes v1 REST packages only (not entire subsystems)
- RPM %post script removes old JAX-RS JARs from existing instances
- Binary RPMs ~2-3MB smaller without v1 code and dependencies

Status: disabled (clean error handling):
- V1ApiDisabledResource catch-all JAX-RS resource created
- Returns HTTP 410 Gone with JSON error instead of stack trace
- Separate methods for each HTTP verb per JAX-RS specification
- All v1 Application classes register only V1ApiDisabledResource
- Clean user experience: {"error": "v1 REST API has been disabled", ...}
- Standard headers: Deprecation, Sunset, Link (RFC 8594, IETF draft)

Status: deprecated (default, migration warning):
- All v1 Application classes log prominent warning on startup
- Full functionality maintained for transition period
- Warnings visible in systemd journal and tomcat logs
- V1ApiDeprecationFilter adds standard headers to all responses
- Headers: Deprecation: true, Link to v2 API documentation

Runtime Behavior:
- Build-time status becomes default runtime behavior
- Administrators can override via -Dv1.api.status system property
- All v1 Application classes (PKI, CA, KRA, OCSP, TKS, TPS) updated
- Default behavior read from build.properties at runtime
- V1ApiStatusHelper centralizes status checking logic
- Runtime values normalized (trimmed, lowercased)
- Invalid values logged and fall back to disabled
- Runtime "dropped" mapped to "disabled" (cannot drop code dynamically)

Implementation Details:
- base/pom.xml: v1-api-deps and v1-api-dropped Maven profiles
- base/common/pom.xml: Property-based profile activation (!dropped)
- base/server/pom.xml: Resource filtering for build.properties
- base/server/src/main/resources/build.properties: New configuration file
- base/server/src/main/java/.../V1ApiDisabledResource.java: New error handler
- base/server/src/main/java/.../V1ApiDeprecationFilter.java: Response filter
- base/server/src/main/java/.../V1ApiStatusHelper.java: Shared utility
- base/javadoc/CMakeLists.txt: Conditional package exclusion
- pki.spec: Conditional dependencies, validation, and %post JAR cleanup
- build.sh: Flag parsing and CMake/RPM integration

HTTP Headers (Standards Compliance):
- Deprecation header (IETF draft-dalal-deprecation-header)
- Sunset header (RFC 8594) for disabled state
- Link header (RFC 8288) pointing to v2 API documentation
- Programmatic detection by API clients and tooling

RPM Build Notes:
- When using build.sh: ./build.sh --v1-api-status=<status>
- When using rpmbuild: rpmbuild --define "v1_api_status <status>"
- SRPMs do not embed macro values - must re-pass --define on rebuild
- Spec file validates v1_api_status value - fail fast on invalid input

Migration Path:
1. Default behavior (deprecated) for gradual migration
2. Override with --v1-api-status=disabled to enforces v2 migration immediately
3. Override with --v1-api-status=enabled for backward compatibility
4. Deploy with --v1-api-status=dropped to remove v1 code permanently

Testing:
- Verified compilation with all four status values
- Verified runtime behavior (enabled, deprecated, disabled)
- Verified v1 code exclusion and JAR removal (dropped)
- Verified HTTP 410 Gone responses (disabled)
- Verified javadoc generation without v1 packages (dropped)
- Verified standard deprecation headers
- Verified input validation and normalization

Documentation: See docs/changes/v11.10.0/Packaging-Changes.adoc and Server-Changes.adoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build flag (--v1-api-status) and runtime v1.api.status to control v1 lifecycle; new runtime helper centralizes status handling and registers appropriate runtime behavior (disabled/deprecated).

* **Behavior Changes**
  * deprecated: startup deprecation banners and response deprecation headers.
  * disabled: v1 endpoints return HTTP 410 Gone with JSON error and alternate-link header.
  * dropped: v1 sources/deps omitted from builds when selected.

* **Documentation**
  * Added packaging, migration, and server behavior notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->