### PR TITLE
Standalone build mechanism for PKI HSM compatibility tools (pki-hsm-c…

### DIFF
--- a/base/tools/CMakeLists.txt
+++ b/base/tools/CMakeLists.txt
@@ -152,3 +152,29 @@ install(
         GROUP_EXECUTE GROUP_READ
         WORLD_EXECUTE WORLD_READ
 )
+
+install(
+    FILES
+        src/main/shell/hsmCompatVerifyServ.bash
+    DESTINATION
+        ${BIN_INSTALL_DIR}
+    RENAME
+        hsmCompatVerifyServ
+    PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)
+
+install(
+    FILES
+        src/main/shell/hsmCompatVerifyClnt.bash
+    DESTINATION
+        ${BIN_INSTALL_DIR}
+    RENAME
+        hsmCompatVerifyClnt
+    PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE
+        GROUP_READ GROUP_EXECUTE
+        WORLD_READ WORLD_EXECUTE
+)

--- a/base/tools/build-hsm-compat-verify.sh
+++ b/base/tools/build-hsm-compat-verify.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Build script for standalone PKI HSM Compatibility Verification package
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_NAME="pki-hsm-compat-verify"
+PKG_VERSION="${PKG_VERSION:-$(awk '/^Version:/ {print $2; exit}' "${SCRIPT_DIR}/pki-hsm-compat-verify.spec")}"
+BUILD_DIR="${BUILD_DIR:-${HOME}/build/${PKG_NAME}}"
+
+echo "=== Building PKI HSM Compatibility Verification Package ==="
+echo "Package: ${PKG_NAME}-${PKG_VERSION}"
+echo "Build directory: ${BUILD_DIR}"
+echo
+
+# Create build directory structure
+echo "Creating build directories..."
+if [ -n "${BUILD_DIR}" ] && [ "${BUILD_DIR}" != "/" ]; then
+   rm -rf "${BUILD_DIR}"
+fi
+mkdir -p "${BUILD_DIR}/"{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
+# Create source tarball
+echo "Creating source tarball..."
+TARBALL_DIR="${BUILD_DIR}/SOURCES/${PKG_NAME}-${PKG_VERSION}"
+mkdir -p "${TARBALL_DIR}/src/main/java/com/netscape/cmstools"
+
+# Copy source files
+cp "${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/hsmCompatVerifyServ.java" \
+   "${TARBALL_DIR}/src/main/java/com/netscape/cmstools/"
+cp "${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/hsmCompatVerifyClnt.java" \
+   "${TARBALL_DIR}/src/main/java/com/netscape/cmstools/"
+cp "${SCRIPT_DIR}/src/main/java/com/netscape/cmstools/CryptoToolsUtil.java" \
+   "${TARBALL_DIR}/src/main/java/com/netscape/cmstools/"
+
+# Copy pom.xml
+cp "${SCRIPT_DIR}/hsm-compat-verify-pom.xml" "${TARBALL_DIR}/pom.xml"
+
+# Create tarball
+cd "${BUILD_DIR}/SOURCES"
+tar czf "${PKG_NAME}-${PKG_VERSION}.tar.gz" "${PKG_NAME}-${PKG_VERSION}"
+rm -rf "${PKG_NAME}-${PKG_VERSION}"
+
+# Copy spec file
+echo "Copying spec file..."
+cp "${SCRIPT_DIR}/pki-hsm-compat-verify.spec" "${BUILD_DIR}/SPECS/"
+
+# Build RPM
+echo "Building RPM..."
+cd "${BUILD_DIR}"
+rpmbuild --define "_topdir ${BUILD_DIR}" \
+         -ba SPECS/pki-hsm-compat-verify.spec
+
+echo
+echo "=== Build Complete ==="
+echo "RPMs: ${BUILD_DIR}/RPMS/"
+ls -lh "${BUILD_DIR}/RPMS/noarch/"
+echo
+echo "To install:"
+echo "  sudo rpm -ivh ${BUILD_DIR}/RPMS/noarch/${PKG_NAME}-${PKG_VERSION}-*.rpm"
+echo

--- a/base/tools/hsm-compat-verify-pom.xml
+++ b/base/tools/hsm-compat-verify-pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.dogtagpki.pki</groupId>
+    <artifactId>pki-hsm-compat-verify</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <name>PKI HSM Compatibility Verification</name>
+    <description>HSM/PKCS#11 compatibility verification tool for Dogtag PKI KRA</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <jss.jar.path>/usr/lib/java/jss.jar</jss.jar.path>
+    </properties>
+
+    <dependencies>
+        <!-- PKI CertSrv (replaces pki-common in 10.13) -->
+        <dependency>
+            <groupId>org.dogtagpki.pki</groupId>
+            <artifactId>pki-certsrv</artifactId>
+            <version>10.13.11</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/pki/pki-certsrv.jar</systemPath>
+        </dependency>
+
+        <!-- PKI CMSUtil (replaces pki-common in 10.13) -->
+        <dependency>
+            <groupId>org.dogtagpki.pki</groupId>
+            <artifactId>pki-cmsutil</artifactId>
+            <version>10.13.11</version>
+            <scope>system</scope>
+            <systemPath>/usr/share/java/pki/pki-cmsutil.jar</systemPath>
+        </dependency>
+
+        <!-- JSS -->
+        <dependency>
+            <groupId>org.dogtagpki.jss</groupId>
+            <artifactId>jss-base</artifactId>
+            <version>4.9.9</version>
+            <scope>system</scope>
+            <systemPath>${jss.jar.path}</systemPath>
+        </dependency>
+
+        <!-- Apache Commons CLI -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.4</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <includes>
+                        <include>com/netscape/cmstools/hsmCompatVerifyServ.java</include>
+                        <include>com/netscape/cmstools/hsmCompatVerifyClnt.java</include>
+                        <include>com/netscape/cmstools/CryptoToolsUtil.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Version>${project.version}</Implementation-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+        <finalName>pki-hsm-compat-verify</finalName>
+    </build>
+
+</project>

--- a/base/tools/pki-hsm-compat-verify.spec
+++ b/base/tools/pki-hsm-compat-verify.spec
@@ -1,0 +1,105 @@
+%global product_name PKI HSM Compatibility Verification
+
+Name:           pki-hsm-compat-verify
+Version:        1.0.0
+Release:        1%{?dist}
+Summary:        PKI HSM/PKCS#11 Compatibility Verification Tool
+License:        GPL-2.0-only
+URL:            https://www.dogtagpki.org
+
+Source0:        %{name}-%{version}.tar.gz
+
+BuildArch:      noarch
+
+BuildRequires:  java-1.8.0-openjdk-devel
+BuildRequires:  maven
+BuildRequires:  jss >= 4.9.0
+BuildRequires:  apache-commons-cli
+BuildRequires:  dogtag-pki-base-java >= 10.13.0
+
+# Runtime dependencies - use file paths instead of package names to avoid forcing upgrades
+Requires:       java-1.8.0-openjdk-headless
+#Requires:       jss >= 4.9.0
+#Requires:       apache-commons-cli
+#Requires:       dogtag-pki-base-java >= 10.13.0
+Requires:       /usr/lib/java/jss.jar
+Requires:       /usr/share/java/apache-commons-cli.jar
+Requires:       /usr/share/java/pki/pki-cmsutil.jar
+Requires:       /usr/share/java/pki/pki-certsrv.jar
+
+%description
+A standalone tool to test HSM/PKCS#11 compatibility for Dogtag PKI KRA
+key archival and recovery operations. This tool can be used to verify
+that an HSM supports the minimum cryptographic capabilities required
+for KRA without requiring a full PKI installation.
+
+The tool performs two-phase testing:
+- Setup phase: Creates PKI infrastructure (CA, transport, storage certs) on HSM
+- Test phase: Tests complete archival/recovery workflow
+
+%prep
+%setup -q
+
+%build
+mvn clean package -DskipTests -Djss.jar.path=/usr/lib/java/jss.jar
+
+%install
+# Install JAR
+install -d -m 755 %{buildroot}%{_javadir}/pki
+install -m 644 target/pki-hsm-compat-verify.jar %{buildroot}%{_javadir}/pki/
+
+# Install wrapper scripts
+install -d -m 755 %{buildroot}%{_bindir}
+
+# hsmCompatVerifyServ wrapper
+cat > %{buildroot}%{_bindir}/hsmCompatVerifyServ <<'EOF'
+#!/bin/sh
+# KRA HSM Compatibility Verification Tool - Server Side
+
+# load default, system-wide, and user-specific PKI configuration
+[ -f /usr/share/pki/scripts/config ] && . /usr/share/pki/scripts/config || exit 1
+
+JAVA="${JAVA_HOME:+${JAVA_HOME}/bin/}java"
+PKI_LIB_DIR="${PKI_LIB:-%{_javadir}}"
+JAVA_OPTIONS=""
+
+${JAVA} ${JAVA_OPTIONS} \
+  -cp "%{_javadir}/pki/pki-hsm-compat-verify.jar:${PKI_LIB_DIR}/*" \
+  -Dcom.redhat.fips=false \
+  ${PKI_LOGGING_CONFIG:+-Djava.util.logging.config.file=${PKI_LOGGING_CONFIG}} \
+  com.netscape.cmstools.hsmCompatVerifyServ "$@"
+
+exit $?
+EOF
+chmod 755 %{buildroot}%{_bindir}/hsmCompatVerifyServ
+
+# hsmCompatVerifyClnt wrapper
+cat > %{buildroot}%{_bindir}/hsmCompatVerifyClnt <<'EOF'
+#!/bin/sh
+# KRA HSM Compatibility Verification Tool - Client Side
+
+# load default, system-wide, and user-specific PKI configuration
+[ -f /usr/share/pki/scripts/config ] && . /usr/share/pki/scripts/config || exit 1
+
+JAVA="${JAVA_HOME:+${JAVA_HOME}/bin/}java"
+PKI_LIB_DIR="${PKI_LIB:-%{_javadir}}"
+JAVA_OPTIONS=""
+
+${JAVA} ${JAVA_OPTIONS} \
+  -cp "%{_javadir}/pki/pki-hsm-compat-verify.jar:${PKI_LIB_DIR}/*" \
+  -Dcom.redhat.fips=false \
+  ${PKI_LOGGING_CONFIG:+-Djava.util.logging.config.file=${PKI_LOGGING_CONFIG}} \
+  com.netscape.cmstools.hsmCompatVerifyClnt "$@"
+
+exit $?
+EOF
+chmod 755 %{buildroot}%{_bindir}/hsmCompatVerifyClnt
+
+%files
+%{_bindir}/hsmCompatVerifyServ
+%{_bindir}/hsmCompatVerifyClnt
+%{_javadir}/pki/pki-hsm-compat-verify.jar
+
+%changelog
+* Mon Apr 06 2026 Christina Fu <cfu@redhat.com> - 1.0.0-1
+- Initial standalone package for PKI HSM compatibility verification tool

--- a/base/tools/src/main/shell/hsmCompatVerifyClnt.bash
+++ b/base/tools/src/main/shell/hsmCompatVerifyClnt.bash
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# --- BEGIN COPYRIGHT BLOCK ---
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+# --- END COPYRIGHT BLOCK ---
+#
+
+# load default, system-wide, and user-specific PKI configuration and
+# set NSS_DEFAULT_DB_TYPE.
+. /usr/share/pki/scripts/config
+
+###############################################################################
+##  (1) Specify variables used by this script.                               ##
+###############################################################################
+
+COMMAND=hsmCompatVerifyClnt
+
+###############################################################################
+##  (2) Check for valid usage of this command wrapper.                       ##
+###############################################################################
+
+###############################################################################
+##  (3) Define helper functions.                                             ##
+###############################################################################
+
+###############################################################################
+##  (4) Set the LD_LIBRARY_PATH environment variable to determine the        ##
+##      search order this command wrapper uses to find shared libraries.     ##
+###############################################################################
+
+JAVA="${JAVA_HOME}/bin/java"
+JAVA_OPTIONS=""
+
+###############################################################################
+##  (5) Execute the java command specified by this java command wrapper      ##
+##      based upon the LD_LIBRARY_PATH and PKI_LIB environment variables.    ##
+###############################################################################
+
+${JAVA} ${JAVA_OPTIONS} \
+  -cp "${PKI_LIB}/*" \
+  -Dcom.redhat.fips=false \
+  -Dredhat.crypto-policies=false \
+  -Djava.util.logging.config.file=${PKI_LOGGING_CONFIG} \
+  com.netscape.cmstools.${COMMAND} "$@"
+
+exit $?

--- a/base/tools/src/main/shell/hsmCompatVerifyServ.bash
+++ b/base/tools/src/main/shell/hsmCompatVerifyServ.bash
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# --- BEGIN COPYRIGHT BLOCK ---
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright (C) 2026 Red Hat, Inc.
+# All rights reserved.
+# --- END COPYRIGHT BLOCK ---
+#
+
+# load default, system-wide, and user-specific PKI configuration and
+# set NSS_DEFAULT_DB_TYPE.
+. /usr/share/pki/scripts/config
+
+###############################################################################
+##  (1) Specify variables used by this script.                               ##
+###############################################################################
+
+COMMAND=hsmCompatVerifyServ
+
+###############################################################################
+##  (2) Check for valid usage of this command wrapper.                       ##
+###############################################################################
+
+###############################################################################
+##  (3) Define helper functions.                                             ##
+###############################################################################
+
+###############################################################################
+##  (4) Set the LD_LIBRARY_PATH environment variable to determine the        ##
+##      search order this command wrapper uses to find shared libraries.     ##
+###############################################################################
+
+JAVA="${JAVA_HOME}/bin/java"
+JAVA_OPTIONS=""
+
+###############################################################################
+##  (5) Execute the java command specified by this java command wrapper      ##
+##      based upon the LD_LIBRARY_PATH and PKI_LIB environment variables.    ##
+###############################################################################
+
+${JAVA} ${JAVA_OPTIONS} \
+  -cp "${PKI_LIB}/*" \
+  -Dcom.redhat.fips=false \
+  -Dredhat.crypto-policies=false \
+  -Djava.util.logging.config.file=${PKI_LOGGING_CONFIG} \
+  com.netscape.cmstools.${COMMAND} "$@"
+
+exit $?

--- a/pki.spec
+++ b/pki.spec
@@ -1169,6 +1169,8 @@ fi
 %{_bindir}/GenExtKeyUsage
 %{_bindir}/GenIssuerAltNameExt
 %{_bindir}/GenSubjectAltNameExt
+%{_bindir}/hsmCompatVerifyClnt
+%{_bindir}/hsmCompatVerifyServ
 %{_bindir}/HttpClient
 %{_bindir}/KRATool
 %{_bindir}/OCSPClient


### PR DESCRIPTION
…ompat-verify rpm)

Add standalone build infrastructure to create a standalone pki-hsm-compat-verify RPM package independent of main PKI build. This allows administrators to install or update the tool independently without overwriting existing PKI RPMs that may contain critical hotfixes.

- build-hsm-compat-verify.sh: Standalone build script
- pki-hsm-compat-verify.spec: RPM spec file
- hsm-compat-verify-pom.xml: Maven configuration

The package provides two command-line tools:
- hsmCompatVerifyServ: Server-side HSM verification
- hsmCompatVerifyClnt: Client-side key generation

Assisted-by: Claude
IDM-4768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new PKI HSM/PKCS#11 compatibility verification tool with two command-line utilities: `hsmCompatVerifyServ` and `hsmCompatVerifyClnt` for verifying hardware security module compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->