### PR TITLE
IDM-5781 Add support to PBMAC1 in pkcs 12 [PKI]

### DIFF
--- a/base/common/python/pki/nssdb.py
+++ b/base/common/python/pki/nssdb.py
@@ -2772,7 +2772,9 @@ class NSSDatabase:
                       append=False,
                       include_trust_flags=True,
                       include_key=True,
-                      include_chain=True):
+                      include_chain=True,
+                      mac_type=None,
+                      mac_digest=None):
 
         tmpdir = self.create_tmpdir()
 
@@ -2824,6 +2826,12 @@ class NSSDatabase:
 
             if not include_chain:
                 cmd.extend(['--no-chain'])
+
+            if mac_type:
+                cmd.extend(['--mac-type', mac_type])
+
+            if mac_digest:
+                cmd.extend(['--mac-digest', mac_digest])
 
             if logger.isEnabledFor(logging.DEBUG):
                 cmd.append('--debug')

--- a/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
+++ b/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
@@ -53,12 +53,14 @@ import org.mozilla.jss.netscape.security.x509.X509CertImpl;
 import org.mozilla.jss.netscape.security.x509.X509Key;
 import org.mozilla.jss.pkcs12.AuthenticatedSafes;
 import org.mozilla.jss.pkcs12.CertBag;
+import org.mozilla.jss.pkcs12.MacType;
 import org.mozilla.jss.pkcs12.PFX;
 import org.mozilla.jss.pkcs12.PasswordConverter;
 import org.mozilla.jss.pkcs12.SafeBag;
 import org.mozilla.jss.pkix.primitive.EncryptedPrivateKeyInfo;
 import org.mozilla.jss.pkix.primitive.PrivateKeyInfo;
 import org.mozilla.jss.util.Password;
+import org.mozilla.jss.crypto.DigestAlgorithm;
 
 import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.SessionContext;
@@ -696,7 +698,8 @@ public class RecoveryService implements IService {
             //				encSafeContents);
             PFX pfx = new PFX(authSafes);
 
-            pfx.computeMacData(pass, null, 5); // ??
+            MacConfig macCfg = configurePFXMac(pfx);
+            pfx.computeMacData(pass, null, macCfg.iterations); // ??
             ByteArrayOutputStream fos = new
                     ByteArrayOutputStream();
 
@@ -876,7 +879,8 @@ public class RecoveryService implements IService {
             //				encSafeContents);
             PFX pfx = new PFX(authSafes);
 
-            pfx.computeMacData(pass, null, 5); // ??
+            MacConfig macCfg = configurePFXMac(pfx);
+            pfx.computeMacData(pass, null, macCfg.iterations); // ??
             ByteArrayOutputStream fos = new
                     ByteArrayOutputStream();
 
@@ -953,5 +957,72 @@ public class RecoveryService implements IService {
             logger.error(CMS.getLogMessage("CMSCORE_KRA_CREAT_KEY_BAG", e.toString()), e);
             throw new EKRAException(CMS.getUserMessage("CMS_KRA_KEYBAG_FAILED_1", e.toString()));
         }
+    }
+
+    /**
+    * Configuration for PKCS#12 MAC computation.
+    */
+    private static class MacConfig {
+        final String macType;
+        final String digest;
+        final int iterations;
+
+        /**
+         * @param macType The MAC type string
+         * @param digest The digest algorithm string
+         * @param iterations The iteration count
+         */
+        MacConfig(String macType, String digest, int iterations) {
+            this.macType = macType;
+            this.digest = digest;
+            this.iterations = iterations;
+        }
+    }
+
+    /**
+    * Configure PKCS#12 MAC type and digest algorithm based on KRA configuration.
+    *
+    * @throws EBaseException if configuration is invalid
+    */
+    private MacConfig configurePFXMac(PFX pfx) throws EBaseException {
+        KRAEngine engine = KRAEngine.getInstance();
+
+        // Check  macType config
+        String macTypeStr = engine.getConfig().getString("kra.pkcs12.macType", "classic");
+        // Get mac iterations, default 100000
+        int macIterations = engine.getConfig().getInteger("kra.pkcs12.macIterations", 100000);
+
+        String digestStr = "SHA256";
+
+        if ("pbmac1".equalsIgnoreCase(macTypeStr)) {
+            pfx.setMacType(MacType.PBMAC1);
+
+            digestStr = engine.getConfig().getString("kra.pkcs12.macDigest", "SHA256");
+            DigestAlgorithm digest;
+
+            if ("SHA256".equalsIgnoreCase(digestStr)) {
+                digest = DigestAlgorithm.SHA256;
+            } else if ("SHA384".equalsIgnoreCase(digestStr)) {
+                digest = DigestAlgorithm.SHA384;
+            } else if ("SHA512".equalsIgnoreCase(digestStr)) {
+                digest = DigestAlgorithm.SHA512;
+            } else {
+                throw new EKRAException(CMS.getUserMessage("CMS_KRA_PKCS12_FAILED_1",
+                    "Invalid kra.pkcs12.macDigest: " + digestStr +
+                    " (must be SHA256, SHA384, or SHA512)"));
+            }
+            pfx.setMacDigest(digest);
+            logger.debug("RecoveryService: Using PBMAC1 with " + digestStr);
+        } else if ("classic".equalsIgnoreCase(macTypeStr)) {
+            pfx.setMacType(MacType.CLASSIC);
+            logger.debug("RecoveryService: Using classic MAC");
+        } else {
+            //In case a bogus mac alg is selected, blow up.
+            throw new EKRAException(CMS.getUserMessage("CMS_KRA_PKCS12_FAILED_1",
+                "Invalid kra.pkcs12.macType: " + macTypeStr + " (must be 'classic' or 'pbmac1')"));
+        }
+
+        // return everything in case we need it all later, but mostly for iterations and future possibilities
+        return new MacConfig(macTypeStr, digestStr, macIterations);
     }
 }

--- a/base/kra/src/main/java/com/netscape/kra/SecurityDataProcessor.java
+++ b/base/kra/src/main/java/com/netscape/kra/SecurityDataProcessor.java
@@ -486,17 +486,27 @@ public class SecurityDataProcessor {
 
         byte[] iv = null;
         byte[] iv_wrap = null;
+        // Check if client provided IV in the request
+        String ivStr_in = null;
+
+        // Only generate IVs if client doesn't provide.
         try {
-            iv = generate_iv(
-                    payloadEncryptOID,
-                    transportUnit.getOldWrappingParams().getPayloadEncryptionAlgorithm());
+             ivStr_in = (String) params.get(Request.SECURITY_DATA_IV_STRING_IN);
+             iv = ivStr_in != null ? Utils.base64decode(ivStr_in) : null;
+
+            if (iv == null) {
+                iv = generate_iv(
+                        payloadEncryptOID,
+                        transportUnit.getOldWrappingParams().getPayloadEncryptionAlgorithm());
+            }
             iv_wrap = generate_wrap_iv(
-                    payloadWrapName,
-                    transportUnit.getOldWrappingParams().getPayloadWrapAlgorithm());
+                payloadWrapName,
+                transportUnit.getOldWrappingParams().getPayloadWrapAlgorithm());
         } catch (Exception e1) {
             jssSubsystem.obscureBytes(unwrappedSecData);
-            throw new EBaseException("Failed to generate IV when wrapping secret", e1);
+            throw new EBaseException("Failed to generate IV data when wrapping secret", e1);
         }
+
         String ivStr = iv != null? Utils.base64encode(iv, false): null;
         String ivStr_wrap = iv_wrap != null ? Utils.base64encode(iv_wrap, false): null;
 

--- a/base/kra/src/main/java/com/netscape/kra/TransportKeyUnit.java
+++ b/base/kra/src/main/java/com/netscape/kra/TransportKeyUnit.java
@@ -442,6 +442,16 @@ public class TransportKeyUnit extends EncryptionUnit {
                 encSymmKey,
                 skWrapAlgorithm);
 
+        if (logger.isDebugEnabled()) {
+            logger.debug("TransportKeyUnit.unwrap: Session key successfully unwrapped");
+            logger.debug("TransportKeyUnit.unwrap: Session key type: " + sk.getType());
+            String tokenName = (sk.getOwningToken() != null) ? sk.getOwningToken().getName() : "unknown";
+            logger.debug("TransportKeyUnit.unwrap: Session key owning token: " + tokenName);
+            logger.debug("TransportKeyUnit.unwrap: Payload wrap algorithm: " + params.getPayloadWrapAlgorithm());
+            logger.debug("TransportKeyUnit.unwrap: Payload wrap IV: " + (params.getPayloadWrappingIV() != null ? "present" : "null"));
+            logger.debug("TransportKeyUnit.unwrap: About to unwrap private key with session key");
+        }
+
         // (2) unwrap the session-wrapped-private key
         return CryptoUtil.unwrap(
                 token,

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -314,6 +314,10 @@ pki_external_pkcs12_password=%(pki_pkcs12_password)s
 pki_import_system_certs=True
 pki_import_admin_cert=False
 
+#PKCS#12 MAC algorithm configuration
+pki_pkcs12_mac_type=classic
+pki_pkcs12_mac_digest=SHA256
+
 pki_ocsp_signing_key_algorithm=SHA256withRSA
 pki_ocsp_signing_key_size=3072
 pki_ocsp_signing_key_type=rsa

--- a/base/server/python/pki/server/cli/instance.py
+++ b/base/server/python/pki/server/cli/instance.py
@@ -102,6 +102,8 @@ class InstanceCertExportCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--help',
             action='store_true')
+        self.parser.add_argument('--mac-type')
+        self.parser.add_argument('--mac-digest')
         self.parser.add_argument(
             'nicknames',
             nargs='*')
@@ -119,6 +121,11 @@ class InstanceCertExportCLI(pki.cli.CLI):
         print('      --no-trust-flags               Do not include trust flags')
         print('      --no-key                       Do not include private key')
         print('      --no-chain                     Do not include certificate chain')
+        print('      --mac-type <type>              MAC algorithm type:')
+        print('                                       classic - SHA256 with HMAC (default)')
+        print('                                       pbmac1 - PBMAC1 per RFC 9579')
+        print('      --mac-digest <digest>          MAC digest (for PBMAC1):')
+        print('                                       SHA256, SHA384, SHA512')
         print('  -v, --verbose                      Run in verbose mode.')
         print('      --debug                        Run in debug mode.')
         print('      --help                         Show help message.')
@@ -147,6 +154,8 @@ class InstanceCertExportCLI(pki.cli.CLI):
         include_trust_flags = not args.no_trust_flags
         include_key = not args.no_key
         include_chain = not args.no_chain
+        mac_type = args.mac_type
+        mac_digest = args.mac_digest
 
         nicknames = args.nicknames
 
@@ -176,7 +185,9 @@ class InstanceCertExportCLI(pki.cli.CLI):
                 append=append,
                 include_trust_flags=include_trust_flags,
                 include_key=include_key,
-                include_chain=include_chain)
+                include_chain=include_chain,
+                mac_type=mac_type,
+                mac_digest=mac_digest)
         finally:
             nssdb.close()
 

--- a/base/server/python/pki/server/cli/subsystem.py
+++ b/base/server/python/pki/server/cli/subsystem.py
@@ -1050,6 +1050,8 @@ class SubsystemCertExportCLI(pki.cli.CLI):
         self.parser.add_argument(
             '--no-chain',
             action='store_true')
+        self.parser.add_argument('--mac-type')
+        self.parser.add_argument('--mac-digest')
         self.parser.add_argument(
             '-v',
             '--verbose',
@@ -1084,6 +1086,11 @@ class SubsystemCertExportCLI(pki.cli.CLI):
         print('      --no-trust-flags               Do not include trust flags')
         print('      --no-key                       Do not include private key')
         print('      --no-chain                     Do not include certificate chain')
+        print('      --mac-type <type>              MAC algorithm type:')
+        print('                                       classic - SHA256 with HMAC (default)')
+        print('                                       pbmac1 - PBMAC1 per RFC 9579')
+        print('      --mac-digest <digest>          MAC digest (for PBMAC1):')
+        print('                                       SHA256, SHA384, SHA512')
         print('  -v, --verbose                      Run in verbose mode.')
         print('      --debug                        Run in debug mode.')
         print('      --help                         Show help message.')
@@ -1114,6 +1121,8 @@ class SubsystemCertExportCLI(pki.cli.CLI):
         include_trust_flags = not args.no_trust_flags
         include_key = not args.no_key
         include_chain = not args.no_chain
+        mac_type = args.mac_type
+        mac_digest = args.mac_digest
 
         subsystem_name = args.subsystem_id
         cert_tag = args.cert_id
@@ -1195,7 +1204,9 @@ class SubsystemCertExportCLI(pki.cli.CLI):
                     append=append,
                     include_trust_flags=include_trust_flags,
                     include_key=include_key,
-                    include_chain=include_chain)
+                    include_chain=include_chain,
+                    mac_type=mac_type,
+                    mac_digest=mac_digest)
 
             finally:
                 nssdb.close()

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1087,6 +1087,12 @@ class PKIDeployer:
                     'kra.transportUnit.nickName',
                     transport_token + ':' + transport_nickname)
 
+            # Configure PKCS#12 MAC for key recovery operations
+            subsystem.set_config('kra.pkcs12.macType',
+                                self.mdict.get('pki_pkcs12_mac_type', 'classic'))
+            subsystem.set_config('kra.pkcs12.macDigest',
+                                self.mdict.get('pki_pkcs12_mac_digest', 'SHA256'))
+
         if subsystem.type == 'OCSP':
 
             signing_nickname = subsystem.config['ocsp.signing.nickname']

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -452,7 +452,11 @@ class PKISubsystem(object):
             pkcs12_file,
             pkcs12_password_file,
             no_key=False,
-            append=False):
+            append=False,
+            mac_type='classic',
+            mac_digest='SHA256'):
+        # Note, hard code this for all subystems until we want to explicity change it to pbmac1 or
+        # create new pkispawn config settings to be used.
 
         cert = self.get_subsystem_cert(cert_tag)
 

--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12ExportCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs12/PKCS12ExportCLI.java
@@ -24,8 +24,10 @@ import java.io.FileReader;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.dogtagpki.cli.CommandCLI;
+import org.mozilla.jss.crypto.DigestAlgorithm;
 import org.mozilla.jss.crypto.PBEAlgorithm;
 import org.mozilla.jss.netscape.security.pkcs.PKCS12;
+import org.mozilla.jss.pkcs12.MacType;
 import org.mozilla.jss.netscape.security.pkcs.PKCS12Util;
 import org.mozilla.jss.util.Password;
 
@@ -72,6 +74,18 @@ public class PKCS12ExportCLI extends CommandCLI {
                 System.out.println(" - " + algorithm);
             }
         }
+
+        System.out.println();
+        System.out.println("Supported MAC types:");
+        System.out.println(" - classic (PKCS#12 v1.0 - default)");
+        System.out.println(" - PBMAC1 (RFC 9579)");
+
+        System.out.println();
+        System.out.println("Supported MAC digest algorithms (for PBMAC1):");
+        System.out.println(" - SHA256 (default)");
+        System.out.println(" - SHA384");
+        System.out.println(" - SHA512");
+
     }
 
     @Override
@@ -110,6 +124,16 @@ public class PKCS12ExportCLI extends CommandCLI {
 
         option = new Option(null, "key-encryption", true,
                 "Key encryption algorithm (default: " + PKCS12Util.DEFAULT_KEY_ENCRYPTION_NAME + ").");
+        option.setArgName("algorithm");
+        options.addOption(option);
+
+        option = new Option(null, "mac-type", true,
+                "MAC algorithm type: classic or PBMAC1 (default: classic).");
+        option.setArgName("type");
+        options.addOption(option);
+
+        option = new Option(null, "mac-digest", true,
+                "MAC digest algorithm for PBMAC1: SHA256, SHA384, SHA512 (default: SHA256).");
         option.setArgName("algorithm");
         options.addOption(option);
 
@@ -158,6 +182,8 @@ public class PKCS12ExportCLI extends CommandCLI {
 
         String certEncryption = cmd.getOptionValue("cert-encryption");
         String keyEncryption = cmd.getOptionValue("key-encryption");
+        String macTypeStr = cmd.getOptionValue("mac-type");
+        String macDigestStr = cmd.getOptionValue("mac-digest");
 
         boolean append = cmd.hasOption("append");
         boolean includeTrustFlags = !cmd.hasOption("no-trust-flags");
@@ -178,6 +204,28 @@ public class PKCS12ExportCLI extends CommandCLI {
                 util.setKeyEncryption(keyEncryption);
             }
             util.setTrustFlagsEnabled(includeTrustFlags);
+
+            if (macTypeStr != null) {
+                if ("classic".equalsIgnoreCase(macTypeStr)) {
+                    util.setMacType(MacType.CLASSIC);
+                } else if ("PBMAC1".equalsIgnoreCase(macTypeStr)) {
+                    util.setMacType(MacType.PBMAC1);
+                } else {
+                    throw new Exception("Unsupported MAC type: " + macTypeStr);
+                }
+            }
+
+            if (macDigestStr != null) {
+                if ("SHA256".equalsIgnoreCase(macDigestStr)) {
+                    util.setMacDigest(DigestAlgorithm.SHA256);
+                } else if ("SHA384".equalsIgnoreCase(macDigestStr)) {
+                    util.setMacDigest(DigestAlgorithm.SHA384);
+                } else if ("SHA512".equalsIgnoreCase(macDigestStr)) {
+                    util.setMacDigest(DigestAlgorithm.SHA512);
+                } else {
+                    throw new Exception("Unsupported MAC digest: " + macDigestStr);
+                }
+            }
 
             PKCS12 pkcs12;
 

--- a/pki.spec
+++ b/pki.spec
@@ -295,8 +295,8 @@ BuildRequires:    mvn(org.apache.tomcat:tomcat-util-scan) >= 10.0.36
 
 %endif
 
-BuildRequires:    mvn(org.dogtagpki.jss:jss-base) >= 5.10
-BuildRequires:    mvn(org.dogtagpki.jss:jss-tomcat) >= 5.10
+BuildRequires:    mvn(org.dogtagpki.jss:jss-base) >= 5.10.0
+BuildRequires:    mvn(org.dogtagpki.jss:jss-tomcat) >= 5.10.0
 BuildRequires:    mvn(org.dogtagpki.ldap-sdk:ldapjdk) >= 5.6.0
 
 # Python build dependencies


### PR DESCRIPTION
Provide support for pbmac1 at the pki level, using the support provided in the JSS version of this effort.

- Add configurePFXMac() to RecoveryService for CS.cfg-driven MAC selection
    - Add --mac-type and --mac-digest to pki pkcs12-export CLI
    - Add PKCS#12 MAC configuration to KRA CS.cfg
    - Add support to KRA to recover p12's optionally using pbmac1.
    - Optimize SecurityDataProcessor IV generation for client-provided IVs
    - Add debug logging to TransportKeyUnit unwrap operations
    - Bump JSS dependency to >= 5.10.0

- Add --mac-type and --mac-digest to pki-server instance-cert-export
    - Add --mac-type and --mac-digest to pki-server subsystem-cert-export
    - Add mac_type/mac_digest params to nssdb.export_pkcs12()
    - Add pki_pkcs12_mac_type/mac_digest to default.cfg
    - Write KRA CS.cfg MAC settings during pkispawn deployment
    - Hardcode legacy defaults for subsystem cert export

  Assisted by Claude Sonnet 4.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PKCS#12 export now supports configurable MAC type and digest algorithms via CLI options and API parameters.
  * Recovery service supports client-provided initialization vectors for wrapping and encrypting recovered secrets.

* **Configuration**
  * New PKCS#12 MAC configuration parameters added with defaults (classic MAC type, SHA256 digest).

* **Improvements**
  * Enhanced debug logging for key unwrapping operations.

* **Dependencies**
  * Updated build requirements for Dogtag JSS to version 5.10.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5346)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->