### PR TITLE
Fix KeyException in PKCS11KeyCLI for JSS API change

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/pkcs11/PKCS11KeyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/pkcs11/PKCS11KeyCLI.java
@@ -39,7 +39,7 @@ public class PKCS11KeyCLI extends CLI {
         addModule(new PKCS11KeyRemoveCLI(this));
     }
 
-    public static void printKeyInfo(String alias, Key key) {
+    public static void printKeyInfo(String alias, Key key) throws java.security.KeyException {
 
         System.out.println("  Key ID: " + alias);
 


### PR DESCRIPTION
JSS PR#1089 (merged) changed PrivateKey.getType() signature from:
  public Type getType()
to:
  public Type getType() throws KeyException

This was needed to support ML-DSA and ML-KEM key parameter detection which can fail when reading CKA_PARAMETER_SET from PKCS#11 tokens.

Impact:
- PKI compilation fails with "unreported exception KeyException"
- Affects PKCS11KeyCLI.printKeyInfo() which calls getType()
- Other PKI code already throws Exception so is unaffected

Fix:
- Add "throws java.security.KeyException" to printKeyInfo() signature
- Callers (PKCS11KeyFindCLI, PKCS11KeyShowCLI) propagate via existing Exception declarations

This fix is required for PKI to build with JSS 5.10.0+ which includes Marco's ML-KEM key generation support.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated key-management API to explicitly declare checked exceptions, improving error transparency. Integrations may need to adjust error handling to accommodate the new declaration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5348)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->