### PR TITLE
Fix pkispawn to support Kryoptic

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -921,7 +921,7 @@ class NSSDatabase:
             fullname
         ])
 
-        self.run(cmd, check=True)
+        self.run(cmd, check=True, runas=True)
 
     def create_noise(self, noise_file, size=2048, key_type='rsa'):
         # Under EC keys, key_size parameter is actually the name of a curve.
@@ -1941,7 +1941,7 @@ class NSSDatabase:
                 fullname
             ])
 
-            result = self.run(cmd, capture_output=True)
+            result = self.run(cmd, capture_output=True, runas=True)
 
         finally:
             shutil.rmtree(tmpdir)
@@ -2071,7 +2071,7 @@ class NSSDatabase:
                 fullname
             ])
 
-            result = self.run(cmd, capture_output=True)
+            result = self.run(cmd, capture_output=True, runas=True)
 
         finally:
             shutil.rmtree(tmpdir)

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -3508,6 +3508,15 @@ class PKIDeployer:
             logger.info('Storing %s cert request', tag)
             self.instance.store_cert_request(cert_id, system_cert)
 
+        if subsystem.type == 'CA' and tag == 'signing':
+            trust_attributes = 'CTu,Cu,Cu'
+
+        elif tag == 'audit_signing':
+            trust_attributes = 'u,u,Pu'
+
+        else:
+            trust_attributes = None
+
         if request.systemCert.type == 'remote':
 
             if cert_info:
@@ -3576,7 +3585,8 @@ class PKIDeployer:
                 nickname=request.systemCert.nickname,
                 cert_data=system_cert['data'],
                 cert_format='base64',
-                token=request.systemCert.token)
+                token=request.systemCert.token,
+                trust_attributes=trust_attributes)
 
             return
 
@@ -3613,7 +3623,8 @@ class PKIDeployer:
                 nickname=request.systemCert.nickname,
                 cert_data=system_cert['data'],
                 cert_format='base64',
-                token=request.systemCert.token)
+                token=request.systemCert.token,
+                trust_attributes=trust_attributes)
 
         if config.str2bool(self.mdict['pki_ds_setup']):
             # import cert into CA database
@@ -3665,34 +3676,6 @@ class PKIDeployer:
             request = self.create_cert_setup_request(subsystem, tag, system_cert)
 
             self.setup_system_cert(nssdb, subsystem, tag, system_cert, request)
-
-        if subsystem.type == 'CA':
-
-            logger.info('Setting up CA signing cert trust flags')
-
-            token = self.mdict['pki_ca_signing_token']
-            if pki.nssdb.internal_token(token):
-                full_name = self.mdict['pki_ca_signing_nickname']
-            else:
-                full_name = token + ':' + self.mdict['pki_ca_signing_nickname']
-
-            nssdb.modify_cert(
-                nickname=full_name,
-                trust_attributes='CTu,Cu,Cu')
-
-        if audit_signing_nickname:
-
-            logger.info('Setting up %s audit signing cert trust flags', subsystem.type)
-
-            token = self.mdict['pki_audit_signing_token']
-            if pki.nssdb.internal_token(token):
-                full_name = audit_signing_nickname
-            else:
-                full_name = token + ':' + audit_signing_nickname
-
-            nssdb.modify_cert(
-                nickname=full_name,
-                trust_attributes='u,u,Pu')
 
         # update NSS database owner
         self.instance.chown(self.instance.nssdb_dir)

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -428,47 +428,23 @@ class PKISubsystem(object):
 
         nickname = cert['nickname']
         token = pki.nssdb.normalize_token(cert['token'])
-
-        if token:
-            fullname = token + ':' + nickname
-        else:
-            fullname = nickname
-
         cert_usage = cert['certusage']
 
-        cmd = [
-            'pki',
-            '-d', self.instance.nssdb_dir,
-            '-f', self.instance.password_conf
-        ]
-
-        if token:
-            cmd.extend(['--token', token])
-
-        cmd.extend([
-            'nss-cert-verify',
-            '--cert-usage', cert_usage,
-            fullname
-        ])
-
-        logger.debug('Command: %s', ' '.join(cmd))
-
-        # don't use capture_output and text params to support Python 3.6
-        # https://stackoverflow.com/questions/53209127/subprocess-unexpected-keyword-argument-capture-output/53209196
-        # https://stackoverflow.com/questions/52663518/python-subprocess-popen-doesnt-take-text-argument
-
+        nssdb = self.instance.open_nssdb()
         try:
-            subprocess.run(
-                cmd,
-                stdout=subprocess.PIPE,
-                check=True,
-                universal_newlines=True)
+            nssdb.verify_cert(
+                nickname,
+                token=token,
+                cert_usage=cert_usage)
 
             logger.debug('%s certificate is valid', tag)
 
         except subprocess.CalledProcessError as e:
             logger.error('Unable to validate %s certificate: %s', tag, e.stdout)
             raise
+
+        finally:
+            nssdb.close()
 
     def export_system_cert(
             self,


### PR DESCRIPTION
The `PKIDeployer.setup_system_cert()` has been updated to set the trust flags while importing the CA signing and audit signing certs instead of modifying them later which does not work with Kryoptic.

The `NSSDatabase.modify_cert()`, `get_trust()`, and `get_cert()` have been modified to execute the operation as `pkiuser` such that it can access Kryoptic token in `pkiuser`'s home directory.

The `PKISubsystem.validate_system_cert()` has been modified to call `NSSDatabase.verify_cert()` which will work properly with Kryoptic.

https://github.com/dogtagpki/pki/wiki/Kryoptic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced security for certificate operations with elevated privilege handling
  * Refined certificate trust flag management during system setup
  * Optimized certificate validation process using internal mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->