### PR TITLE
Fix password prompt in pki CLI

### DIFF
--- a/.github/workflows/pki-nss-ecc-test.yml
+++ b/.github/workflows/pki-nss-ecc-test.yml
@@ -1,4 +1,20 @@
 name: PKI NSS CLI with ECC
+# This test will perform the following operations:
+# - create NSS database
+# - create CA signing key
+# - create CA signing CSR with existing key
+# - issue self-signed CA signing cert
+# - import CA signing cert
+# - create SSL server CSR with new key
+# - issue SSL server cert
+# - import SSL server cert
+# - remove SSL server cert and key
+# - create audit signing CSR with new key
+# - issue audit signing cert
+# - import audit signing cert
+# - modify audit signing cert trust flags
+# - remove audit signing cert and key
+# - remove CA signing cert and key
 
 on: workflow_call
 
@@ -31,215 +47,491 @@ jobs:
               --hostname=pki.example.com \
               pki
 
-      - name: Create EC key
+      - name: Create NSS database
         run: |
-          docker exec pki pki nss-key-create \
+          # create password file
+          echo "Secret.123" > password.txt
+
+          # create password config
+          echo "internal=$(cat password.txt)" > password.conf
+
+          # create password-protected NSS database
+          docker exec pki pki \
+              -C $SHARED/password.txt \
+              nss-create
+
+      - name: Create CA signing key
+        run: |
+          cat password.txt | docker exec -i pki pki \
+              nss-key-create \
               --key-type EC \
               --key-id-file $SHARED/ca_signing.key-id
 
-          docker exec pki pki nss-key-show \
-              --key-id-file $SHARED/ca_signing.key-id
-
-      - name: Verify key type
+      - name: Check CA signing key
         run: |
-          echo ec > expected
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
+          # key type should be EC
+          echo "ec" > expected
           sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+.*$/\1/p' output > actual
-          diff actual expected
 
-          docker exec pki pki nss-key-find | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
+          diff expected actual
 
-      # https://github.com/dogtagpki/pki/wiki/Generating-CA-Signing-CSR-with-PKI-NSS
-      - name: Create CA signing cert request with existing EC key
+          # list all keys
+          docker exec pki pki \
+              -C $SHARED/password.txt \
+              nss-key-find \
+              | tee output
+
+          # key type should be EC
+          echo "EC" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with inline password
+          docker exec pki pki \
+              -c $(cat password.txt) \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be EC
+          echo "EC" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password file
+          docker exec pki pki \
+              -C $SHARED/password.txt \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be EC
+          echo "EC" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password config
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be EC
+          echo "EC" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password prompt
+          cat password.txt | docker exec -i pki pki \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be EC
+          echo "EC" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Create CA signing CSR with existing key
         run: |
-          docker exec pki pki nss-cert-request \
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-request \
               --key-id-file $SHARED/ca_signing.key-id \
               --subject "CN=Certificate Authority" \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               --csr ca_signing.csr
+
           docker exec pki openssl req -text -noout -in ca_signing.csr
 
-      # https://github.com/dogtagpki/pki/wiki/Issuing-CA-Signing-Certificate-with-PKI-NSS
       - name: Issue self-signed CA signing cert
         run: |
-          docker exec pki pki nss-cert-issue \
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-issue \
               --csr ca_signing.csr \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               --cert ca_signing.crt
+
           docker exec pki openssl x509 -text -noout -in ca_signing.crt
 
       - name: Import CA signing cert
         run: |
-          docker exec pki pki nss-cert-import \
+          # this command doesn't prompt for a password but it requires
+          # a password in order to set the trust flags properly so the
+          # password is provided explicitly
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-import \
               --cert ca_signing.crt \
-              --trust CT,C,C \
+              --trust "CT,C,C" \
               ca_signing
 
-      - name: Verify trust flags
+      - name: Check CA signing cert
         run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
           echo "CTu,Cu,Cu" > expected
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
           sed -n 's/^ca_signing\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
 
-          docker exec pki pki nss-cert-show ca_signing | tee output
+          diff expected actual
+
+          # check cert with nickname
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              ca_signing \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
+          echo "CTu,Cu,Cu" > expected
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
 
-          docker exec pki pki nss-cert-show --cert-file ca_signing.crt
+          diff expected actual
 
-      # https://github.com/dogtagpki/pki/wiki/Generating-SSL-Server-CSR-with-PKI-NSS
-      - name: Create SSL server cert request with new EC key
+          # check cert with cert file
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              --cert-file ca_signing.crt \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
+          echo "CTu,Cu,Cu" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Create SSL server CSR with new key
         run: |
-          docker exec pki pki nss-cert-request \
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-request \
               --key-type EC \
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --csr sslserver.csr
+
+          # CSR should be created
           docker exec pki openssl req -text -noout -in sslserver.csr
 
-      # https://github.com/dogtagpki/pki/wiki/Issuing-SSL-Server-Certificate-with-PKI-NSS
       - name: Issue SSL server cert
         run: |
-          docker exec pki pki nss-cert-issue \
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-issue \
               --issuer ca_signing \
               --csr sslserver.csr \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --cert sslserver.crt
+
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
       - name: Import SSL server cert
         run: |
-          docker exec pki pki nss-cert-import \
+          # this command doesn't prompt for a password
+          docker exec pki pki \
+              nss-cert-import \
               --cert sslserver.crt \
               sslserver
 
-          # get key ID
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-          sed -n \
-              's/^<.*>\s\+\S\+\s\+\(\S\+\)\s\+NSS Certificate DB:sslserver$/0x\1/p' \
-              output \
-              > sslserver.key-id
-
-      - name: Verify trust flags
+      - name: Check SSL server key
         run: |
-          echo "u,u,u" > expected
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
 
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki nss-cert-show sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-      - name: Verify key type
-        run: |
-          echo ec > expected
-
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
+          # key type should be EC
+          echo "ec" > expected
           sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:sslserver$/\1/p' output > actual
-          diff actual expected
 
-          docker exec pki pki nss-key-find --nickname sslserver | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
-
-      - name: Delete SSL server cert but keep the key
-        run: |
-          docker exec pki pki nss-cert-del sslserver
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-
-          # SSL server cert should not exist
-          echo "ca_signing CTu,Cu,Cu" > expected
-          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
           diff expected actual
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              --nickname sslserver | tee output
 
-          # SSL server key should exist but orphaned
-          echo "(orphan)" > expected
-          echo "NSS Certificate DB:ca_signing" >> expected
-          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+          # key type should be EC
+          echo "EC" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
           diff expected actual
 
-      - name: Create new SSL server cert request with existing EC key
+      - name: Check SSL server cert
         run: |
-          docker exec pki pki nss-cert-request \
-              --key-id-file $SHARED/sslserver.key-id \
-              --subject "CN=pki.example.com" \
-              --ext /usr/share/pki/server/certs/sslserver.conf \
-              --csr new_sslserver.csr
-          docker exec pki openssl req -text -noout -in new_sslserver.csr
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
 
-      - name: Issue new SSL server cert
-        run: |
-          docker exec pki pki nss-cert-issue \
-              --issuer ca_signing \
-              --csr new_sslserver.csr \
-              --ext /usr/share/pki/server/certs/sslserver.conf \
-              --cert new_sslserver.crt
-          docker exec pki openssl x509 -text -noout -in new_sslserver.crt
-
-      - name: Import new SSL server cert
-        run: |
-          docker exec pki pki nss-cert-import \
-              --cert new_sslserver.crt \
-              new_sslserver
-
-      - name: Verify trust flags
-        run: |
+          # trust flags should be u,u,u
           echo "u,u,u" > expected
+          sed -n 's/^sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
 
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^new_sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki nss-cert-show new_sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-      - name: Verify key type
-        run: |
-          echo ec > expected
-
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:new_sslserver$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki nss-key-find --nickname new_sslserver | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
-
-      - name: Verify key ID
-        run: |
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-          sed -n \
-              's/^<.*>\s\+\S\+\s\+\(\S\+\)\s\+NSS Certificate DB:new_sslserver$/0x\1/p' \
-              output \
-              > new_sslserver.key-id
-
-          diff sslserver.key-id new_sslserver.key-id
-
-      - name: Delete SSL server cert and key
-        run: |
-          docker exec pki pki nss-cert-del new_sslserver --remove-key
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-
-          # SSL server cert should not exist
-          echo "ca_signing CTu,Cu,Cu" > expected
-          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
           diff expected actual
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              sslserver \
+              | tee output
 
-          # SSL server key should not exist
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove SSL server cert and key
+        run: |
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-del \
+              sslserver \
+              --remove-key
+
+      - name: Check SSL server cert and key
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          echo "ca_signing CTu,Cu,Cu" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff expected actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should be removed
           echo "NSS Certificate DB:ca_signing" > expected
           sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
           diff expected actual
+
+          docker exec pki pki \
+              nss-cert-show \
+              sslserver \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: sslserver
+          EOF
+
+          diff expected stderr
+
+          docker exec pki pki \
+              nss-cert-export \
+              sslserver \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: sslserver
+          EOF
+
+          diff expected stderr
+
+      - name: Create audit signing CSR with new key
+        run: |
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-request \
+              --key-type EC \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --csr audit_signing.csr
+
+          docker exec pki openssl req -text -noout -in audit_signing.csr
+
+      - name: Issue audit signing cert
+        run: |
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert audit_signing.crt
+
+          docker exec pki openssl x509 -text -noout -in audit_signing.crt
+
+      - name: Import audit signing cert
+        run: |
+          # this command doesn't prompt for a password
+          docker exec pki pki \
+              nss-cert-import \
+              --cert audit_signing.crt \
+              audit_signing
+
+      - name: Check audit signing key
+        run: |
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key type should be EC
+          echo "ec" > expected
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:audit_signing$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              --nickname audit_signing | tee output
+
+          # key type should be EC
+          echo "EC" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Check audit signing cert
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/^audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              audit_signing | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Modify audit signing cert trust flags
+        run: |
+          # this command doesn't prompt for a password but it requires
+          # the password to the internal token in order to set the trust
+          # flags properly so the
+          # password is provided explicitly
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-mod \
+              --trust-flags ",,P" \
+              audit_signing
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be be u,u,Pu
+          echo "u,u,Pu" > expected
+          sed -n 's/^audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              audit_signing \
+              | tee output
+
+          # trust flags should be u,u,Pu
+          echo "u,u,Pu" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove audit signing cert and key
+        run: |
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-del \
+              audit_signing \
+              --remove-key
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          echo "ca_signing CTu,Cu,Cu" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff expected actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should be removed
+          echo "NSS Certificate DB:ca_signing" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff expected actual
+
+      - name: Remove CA signing cert
+        run: |
+          # this command doesn't prompt for a password
+          docker exec pki pki \
+              nss-cert-del \
+              ca_signing
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff /dev/null actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should no be removed
+          echo "(orphan)" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff expected actual
+
+      - name: Remove CA signing key
+        run: |
+          cat password.txt | docker exec -i pki pki \
+              nss-key-del \
+              --key-id-file $SHARED/ca_signing.key-id
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should be removed
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff /dev/null actual

--- a/.github/workflows/pki-nss-rsa-test.yml
+++ b/.github/workflows/pki-nss-rsa-test.yml
@@ -1,4 +1,20 @@
 name: PKI NSS CLI with RSA
+# This test will perform the following operations:
+# - create NSS database
+# - create CA signing key
+# - create CA signing CSR with existing key
+# - issue self-signed CA signing cert
+# - import CA signing cert
+# - create SSL server CSR with new key
+# - issue SSL server cert
+# - import SSL server cert
+# - remove SSL server cert and key
+# - create audit signing CSR with new key
+# - issue audit signing cert
+# - import audit signing cert
+# - modify audit signing cert trust flags
+# - remove audit signing cert and key
+# - remove CA signing cert and key
 
 on: workflow_call
 
@@ -57,79 +73,119 @@ jobs:
 
           # TODO: validate output
 
-      - name: Create RSA key
+      - name: Create CA signing key
         run: |
-          docker exec pki pki nss-key-create --key-type RSA | tee output
+          docker exec pki pki \
+              nss-key-create \
+              --key-id-file $SHARED/ca_signing.key-id
 
-          # get key ID
-          KEY_ID=$(sed -n 's/^\s*Key ID:\s*\(\S\+\)\s*$/\1/p' output)
-          echo $KEY_ID > ca_signing_key_id
-
-          docker exec pki pki nss-key-show --key-id $KEY_ID
-
-      - name: Verify key type
+      - name: Check CA signing key
         run: |
-          echo rsa > expected
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              | tee output
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
+          # key type should be RSA
+          echo "rsa" > expected
           sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+.*$/\1/p' output > actual
-          diff actual expected
 
-          docker exec pki pki nss-key-find | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
+          diff expected actual
 
-      # https://github.com/dogtagpki/pki/wiki/Generating-CA-Signing-CSR-with-PKI-NSS
-      - name: Create CA signing cert request with existing RSA key
+          # list all keys
+          docker exec pki pki \
+              nss-key-find \
+              | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Create CA signing CSR with existing key
         run: |
-          docker exec pki pki nss-cert-request \
-              --key-id $(cat ca_signing_key_id) \
+          docker exec pki pki \
+              nss-cert-request \
+              --key-id-file $SHARED/ca_signing.key-id \
               --subject "CN=Certificate Authority" \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               --csr ca_signing.csr
+
           docker exec pki openssl req -text -noout -in ca_signing.csr
 
-      # https://github.com/dogtagpki/pki/wiki/Issuing-CA-Signing-Certificate-with-PKI-NSS
       - name: Issue self-signed CA signing cert
         run: |
-          docker exec pki pki nss-cert-issue \
+          docker exec pki pki \
+              nss-cert-issue \
               --csr ca_signing.csr \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               --cert ca_signing.crt
+
           docker exec pki openssl x509 -text -noout -in ca_signing.crt
 
       - name: Import CA signing cert
         run: |
-          docker exec pki pki nss-cert-import \
+          docker exec pki pki \
+              nss-cert-import \
               --cert ca_signing.crt \
-              --trust CT,C,C \
+              --trust "CT,C,C" \
               ca_signing
 
-      - name: Verify trust flags
+      - name: Check CA signing cert
         run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
           echo "CTu,Cu,Cu" > expected
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
           sed -n 's/^ca_signing\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
 
-          docker exec pki pki nss-cert-show ca_signing | tee output
+          diff expected actual
+
+          docker exec pki pki \
+              nss-cert-show \
+              ca_signing \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
+          echo "CTu,Cu,Cu" > expected
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
 
-          docker exec pki pki nss-cert-show --cert-file ca_signing.crt
+          diff expected actual
 
-      # https://github.com/dogtagpki/pki/wiki/Generating-SSL-Server-CSR-with-PKI-NSS
-      - name: Create SSL server cert request with new RSA key
+          # check cert with cert file
+          docker exec pki pki \
+              nss-cert-show \
+              --cert-file ca_signing.crt \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
+          echo "CTu,Cu,Cu" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Create SSL server CSR with new key
         run: |
           docker exec pki pki nss-cert-request \
-              --key-type RSA \
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --csr sslserver.csr
+
           docker exec pki openssl req -text -noout -in sslserver.csr
 
-      # https://github.com/dogtagpki/pki/wiki/Issuing-SSL-Server-Certificate-with-PKI-NSS
       - name: Issue SSL server cert
         run: |
           docker exec pki pki nss-cert-issue \
@@ -137,6 +193,7 @@ jobs:
               --csr sslserver.csr \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --cert sslserver.crt
+
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
       - name: Import SSL server cert
@@ -145,161 +202,273 @@ jobs:
               --cert sslserver.crt \
               sslserver
 
-          # get key ID
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^<.*>\s\+\S\+\s\+\(\S\+\)\s\+NSS Certificate DB:sslserver$/\1/p' output > sslserver_key_id
-
-      - name: Verify trust flags
+      - name: Check SSL server key
         run: |
-          echo "u,u,u" > expected
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              | tee output
 
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki nss-cert-show sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-      - name: Verify key type
-        run: |
-          echo rsa > expected
-
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
+          # key type should be RSA
+          echo "rsa" > expected
           sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:sslserver$/\1/p' output > actual
-          diff actual expected
 
-          docker exec pki pki nss-key-find --nickname sslserver | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
-
-      - name: Delete SSL server cert but keep the key
-        run: |
-          docker exec pki pki nss-cert-del sslserver
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-
-          # SSL server cert should not exist
-          echo "ca_signing CTu,Cu,Cu" > expected
-          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
           diff expected actual
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
+          docker exec pki pki \
+              nss-key-find \
+              --nickname sslserver \
+              | tee output
 
-          # SSL server key should exist but orphaned
-          echo "(orphan)" > expected
-          echo "NSS Certificate DB:ca_signing" >> expected
-          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
           diff expected actual
 
-      - name: Create new SSL server cert request with existing RSA key
+      - name: Check SSL server cert
         run: |
-          docker exec pki pki nss-cert-request \
-              --key-id "0x`cat sslserver_key_id`" \
-              --subject "CN=pki.example.com" \
-              --ext /usr/share/pki/server/certs/sslserver.conf \
-              --csr new_sslserver.csr
-          docker exec pki openssl req -text -noout -in new_sslserver.csr
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              | tee output
 
-      - name: Issue new SSL server cert
-        run: |
-          docker exec pki pki nss-cert-issue \
-              --issuer ca_signing \
-              --csr new_sslserver.csr \
-              --ext /usr/share/pki/server/certs/sslserver.conf \
-              --cert new_sslserver.crt
-          docker exec pki openssl x509 -text -noout -in new_sslserver.crt
-
-      - name: Import new SSL server cert
-        run: |
-          docker exec pki pki nss-cert-import \
-              --cert new_sslserver.crt \
-              new_sslserver
-
-          # check short cert info
-          docker exec pki pki nss-cert-show new_sslserver
-
-          # check full cert info
-          docker exec pki pki nss-cert-export \
-              --format RAW \
-              new_sslserver
-
-          # check PEM cert
-          docker exec pki pki nss-cert-export \
-              --format PEM \
-              new_sslserver
-
-      - name: Verify trust flags
-        run: |
+          # trust flags should be u,u,u
           echo "u,u,u" > expected
+          sed -n 's/^sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
 
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^new_sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki nss-cert-show new_sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-      - name: Verify key type
-        run: |
-          echo rsa > expected
-
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:new_sslserver$/\1/p' output > actual
-          diff actual expected
-
-          # verify key ID
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^<.*>\s\+\S\+\s\+\(\S\+\)\s\+NSS Certificate DB:new_sslserver$/\1/p' output > new_sslserver_key_id
-          diff sslserver_key_id new_sslserver_key_id
-
-          docker exec pki pki nss-key-find --nickname new_sslserver | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
-
-      - name: Modify trust flags
-        run: |
-          docker exec pki pki nss-cert-mod \
-              --trust-flags ",,P" \
-              new_sslserver | tee output
-
-          echo "u,u,Pu" > expected
-
-          docker exec pki pki nss-cert-show new_sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
           diff expected actual
 
-      - name: Delete SSL server cert and key
+          docker exec pki pki \
+              nss-cert-show \
+              sslserver \
+              | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove SSL server cert and key
         run: |
-          docker exec pki pki nss-cert-del new_sslserver --remove-key
+          docker exec pki pki \
+              nss-cert-del \
+              sslserver \
+              --remove-key
 
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
+      - name: Check SSL server cert and key
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              | tee output
 
-          # SSL server cert should not exist
+          # cert should be removed
           echo "ca_signing CTu,Cu,Cu" > expected
           sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
           diff expected actual
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              | tee output
 
-          # SSL server key should not exist
+          # key should be removed
           echo "NSS Certificate DB:ca_signing" > expected
           sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
           diff expected actual
 
+          docker exec pki pki \
+              nss-cert-show \
+              sslserver \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
           cat > expected << EOF
-          ERROR: Certificate not found: new_sslserver
+          ERROR: Certificate not found: sslserver
           EOF
 
-          # pki nss-cert-show should fail
-          docker exec pki pki nss-cert-show new_sslserver \
+          diff expected stderr
+
+          docker exec pki pki \
+              nss-cert-export \
+              sslserver \
               > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: sslserver
+          EOF
 
           diff expected stderr
 
-          # pki nss-cert-export should fail
-          docker exec pki pki nss-cert-export new_sslserver \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+      - name: Create audit signing CSR with new key
+        run: |
+          docker exec pki pki \
+              nss-cert-request \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --csr audit_signing.csr
 
-          diff expected stderr
+          docker exec pki openssl req -text -noout -in audit_signing.csr
+
+      - name: Issue audit signing cert
+        run: |
+          docker exec pki pki \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert audit_signing.crt
+
+          docker exec pki openssl x509 -text -noout -in audit_signing.crt
+
+      - name: Import audit signing cert
+        run: |
+          docker exec pki pki \
+              nss-cert-import \
+              --cert audit_signing.crt \
+              audit_signing
+
+      - name: Check audit signing key
+        run: |
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # key type should be RSA
+          echo "rsa" > expected
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:audit_signing$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              nss-key-find \
+              --nickname audit_signing | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Check audit signing cert
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/^audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              nss-cert-show \
+              audit_signing | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Modify audit signing cert trust flags
+        run: |
+          docker exec pki pki \
+              nss-cert-mod \
+              --trust-flags ",,P" \
+              audit_signing \
+              | tee output
+
+      - name: Check audit signing cert trust flags
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # trust flags should be be u,u,Pu
+          echo "u,u,Pu" > expected
+          sed -n 's/^audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              nss-cert-show \
+              audit_signing \
+              | tee output
+
+          # trust flags should be u,u,Pu
+          echo "u,u,Pu" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove audit signing cert and key
+        run: |
+          docker exec pki pki \
+              nss-cert-del \
+              audit_signing \
+              --remove-key
+
+      - name: Check audit signing cert and key
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # cert should be removed
+          echo "ca_signing CTu,Cu,Cu" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff expected actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # key should be removed
+          echo "NSS Certificate DB:ca_signing" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff expected actual
+
+      - name: Remove CA signing cert
+        run: |
+          docker exec pki pki \
+              nss-cert-del \
+              ca_signing
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # cert should be removed
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff /dev/null actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # key should not be removed
+          echo "(orphan)" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff expected actual
+
+      - name: Remove CA signing key
+        run: |
+          docker exec pki pki \
+              nss-key-del \
+              --key-id-file $SHARED/ca_signing.key-id
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # key should be removed
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff /dev/null actual

--- a/.github/workflows/pki-nss-softhsm-test.yml
+++ b/.github/workflows/pki-nss-softhsm-test.yml
@@ -1,4 +1,19 @@
 name: PKI NSS CLI with SoftHSM
+# This test will perform the following operations:
+# - create NSS database
+# - create CA signing key
+# - create CA signing CSR with existing key
+# - issue self-signed CA signing cert
+# - import CA signing cert
+# - create SSL server CSR with new key
+# - issue SSL server cert
+# - import SSL server cert
+# - remove SSL server cert and key
+# - create audit signing CSR with new key
+# - issue audit signing cert
+# - import audit signing cert
+# - remove audit signing cert and key
+# - remove CA signing cert and key
 
 on: workflow_call
 
@@ -35,538 +50,705 @@ jobs:
         run: |
           docker exec pki dnf install -y softhsm opendnssec
 
+          # create password file for HSM
+          echo "Secret.HSM" > password.hsm
+
           docker exec pki softhsm2-util --init-token \
               --label HSM \
-              --so-pin Secret.HSM \
-              --pin Secret.HSM \
+              --so-pin $(cat password.hsm) \
+              --pin $(cat password.hsm) \
               --free
 
           docker exec pki softhsm2-util --show-slots
 
           docker exec pki modutil -nocertdb -list
 
-          # create password.conf
-          echo "internal=" > password.conf
-          echo "hardware-HSM=Secret.HSM" >> password.conf
-
-      - name: Create key in HSM
+      - name: Create NSS database
         run: |
+          # create password file for internal token
+          echo "Secret.123" > password.txt
+
+          # create password config
+          echo "internal=$(cat password.txt)" > password.conf
+          echo "hardware-HSM=$(cat password.hsm)" >> password.conf
+
+          # create password-protected NSS database
           docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-key-create | tee output
+              -C $SHARED/password.txt \
+              nss-create
 
-          # get key ID
-          KEY_ID=$(sed -n 's/^\s*Key ID:\s*\(\S\+\)\s*$/\1/p' output)
-          echo $KEY_ID > ca_signing_key_id
-
-          docker exec pki pki \
-              --token HSM \
-               -f $SHARED/password.conf \
-              nss-key-show \
-              --key-id $KEY_ID
-
-      - name: Verify key in HSM
+      - name: Create CA signing key
         run: |
-          docker exec pki pki \
+          cat password.hsm | docker exec -i pki pki \
               --token HSM \
-              -f $SHARED/password.conf \
-              nss-key-find | tee output
+              nss-key-create \
+              --key-id-file $SHARED/ca_signing.key-id
 
-          sed -n 's/\s*Key ID:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff ca_signing_key_id actual
-
-          # verify key not in internal token
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-key-find | tee actual
-          echo -n "" > expected
-          diff expected actual
-
-      # https://github.com/dogtagpki/pki/wiki/Generating-CA-Signing-CSR-with-PKI-NSS
-      - name: Generate CA signing cert request with existing key in HSM
+      - name: Check CA signing key in internal token
         run: |
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-cert-request \
-              --key-id $(cat ca_signing_key_id) \
-              --subject "CN=Certificate Authority" \
-              --ext /usr/share/pki/server/certs/ca_signing.conf \
-              --csr ca_signing.csr
-          docker exec pki openssl req -text -noout -in ca_signing.csr
-
-          docker exec pki certutil -K -d /root/.dogtag/nssdb || true
-
-          echo "Secret.HSM" > password.txt
           docker exec pki certutil -K \
               -d /root/.dogtag/nssdb \
               -f $SHARED/password.txt \
-              -h HSM
+              | tee output
 
-      # https://github.com/dogtagpki/pki/wiki/Issuing-CA-Signing-Certificate-with-PKI-NSS
+          # key should not exist
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+.*$/\1/p' output > actual
+
+          diff /dev/null actual
+
+          # list all keys
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              | tee output
+
+          # key should not exist
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff /dev/null actual
+
+      - name: Check CA signing key in HSM
+        run: |
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # key type should be RSA
+          echo "rsa" > expected
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+.*$/\1/p' output > actual
+
+          diff expected actual
+
+          # list all keys
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-key-find \
+              | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with inline password
+          docker exec pki pki \
+              -c $(cat password.hsm) \
+              --token HSM \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password file
+          docker exec pki pki \
+              -C $SHARED/password.hsm \
+              --token HSM \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password config
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password prompt
+          cat password.hsm | docker exec -i pki pki \
+              --token HSM \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Create CA signing CSR with existing key
+        run: |
+          cat password.hsm | docker exec -i pki pki \
+              --token HSM \
+              nss-cert-request \
+              --key-id-file $SHARED/ca_signing.key-id \
+              --subject "CN=Certificate Authority" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr ca_signing.csr
+
+          docker exec pki openssl req -text -noout -in ca_signing.csr
+
       - name: Issue self-signed CA signing cert
         run: |
-          docker exec pki pki \
+          cat password.hsm | docker exec -i pki pki \
               --token HSM \
-              -f $SHARED/password.conf \
               nss-cert-issue \
               --csr ca_signing.csr \
               --ext /usr/share/pki/server/certs/ca_signing.conf \
               --cert ca_signing.crt
+
           docker exec pki openssl x509 -text -noout -in ca_signing.crt
 
-      - name: Import CA signing cert into internal token and HSM
+      - name: Import CA signing cert
         run: |
+          # this command doesn't prompt for a password but it requires
+          # the passwords to the internal token and HSM in order to set
+          # the trust flags properly
           docker exec pki pki \
-              --token HSM \
               -f $SHARED/password.conf \
               nss-cert-import \
               --cert ca_signing.crt \
-              --trust CT,C,C \
-              ca_signing
+              --trust "CT,C,C" \
+              HSM:ca_signing
 
-      - name: Verify CA signing cert in internal token
+      - name: Check CA signing cert in internal token
         run: |
-          echo "CT,C,C" > expected
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^ca_signing\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki nss-cert-show ca_signing | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          # verify key not in internal token
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-key-find \
-              --nickname ca_signing | tee actual
-          echo -n "" > expected
-          diff actual expected
-
-          docker exec pki pki nss-cert-show --cert-file ca_signing.crt
-
-      - name: Verify CA signing cert in HSM
-        run: |
-          echo "CTu,Cu,Cu" > expected
-
           docker exec pki certutil -L \
               -d /root/.dogtag/nssdb \
-              -h HSM \
-              -f $SHARED/password.txt | tee output
-          sed -n 's/^HSM:ca_signing\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
+              -f $SHARED/password.txt \
+              | tee output
 
+          # trust flags should be CT,C,C
+          echo "CT,C,C" > expected
+          sed -n 's/^ca_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check cert with nickname
           docker exec pki pki \
-              --token HSM \
               -f $SHARED/password.conf \
               nss-cert-show \
-              HSM:ca_signing | tee output
+              ca_signing \
+              | tee output
+
+          # trust flags should be CT,C,C
+          echo "CT,C,C" > expected
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
 
-          echo rsa > expected
+          diff expected actual
 
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-key-find \
-              --nickname HSM:ca_signing | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-cert-show \
-              --cert-file ca_signing.crt
-
-      # https://github.com/dogtagpki/pki/wiki/Generating-SSL-Server-CSR-with-PKI-NSS
-      - name: Create SSL server cert request with key in HSM
+      - name: Check CA signing cert in HSM
         run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
+          echo "CTu,Cu,Cu" > expected
+          sed -n 's/^HSM:ca_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check cert with nickname
           docker exec pki pki \
-              --token HSM \
               -f $SHARED/password.conf \
+              --token HSM \
+              nss-cert-show \
+              HSM:ca_signing \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
+          echo "CTu,Cu,Cu" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Create SSL server CSR with new key
+        run: |
+          cat password.hsm | docker exec -i pki pki \
+              --token HSM \
               nss-cert-request \
               --subject "CN=pki.example.com" \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --csr sslserver.csr
+
+          # CSR should be created
           docker exec pki openssl req -text -noout -in sslserver.csr
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb || true
-
-          docker exec pki certutil -K \
-              -d /root/.dogtag/nssdb \
-              -f $SHARED/password.txt \
-              -h HSM
-
-      # https://github.com/dogtagpki/pki/wiki/Issuing-SSL-Server-Certificate-with-PKI-NSS
       - name: Issue SSL server cert
         run: |
-          docker exec pki pki \
+          cat password.hsm | docker exec -i pki pki \
               --token HSM \
-              -f $SHARED/password.conf \
               nss-cert-issue \
               --issuer HSM:ca_signing \
               --csr sslserver.csr \
               --ext /usr/share/pki/server/certs/sslserver.conf \
               --cert sslserver.crt
+
           docker exec pki openssl x509 -text -noout -in sslserver.crt
 
-      - name: Import SSL server cert into internal token and HSM
+      - name: Import SSL server cert
         run: |
+          # this command doesn't prompt for a password
           docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
               nss-cert-import \
               --cert sslserver.crt \
-              sslserver
-
-      - name: Verify SSL server cert in internal token
-        run: |
-          echo ",," > expected
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki nss-cert-show sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          # verify key not in internal token
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-key-find \
-              --nickname sslserver | tee actual
-          echo -n "" > expected
-          diff actual expected
-
-      - name: Verify SSL server cert in HSM
-        run: |
-          echo "u,u,u" > expected
-
-          docker exec pki certutil -L \
-              -d /root/.dogtag/nssdb \
-              -h HSM \
-              -f $SHARED/password.txt | tee output
-          sed -n 's/^HSM:sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-cert-show \
-              HSM:sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          echo rsa > expected
-
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-key-find \
-              --nickname HSM:sslserver | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
-
-          # get key ID
-          sed -n 's/\s*Key ID:\s*\(\S\+\)\s*$/\L\1/p' output > sslserver_key_id
-
-      - name: Delete SSL server cert but keep the key
-        run: |
-          # delete cert from internal token
-          docker exec pki pki \
-              nss-cert-del \
-              sslserver
-
-          # delete cert from HSM
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-cert-del \
               HSM:sslserver
 
-      - name: Verify SSL server cert in internal token
+      - name: Check SSL server key in internal token
         run: |
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              --nickname sslserver \
+              | tee output
 
-          # SSL server cert should not exist
-          echo "ca_signing CT,C,C" > expected
-          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+          # key should not exist
+          diff /dev/null output
+
+      - name: Check SSL server key in HSM
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-key-find \
+              --nickname HSM:sslserver | tee output
+
+          # key type should be RSA
+          echo rsa > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
+
           diff expected actual
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-
-          # SSL server key should not exist
-          echo -n > expected
-          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
-          diff expected actual
-
-      - name: Verify SSL server cert in HSM
+      - name: Check SSL server cert in internal token
         run: |
           docker exec pki certutil -L \
               -d /root/.dogtag/nssdb \
-              -h HSM \
-              -f $SHARED/password.txt | tee output
+              | tee output
 
-          # SSL server cert should not exist
-          echo "HSM:ca_signing CTu,Cu,Cu" > expected
-          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+          # trust flags should be ,,
+          echo ",," > expected
+          sed -n 's/^sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
+
           diff expected actual
 
-          docker exec pki certutil -K \
-              -d /root/.dogtag/nssdb \
-              -h HSM \
-              -f $SHARED/password.txt | tee output
-
-          # SSL server key should exist but orphaned
-          echo "(orphan)" > expected
-          echo "HSM:ca_signing" >> expected
-          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
-          diff expected actual
-
-      - name: Create new SSL server cert request with existing key in HSM
-        run: |
           docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-cert-request \
-              --key-id $(cat sslserver_key_id) \
-              --subject "CN=pki.example.com" \
-              --ext /usr/share/pki/server/certs/sslserver.conf \
-              --csr new_sslserver.csr
-          docker exec pki openssl req -text -noout -in new_sslserver.csr
+              nss-cert-show \
+              sslserver \
+              | tee output
 
-          docker exec pki certutil -K -d /root/.dogtag/nssdb || true
+          # trust flags should be ,,
+          echo ",," > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Check SSL server cert in HSM
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/^HSM:sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-cert-show \
+              HSM:sslserver | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove SSL server cert from internal token
+        run: |
+          cat password.txt | docker exec -i pki pki \
+              nss-cert-del \
+              sslserver \
+              --remove-key
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              | tee output
+
+          # cert should not exist
+          echo "ca_signing CT,C,C" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff expected actual
 
           docker exec pki certutil -K \
               -d /root/.dogtag/nssdb \
               -f $SHARED/password.txt \
-              -h HSM
+              | tee output
 
-      - name: Issue new  SSL server cert
-        run: |
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-cert-issue \
-              --issuer HSM:ca_signing \
-              --csr new_sslserver.csr \
-              --ext /usr/share/pki/server/certs/sslserver.conf \
-              --cert new_sslserver.crt
-          docker exec pki openssl x509 -text -noout -in new_sslserver.crt
-
-      - name: Import new SSL server cert into internal token and HSM
-        run: |
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-cert-import \
-              --cert new_sslserver.crt \
-              new_sslserver
-
-          # check short cert info
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-cert-show HSM:new_sslserver
-
-          # check full cert info
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-cert-export \
-              --format RAW \
-              HSM:new_sslserver
-
-          # check PEM cert
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-cert-export \
-              --format PEM \
-              HSM:new_sslserver
-
-      - name: Verify SSL server cert in internal token
-        run: |
-          # verify trust flags
-          echo ",," > expected
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^new_sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki nss-cert-show new_sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          # verify key not in internal token
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-key-find \
-              --nickname new_sslserver | tee actual
-          echo -n > expected
-          diff actual expected
-
-      - name: Verify SSL server cert in HSM
-        run: |
-          # verify trust flags
-          echo "u,u,u" > expected
-
-          docker exec pki certutil -L \
-              -d /root/.dogtag/nssdb \
-              -h HSM \
-              -f $SHARED/password.txt | tee output
-          sed -n 's/^HSM:new_sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-cert-show \
-              HSM:new_sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff actual expected
-
-          # verify key type
-          echo rsa > expected
-
-          docker exec pki pki \
-              --token HSM \
-              -f $SHARED/password.conf \
-              nss-key-find \
-              --nickname HSM:new_sslserver | tee output
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\L\1/p' output > actual
-          diff actual expected
-
-          # get key ID
-          sed -n 's/\s*Key ID:\s*\(\S\+\)\s*$/\L\1/p' output > new_sslserver_key_id
-          diff sslserver_key_id new_sslserver_key_id
-
-      - name: Modify trust flags
-        run: |
-          docker exec pki pki nss-cert-mod \
-              --trust-flags ",,P" \
-              new_sslserver
-
-          # trust flags should be modified in internal token
-          echo ",,P" > expected
-
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-          sed -n 's/^new_sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff expected actual
-
-          docker exec pki pki nss-cert-show new_sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff expected actual
-
-          # trust flags should be modified in HSM
-          echo "u,u,Pu" > expected
-
-          docker exec pki certutil -L \
-              -d /root/.dogtag/nssdb \
-              -h HSM \
-              -f $SHARED/password.txt | tee output
-          sed -n 's/^HSM:new_sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff expected actual
-
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-cert-show \
-              HSM:new_sslserver | tee output
-          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
-          diff expected actual
-
-      - name: Delete SSL server cert and key from internal token and HSM
-        run: |
-          # delete cert from internal token
-          docker exec pki pki \
-              nss-cert-del \
-              new_sslserver \
-              --remove-key
-
-          # delete cert from HSM
-          docker exec pki pki \
-              -f $SHARED/password.conf \
-              nss-cert-del \
-              HSM:new_sslserver \
-              --remove-key
-
-      - name: Verify SSL server cert in internal token
-        run: |
-          docker exec pki certutil -L -d /root/.dogtag/nssdb | tee output
-
-          # SSL server cert should not exist
-          echo "ca_signing CT,C,C" > expected
-          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
-          diff expected actual
-
-          docker exec pki certutil -K -d /root/.dogtag/nssdb | tee output
-
-          # SSL server key should not exist
-          echo -n > expected
+          # key should not exist
           sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
-          diff expected actual
 
+          diff /dev/null actual
+
+          docker exec pki pki \
+              nss-cert-show \
+              sslserver \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should not exist
           cat > expected << EOF
-          ERROR: Certificate not found: new_sslserver
+          ERROR: Certificate not found: sslserver
           EOF
 
-          # pki nss-cert-show should fail
-          docker exec pki pki nss-cert-show new_sslserver \
+          diff expected stderr
+
+          docker exec pki pki \
+              nss-cert-export \
+              sslserver \
               > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should not exist
+          cat > expected << EOF
+          ERROR: Certificate not found: sslserver
+          EOF
 
           diff expected stderr
 
-          # pki nss-cert-export should fail
-          docker exec pki pki nss-cert-export new_sslserver \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
-
-          diff expected stderr
-
-      - name: Verify SSL server cert in HSM
+      - name: Remove SSL server cert and key from HSM
         run: |
+          cat password.hsm | docker exec -i pki pki \
+              nss-cert-del \
+              HSM:sslserver \
+              --remove-key
+
           docker exec pki certutil -L \
               -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
               -h HSM \
-              -f $SHARED/password.txt | tee output
+              | tee output
 
-          # SSL server cert should not exist
+          # cert should be removed
           echo "HSM:ca_signing CTu,Cu,Cu" > expected
           sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
           diff expected actual
 
           docker exec pki certutil -K \
               -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
               -h HSM \
-              -f $SHARED/password.txt | tee output
+              | tee output
 
-          # SSL server key should not exist
+          # key should be removed
           echo "HSM:ca_signing" > expected
           sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
           diff expected actual
 
-          cat > expected << EOF
-          ERROR: Certificate not found: HSM:new_sslserver
-          EOF
-
-          # pki nss-cert-show should fail
           docker exec pki pki \
               -f $SHARED/password.conf \
               nss-cert-show \
-              HSM:new_sslserver \
+              HSM:sslserver \
               > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: HSM:sslserver
+          EOF
 
           diff expected stderr
 
-          # pki nss-cert-export should fail
           docker exec pki pki \
               -f $SHARED/password.conf \
               nss-cert-export \
-              HSM:new_sslserver \
+              HSM:sslserver \
               > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: HSM:sslserver
+          EOF
 
           diff expected stderr
 
+      - name: Create audit signing CSR with new key
+        run: |
+          cat password.hsm | docker exec -i pki pki \
+              --token HSM \
+              nss-cert-request \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --csr audit_signing.csr
+
+          docker exec pki openssl req -text -noout -in audit_signing.csr
+
+      - name: Issue audit signing cert
+        run: |
+          cat password.hsm | docker exec -i pki pki \
+              --token HSM \
+              nss-cert-issue \
+              --issuer HSM:ca_signing \
+              --csr audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert audit_signing.crt
+
+          docker exec pki openssl x509 -text -noout -in audit_signing.crt
+
+      - name: Import audit signing cert
+        run: |
+          # this command doesn't prompt for a password
+          docker exec pki pki \
+              nss-cert-import \
+              --cert audit_signing.crt \
+              HSM:audit_signing
+
+      - name: Check audit signing key
+        run: |
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # key type should be RSA
+          echo "rsa" > expected
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+HSM:audit_signing$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              --nickname HSM:audit_signing | tee output
+
+          # key type should be RSA
+          echo "RSA" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Check audit signing cert
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/^HSM:audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              HSM:audit_signing | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Modify audit signing cert trust flags
+        run: |
+          # this command doesn't prompt for a password but it requires
+          # the passwords to the internal token and HSM in order to set
+          # the trust flags properly
+          docker exec -i pki pki \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-cert-mod \
+              --trust-flags ",,P" \
+              HSM:audit_signing
+
+      - name: Check audit signing cert trust flags in internal token
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be be ,,P
+          echo ",,P" > expected
+          sed -n 's/^audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              audit_signing \
+              | tee output
+
+          # trust flags should be ,,P
+          echo ",,P" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Check audit signing cert trust flags in HSM
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # trust flags should be u,u,Pu
+          echo "u,u,Pu" > expected
+          sed -n 's/^HSM:audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              HSM:audit_signing \
+              | tee output
+
+          # trust flags should be u,u,Pu
+          echo "u,u,Pu" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove audit signing cert from internal token
+        run: |
+          # this command doesn't prompt for a password
+          docker exec pki pki \
+              nss-cert-del \
+              audit_signing
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          echo "ca_signing CT,C,C" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff expected actual
+
+      - name: Remove audit signing cert and key from HSM
+        run: |
+          cat password.hsm | docker exec -i pki pki \
+              --token HSM \
+              nss-cert-del \
+              HSM:audit_signing \
+              --remove-key
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # cert should be removed
+          echo "HSM:ca_signing CTu,Cu,Cu" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff expected actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # key should be removed
+          echo "HSM:ca_signing" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff expected actual
+
+      - name: Remove CA signing cert from internal token
+        run: |
+          # this command doesn't prompt for a password
+          docker exec pki pki \
+              nss-cert-del \
+              ca_signing
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff /dev/null actual
+
+      - name: Remove CA signing cert from HSM
+        run: |
+          cat password.hsm | docker exec -i pki pki \
+              --token HSM \
+              nss-cert-del \
+              HSM:ca_signing
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # cert should be removed
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff /dev/null actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # key should not be removed
+          echo "(orphan)" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff expected actual
+
+      - name: Remove CA signing key
+        run: |
+          cat password.hsm | docker exec -i pki pki \
+              --token HSM \
+              nss-key-del \
+              --key-id-file $SHARED/ca_signing.key-id
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.hsm \
+              -h HSM \
+              | tee output
+
+          # key should be removed
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff /dev/null actual
+
       - name: Remove SoftHSM token
-        run: docker exec pki softhsm2-util --delete-token --token HSM
+        run: |
+          docker exec pki softhsm2-util --delete-token --token HSM

--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -87,6 +87,7 @@ public class MainCLI extends CLI {
 
     public ClientConfig config = new ClientConfig();
 
+    String nssPasswordConfig;
     NSSDatabase nssdb;
     String apiVersion;
 
@@ -426,7 +427,7 @@ public class MainCLI extends CLI {
         String nssDatabase = cmd.getOptionValue("d");
         String nssPassword = cmd.getOptionValue("c");
         String nssPasswordFile = cmd.getOptionValue("C");
-        String nssPasswordConfig = cmd.getOptionValue("f");
+        nssPasswordConfig = cmd.getOptionValue("f");
 
         String tokenName = cmd.getOptionValue("token");
         String certNickname = cmd.getOptionValue("n");
@@ -576,6 +577,7 @@ public class MainCLI extends CLI {
         }
 
         logger.debug("Initializing NSS");
+        // by default CryptoManager will use ConsolePasswordCallback
         CryptoManager.initialize(nssdb.getPath().toString());
 
         CryptoManager manager;
@@ -587,13 +589,14 @@ public class MainCLI extends CLI {
             throw new Exception("NSS has not been initialized", e);
         }
 
-        // If password is specified, use password to access security token
         if (config.getNSSPassword() != null) {
+            // if token password is specified, use it to log in to token
+            // keep ConsolePasswordCallback in case NSS needs additional passwords
 
             String tokenName = config.getTokenName();
             tokenName = tokenName == null ? CryptoUtil.INTERNAL_TOKEN_NAME : tokenName;
 
-            logger.debug("Logging into " + tokenName + " token");
+            logger.debug("Logging in to " + tokenName + " token");
 
             CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
             Password password = new Password(config.getNSSPassword().toCharArray());
@@ -609,16 +612,17 @@ public class MainCLI extends CLI {
                 password.clear();
             }
 
-        } else {
+        } else if (nssPasswordConfig != null) {
+            // if password config is specified, use it to log in to all specified tokens
 
             Map<String, String> passwords = config.getNSSPasswords();
-
             for (String tokenName : passwords.keySet()) {
 
-                logger.debug("Logging into " + tokenName + " token");
+                logger.debug("Logging in to " + tokenName + " token");
 
                 CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
                 Password password = new Password(passwords.get(tokenName).toCharArray());
+
                 try {
                     token.login(password);
 
@@ -630,14 +634,23 @@ public class MainCLI extends CLI {
                     password.clear();
                 }
             }
+
+            // disable ConsolePasswordCallback due to issue with OpenDNSSEC:
+            // https://github.com/dogtagpki/pki/issues/5045
             manager.setPasswordCallback(new NullPasswordCallback());
+
+            // ignore unspecified tokens
             Enumeration<CryptoToken> externalTokens = CryptoUtil.getExternalTokens();
-            while (externalTokens!=null && externalTokens.hasMoreElements()) {
+            while (externalTokens != null && externalTokens.hasMoreElements()) {
                 CryptoToken extToken = externalTokens.nextElement();
                 if (!extToken.isLoggedIn()) {
                     logger.info("Password for token '{}' has not been provided, it will be skipped.", extToken.getName());
                 }
             }
+
+        } else {
+            // no passwords specified
+            // keep ConsolePasswordCallback in case NSS needs additional passwords
         }
 
         String tokenName = config.getTokenName();


### PR DESCRIPTION
The `pki` CLI has been modified to disable the password callback only if the password config is specified (e.g. during installation) to prevent OpenDNSSEC from triggering a password prompt but still allow password prompts in other cases.

The tests for `pki` CLI with RSA, ECC, and SoftHSM has been updated to create CA signing cert, SSL server cert, and audit signing cert to validate the password prompts.

https://github.com/edewata/pki/blob/DOGTAG-4274/docs/user/tools/PKI-NSS-Key-CLI.adoc
https://redhat.atlassian.net/browse/DOGTAG-4274



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for password configuration files and multi-token authenticated logins in the CLI.

* **Tests**
  * Expanded PKI NSS CLI test coverage (ECC, RSA, SoftHSM) with explicit password handling, a new audit-signing lifecycle, stronger cert/key removal semantics, and enhanced verification of key/certificate state and trust flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->