### PR TITLE
Fixes to make Dogtag PKI working with post-quantum TLS 1.3 connections

### DIFF
--- a/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
+++ b/base/ca/src/main/java/com/netscape/cmscore/dbs/CertificateRepository.java
@@ -881,14 +881,12 @@ public class CertificateRepository extends Repository {
      */
     public CertRecord readCertificateRecord(BigInteger serialNo)
             throws EBaseException {
-        CertRecord rec = null;
 
         try (DBSSession s = dbSubsystem.createSession()) {
             String name = "cn=" + serialNo + "," + mBaseDN;
 
-            rec = (CertRecord) s.read(name);
+            return (CertRecord) s.read(name);
         }
-        return rec;
     }
 
     public boolean checkCertificateRecord(BigInteger serialNo)

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -223,6 +223,7 @@ pki_ajp_host_ipv6=localhost6
 
 pki_ajp_port=8009
 pki_ajp_secret=%(pki_random_ajp_secret)s
+pki_ajp_packet_size=65536
 pki_server_pkcs12_path=
 pki_server_pkcs12_password=
 pki_server_external_certs_path=

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -505,6 +505,7 @@ class PKIDeployer:
         connector.set('redirectPort', self.mdict['pki_https_port'])
         connector.set('address', self.mdict['pki_ajp_host_ipv4'])
         connector.set('secret', self.mdict['pki_ajp_secret'])
+        connector.set('packetSize', self.mdict['pki_ajp_packet_size'])
 
         server_config.add_connector(connector)
 
@@ -516,6 +517,7 @@ class PKIDeployer:
         connector.set('redirectPort', self.mdict['pki_https_port'])
         connector.set('address', self.mdict['pki_ajp_host_ipv6'])
         connector.set('secret', self.mdict['pki_ajp_secret'])
+        connector.set('packetSize', self.mdict['pki_ajp_packet_size'])
 
         server_config.add_connector(connector)
 

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/LDAPSession.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/LDAPSession.java
@@ -178,6 +178,9 @@ public class LDAPSession extends DBSSession {
                     LDAPv3.SCOPE_BASE, "(objectclass=*)",
                     ldapattrs, false);
             LDAPEntry entry = res.next();
+            if (entry == null) {
+                throw new DBRecordNotFoundException(CMS.getUserMessage("CMS_DBS_RECORD_NOT_FOUND"));
+            }
             LDAPAttributeSet attrSet = entry.getAttributeSet();
 
             for (Enumeration<LDAPAttribute> e = attrSet.getAttributes(); e.hasMoreElements(); ) {

--- a/base/server/upgrade/11.10.0/02-AddAJPPacketSize.py
+++ b/base/server/upgrade/11.10.0/02-AddAJPPacketSize.py
@@ -1,0 +1,55 @@
+# Copyright Red Hat, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+from __future__ import absolute_import
+import configparser
+import logging
+from lxml import etree
+
+import pki
+import pki.server.upgrade
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CFG = pki.SHARE_DIR + '/server/etc/default.cfg'
+
+
+class AddAJPPacketSize(pki.server.upgrade.PKIServerUpgradeScriptlet):
+
+    def __init__(self):
+        super().__init__()
+        self.message = 'Add packetSize to AJP connectors in server.xml'
+
+        self.parser = etree.XMLParser(remove_blank_text=True)
+
+    def upgrade_instance(self, instance):
+
+        config = configparser.ConfigParser()
+        config.optionxform = str
+        config.read(DEFAULT_CFG)
+
+        packet_size = config.get('Tomcat', 'pki_ajp_packet_size',
+                                 fallback='65536')
+
+        logger.info('Updating %s', instance.server_xml)
+        self.backup(instance.server_xml)
+
+        document = etree.parse(instance.server_xml, self.parser)
+        server = document.getroot()
+
+        for connector in server.findall('Service/Connector'):
+
+            if not connector.get('protocol', '').startswith('AJP/'):
+                continue
+
+            if connector.get('packetSize'):
+                logger.debug('AJP connector already has packetSize, skipping')
+                continue
+
+            connector.set('packetSize', packet_size)
+            logger.info('Set packetSize=%s on AJP connector at %s',
+                        packet_size, connector.get('address', '<unknown>'))
+
+        with open(instance.server_xml, 'wb') as f:
+            document.write(f, pretty_print=True, encoding='utf-8')

--- a/docs/changes/v11.10.0/Server-Changes.adoc
+++ b/docs/changes/v11.10.0/Server-Changes.adoc
@@ -1,5 +1,38 @@
 = Server Changes =
 
+== AJP Connector Packet Size ==
+
+The AJP connector `packetSize` is now set to `65536` bytes (the AJP maximum)
+by default. This is required when the upstream reverse proxy forwards large TLS
+handshake data from clients using post-quantum certificates (ML-DSA or ML-KEM),
+which produce significantly larger certificate chains than classical algorithms.
+
+The default value is controlled by `pki_ajp_packet_size` in `default.cfg` and
+can be overridden per deployment in the user configuration file passed to
+`pkispawn`.
+
+The upstream httpd proxy must be configured with a matching buffer size.
+For `mod_proxy_ajp`, set `ProxyIOBufferSize` to the same value in the
+appropriate virtual host or global configuration:
+
+----
+ProxyIOBufferSize 65536
+----
+
+For new instances, the value is applied automatically during installation.
+
+For existing instances, the upgrade script sets `packetSize` on all AJP/1.3
+connectors in `server.xml`. Connectors that already carry a `packetSize`
+attribute are left unchanged.
+
+== Fix NullPointerException in LDAPSession.read() ==
+
+`LDAPSession.read()` now throws `DBRecordNotFoundException` when the LDAP
+search returns no entry, instead of dereferencing a null `LDAPEntry` and
+raising a `NullPointerException`. This aligns the null-result code path with
+the existing `LDAPException(NO_SUCH_OBJECT)` path handled by
+`LDAPExceptionConverter`.
+
 == VLV Index for CRL Generation ==
 
 VLV indexes are not enabled by default. However, if VLV is enabled during


### PR DESCRIPTION
Large AJP packets are needed when the upstream proxy forwards TLS handshake data from clients presenting post-quantum certificates (ML-DSA, ML-KEM), which produce significantly larger certificate chains than classical algorithms.

For FreeIPA, we also need to bump ProxyIOBufferSize to the same value on our side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented null errors when LDAP or certificate lookups return no record.

* **Improvements**
  * Added a Tomcat AJP packetSize setting (default 65536), applied to AJP connectors for compatibility.
  * Automatic upgrade step to propagate the AJP packetSize to existing instances.

* **Documentation**
  * Updated server docs with packetSize defaults and guidance for VLV index creation and CA upgrade steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->