### PR TITLE
Support for cert bundle in pki_ds_secure_connection_ca_pem_file

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -44,6 +44,9 @@ except ImportError:
 
 import pki
 
+PRIVATE_KEY_HEADER = '-----BEGIN PRIVATE KEY-----'
+PRIVATE_KEY_FOOTER = '-----END PRIVATE KEY-----'
+
 CSR_HEADER = '-----BEGIN CERTIFICATE REQUEST-----'
 CSR_FOOTER = '-----END CERTIFICATE REQUEST-----'
 
@@ -55,6 +58,22 @@ CERT_FOOTER = '-----END CERTIFICATE-----'
 
 PKCS7_HEADER = '-----BEGIN PKCS7-----'
 PKCS7_FOOTER = '-----END PKCS7-----'
+
+PEM_HEADERS = [
+    PRIVATE_KEY_HEADER,
+    CSR_HEADER,
+    LEGACY_CSR_HEADER,
+    CERT_HEADER,
+    PKCS7_HEADER
+]
+PEM_FOOTERS = [
+    PRIVATE_KEY_FOOTER,
+    CSR_FOOTER,
+    LEGACY_CSR_FOOTER,
+    CERT_FOOTER,
+    PKCS7_FOOTER
+]
+
 
 INTERNAL_TOKEN_NAME = 'internal'
 INTERNAL_TOKEN_FULL_NAME = 'Internal Key Storage Token'
@@ -136,25 +155,46 @@ def convert_pkcs7(pkcs7_data, input_format, output_format):
                         PKCS7_HEADER, PKCS7_FOOTER)
 
 
-def get_file_type(filename):
+def get_pem_type(data):
     '''
-    This method detects the content of a PEM file. It supports
-    CSR, certificate, PKCS #7 certificate chain.
+    Get PEM data type.
     '''
 
-    with open(filename, 'r') as f:
-        data = f.read()
+    if data.startswith(PRIVATE_KEY_HEADER):
+        return 'PRIVATE KEY'
 
     if data.startswith(CSR_HEADER) or data.startswith(LEGACY_CSR_HEADER):
-        return 'csr'
+        return 'CERTIFICATE REQUEST'
 
     if data.startswith(CERT_HEADER):
-        return 'cert'
+        return 'CERTIFICATE'
 
     if data.startswith(PKCS7_HEADER):
-        return 'pkcs7'
+        return 'PKCS7'
 
     return None
+
+
+def split_pem_data(data):
+    '''
+    Split PEM data which might contain multiple parts:
+    - private keys
+    - CSRs
+    - certs
+    - PKCS #7 cert chain
+    If the input contains Base64 data without headers/footers,
+    it will be returned as is.
+    '''
+    parts = []
+    part = ''
+    for line in data.splitlines():
+        part += line + '\n'
+        if line.strip() in PEM_FOOTERS:
+            parts.append(part)
+            part = ''
+    if part:
+        parts.append(part)
+    return parts
 
 
 def normalize_token(token):
@@ -1563,6 +1603,7 @@ class NSSDatabase(object):
         finally:
             shutil.rmtree(tmpdir)
 
+
     def import_cert_chain(
             self,
             nickname,
@@ -1572,16 +1613,36 @@ class NSSDatabase(object):
 
         logger.debug('NSSDatabase.import_cert_chain(%s) begins', nickname)
 
+        if not cert_chain_file:
+            return
+
+        with open(cert_chain_file, 'r', encoding='utf-8') as f:
+            data = f.read()
+        pem_parts = split_pem_data(data)
         tmpdir = tempfile.mkdtemp()
 
         try:
-            file_type = get_file_type(cert_chain_file)
+            if len(pem_parts) > 1:  # cert bundle
+                logger.debug('Importing CA cert bundle')
+                part = 1
+                for pem_part in pem_parts:
+                    part_file = os.path.join(tmpdir, f'part{part}.pem')
+                    part += 1
+                    with open(part_file, 'w') as f:
+                        f.write(pem_part)
+                    self.add_ca_cert(cert_file=part_file)
 
-            if file_type == 'cert':  # import single PEM cert
+                base64_data = convert_cert(data, 'pem', 'base64')
+                return (base64_data, [])
+
+            input_type = get_pem_type(pem_parts[0])
+            input_file = cert_chain_file
+
+            if input_type == 'CERTIFICATE':  # import single PEM cert
                 logger.debug('Importing a single cert')
                 self.add_cert(
                     nickname=nickname,
-                    cert_file=cert_chain_file,
+                    cert_file=input_file,
                     token=token,
                     trust_attributes=trust_attributes)
                 return (
@@ -1592,31 +1653,25 @@ class NSSDatabase(object):
                     [nickname]
                 )
 
-            elif file_type == 'pkcs7':  # import PKCS #7 cert chain
+            elif input_type == 'PKCS7':  # import PKCS #7 cert chain
                 logger.debug('Importing a PKCS #7 cert chain')
                 self.import_pkcs7(
-                    pkcs7_file=cert_chain_file,
+                    pkcs7_file=input_file,
                     nickname=nickname,
                     token=token,
                     trust_attributes=trust_attributes)
 
-                with open(cert_chain_file, 'r') as f:
-                    pkcs7_data = f.read()
-
-                base64_data = convert_pkcs7(pkcs7_data, 'pem', 'base64')
+                base64_data = convert_pkcs7(data, 'pem', 'base64')
 
                 return base64_data, [nickname]
 
             else:  # import PKCS #7 data without header/footer
                 logger.debug('Importing a PKCS #7 data without header/footer')
-                with open(cert_chain_file, 'r') as f:
-                    base64_data = f.read()
-
                 # TODO: fix ipaserver/install/cainstance.py in IPA
                 # to no longer remove PKCS #7 header/footer
 
                 # join base-64 data into a single line
-                base64_data = base64_data.replace('\r', '').replace('\n', '')
+                base64_data = data.replace('\r', '').replace('\n', '')
 
                 pkcs7_data = convert_pkcs7(base64_data, 'base64', 'pem')
 

--- a/base/server/python/pki/server/deployment/scriptlets/security_databases.py
+++ b/base/server/python/pki/server/deployment/scriptlets/security_databases.py
@@ -252,14 +252,22 @@ class PkiScriptlet(pkiscriptlet.AbstractBasePkiScriptlet):
                     password_file=deployer.mdict['pki_shared_pfile'])
                 if not rv:
                     # Import the directory server CA certificate
-                    rv = deployer.certutil.import_cert(
-                        deployer.mdict['pki_ds_secure_connection_ca_nickname'],
-                        deployer.mdict[
-                            'pki_ds_secure_connection_ca_trustargs'],
-                        deployer.mdict['pki_ds_secure_connection_ca_pem_file'],
-                        password_file=deployer.mdict['pki_shared_pfile'],
-                        path=deployer.mdict['pki_server_database_path'],
-                        token=deployer.mdict['pki_self_signed_token'])
+                    nssdb = pki.nssdb.NSSDatabase(
+                        directory=pki_server_database_path,
+                        password_file=deployer.mdict['pki_shared_pfile'])
+
+                    try:
+                        nssdb.import_cert_chain(
+                            nickname=deployer.mdict[
+                                'pki_ds_secure_connection_ca_nickname'],
+                            cert_chain_file=deployer.mdict[
+                                'pki_ds_secure_connection_ca_pem_file'],
+                            trust_attributes=deployer.mdict[
+                                'pki_ds_secure_connection_ca_trustargs'],
+                            token=deployer.mdict['pki_self_signed_token']
+                        )
+                    finally:
+                        nssdb.close()
 
         # Always delete the temporary 'pfile'
         deployer.file.delete(deployer.mdict['pki_shared_pfile'])


### PR DESCRIPTION
If DS is configured with a certificate from a CA different from the signing CA, IPA will create a bundle with both CA but certutil will add only the first and ignores the others.

The nssdb import has been converted from certutil command to internal PKI and the bundle is split in multiple certificates which are all imported.