### PR TITLE
Update PKI CLI to support PQC

### DIFF
--- a/.github/workflows/pki-nss-pqc-test.yml
+++ b/.github/workflows/pki-nss-pqc-test.yml
@@ -1,0 +1,667 @@
+name: PKI NSS CLI with PQC
+# This test will perform the following operations:
+# - create CA signing key
+# - create CA signing CSR with existing key
+# - issue self-signed CA signing cert
+# - import CA signing cert
+# - create SSL server CSR with new key
+# - issue SSL server cert
+# - import SSL server cert
+# - remove SSL server cert and key
+# - create audit signing CSR with new key
+# - issue audit signing cert
+# - import audit signing cert
+# - remove audit signing cert and key
+# - create KRA storage CSR with new key
+# - issue KRA storage cert
+# - import KRA storage cert
+# - remove KRA storage cert and key
+# - remove CA signing cert and key
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # https://github.com/dogtagpki/pki/wiki/PKI-NSS-CLI
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Set up runner container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              pki
+
+          docker exec pki dnf install -y dumpasn1
+
+      - name: Create NSS database
+        run: |
+          # create password file
+          echo "Secret.123" > password.txt
+
+          # create password config
+          echo "internal=$(cat password.txt)" > password.conf
+
+          # create password-protected NSS database
+          docker exec pki pki \
+              -C $SHARED/password.txt \
+              nss-create
+
+      - name: Create CA signing key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-create \
+              --key-type MLDSA \
+              --key-id-file $SHARED/ca_signing.key-id
+
+      - name: Check CA signing key
+        run: |
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key type should be ML-DSA
+          echo "mldsa" > expected
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+.*$/\1/p' output > actual
+
+          diff expected actual
+
+          # list all keys
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              | tee output
+
+          # key type should be ML-DSA
+          echo "ML-DSA-65" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with inline password
+          docker exec pki pki \
+              -c $(cat password.txt) \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be ML-DSA
+          echo "ML-DSA-65" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password file
+          docker exec pki pki \
+              -C $SHARED/password.txt \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be ML-DSA
+          echo "ML-DSA-65" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password config
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be ML-DSA
+          echo "ML-DSA-65" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          # check key with password prompt
+          cat password.txt | docker exec -i pki pki \
+              nss-key-show \
+              --key-id-file $SHARED/ca_signing.key-id \
+              | tee output
+
+          # key type should be ML-DSA
+          echo "ML-DSA-65" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Create CA signing CSR with existing key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-request \
+              --key-id-file $SHARED/ca_signing.key-id \
+              --subject "CN=Certificate Authority" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr ca_signing.csr
+
+          docker exec pki openssl req -text -noout -in ca_signing.csr
+
+      - name: Issue self-signed CA signing cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-issue \
+              --csr ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --cert ca_signing.crt
+
+          docker exec pki openssl x509 -text -noout -in ca_signing.crt
+
+      - name: Import CA signing cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-import \
+              --cert ca_signing.crt \
+              --trust "CT,C,C" \
+              ca_signing
+
+      - name: Check CA signing cert
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
+          echo "CTu,Cu,Cu" > expected
+          sed -n 's/^ca_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              ca_signing \
+              | tee output
+
+          # trust flags should be CTu,Cu,Cu
+          echo "CTu,Cu,Cu" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Create SSL server CSR with new key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-request \
+              --key-type MLDSA \
+              --subject "CN=pki.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr sslserver.csr
+
+          # CSR should be created
+          docker exec pki openssl req -text -noout -in sslserver.csr
+
+      - name: Issue SSL server cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --cert sslserver.crt
+
+          docker exec pki openssl x509 -text -noout -in sslserver.crt
+
+      - name: Import SSL server cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-import \
+              --cert sslserver.crt \
+              sslserver
+
+      - name: Check SSL server key
+        run: |
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key type should be ML-DSA
+          echo "mldsa" > expected
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:sslserver$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              --nickname sslserver | tee output
+
+          # key type should be ML-DSA
+          echo "ML-DSA-65" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Check SSL server cert
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/^sslserver\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              sslserver | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove SSL server cert and key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-del \
+              sslserver \
+              --remove-key
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          echo "ca_signing CTu,Cu,Cu" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+          diff expected actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should be removed
+          echo "NSS Certificate DB:ca_signing" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              sslserver \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: sslserver
+          EOF
+
+          diff expected stderr
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-export \
+              sslserver \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: sslserver
+          EOF
+
+          diff expected stderr
+
+      - name: Create audit signing CSR with new key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-request \
+              --key-type MLDSA \
+              --subject "CN=Audit Signing Certificate" \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --csr audit_signing.csr
+
+          docker exec pki openssl req -text -noout -in audit_signing.csr
+
+      - name: Issue audit signing cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr audit_signing.csr \
+              --ext /usr/share/pki/server/certs/audit_signing.conf \
+              --cert audit_signing.crt
+
+          docker exec pki openssl x509 -text -noout -in audit_signing.crt
+
+      - name: Import audit signing cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-import \
+              --cert audit_signing.crt \
+              audit_signing
+
+      - name: Check audit signing key
+        run: |
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key type should be ML-DSA
+          echo "mldsa" > expected
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:audit_signing$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              --nickname audit_signing | tee output
+
+          # key type should be ML-DSA
+          echo "ML-DSA-65" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Check audit signing cert
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/^audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              audit_signing | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Modify audit signing cert trust flags
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-mod \
+              --trust-flags "u,u,P" \
+              audit_signing
+
+      - name: Check audit signing cert trust flags
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be u,u,Pu
+          echo "u,u,Pu" > expected
+          sed -n 's/^audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              audit_signing \
+              | tee output
+
+          # trust flags should be u,u,Pu
+          echo "u,u,Pu" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove audit signing cert and key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-del \
+              audit_signing \
+              --remove-key
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          echo "ca_signing CTu,Cu,Cu" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff expected actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should be removed
+          echo "NSS Certificate DB:ca_signing" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff expected actual
+
+      - name: Create KRA storage CSR with new key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-request \
+              --type crmf \
+              --key-type MLKEM \
+              --subject "CN=KRA Storage Certificate" \
+              --ext /usr/share/pki/server/certs/kra_storage.conf \
+              --csr kra_storage.csr
+
+          # CSR should be created
+          docker exec pki AtoB kra_storage.csr kra_storage.der
+          docker exec pki dumpasn1 kra_storage.der
+
+      - name: Issue KRA storage cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr-type crmf \
+              --csr kra_storage.csr \
+              --ext /usr/share/pki/server/certs/kra_storage.conf \
+              --cert kra_storage.crt
+
+          docker exec pki openssl x509 -text -noout -in kra_storage.crt
+
+      - name: Import KRA storage cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-import \
+              --cert kra_storage.crt \
+              kra_storage
+
+      - name: Check KRA storage key
+        run: |
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key type should be ML-KEM
+          echo "mlkem" > expected
+          sed -n 's/^<.*>\s\+\(\S\+\)\s\+\S\+\s\+NSS Certificate DB:kra_storage$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-find \
+              --nickname kra_storage | tee output
+
+          # key type should be ML-KEM
+          echo "ML-KEM-768" > expected
+          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Check KRA storage cert
+        run: |
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/^kra_storage\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              kra_storage | tee output
+
+          # trust flags should be u,u,u
+          echo "u,u,u" > expected
+          sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
+
+          diff expected actual
+
+      - name: Remove KRA storage cert and key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-del \
+              kra_storage \
+              --remove-key
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          echo "ca_signing CTu,Cu,Cu" > expected
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+          diff expected actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should be removed
+          echo "NSS Certificate DB:ca_signing" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+          diff expected actual
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              kra_storage \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: kra_storage
+          EOF
+
+          diff expected stderr
+
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-export \
+              kra_storage \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # cert should be removed
+          cat > expected << EOF
+          ERROR: Certificate not found: kra_storage
+          EOF
+
+          diff expected stderr
+
+      - name: Remove CA signing cert
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-cert-del \
+              ca_signing
+
+          docker exec pki certutil -L \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # cert should be removed
+          sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
+
+          diff /dev/null actual
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should not be removed
+          echo "(orphan)" > expected
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff expected actual
+
+      - name: Remove CA signing key
+        run: |
+          docker exec pki pki \
+              -f $SHARED/password.conf \
+              nss-key-del \
+              --key-id-file $SHARED/ca_signing.key-id
+
+          docker exec pki certutil -K \
+              -d /root/.dogtag/nssdb \
+              -f $SHARED/password.txt \
+              | tee output
+
+          # key should be removed
+          sed -n 's/^<.*>\s\+\S\+\s\+\S\+\s\+\(.*\)$/\1/p' output | sort > actual
+
+          diff /dev/null actual

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -28,6 +28,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/pki-nss-ecc-test.yml
 
+  pki-nss-pqc-test:
+    name: PKI NSS CLI with PQC
+    needs: build
+    uses: ./.github/workflows/pki-nss-pqc-test.yml
+
   pki-nss-aes-test:
     name: PKI NSS CLI with AES
     needs: build

--- a/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -518,6 +518,51 @@ public class CryptoUtil {
         return keygen.genKeyPair();
     }
 
+    /**
+     * Generates an ML-KEM key pair.
+     */
+    public static KeyPair generateMLKEMKeyPair(
+            CryptoToken token,
+            int strength,
+            Boolean temporary,
+            Boolean sensitive,
+            Boolean extractable,
+            Usage[] usages,
+            Usage[] usagesMask) throws Exception {
+
+        logger.debug("CryptoUtil: Generating ML-KEM key pair");
+
+        KeyPairGenerator keygen = token.getKeyPairGenerator(KeyPairAlgorithm.MLKEM);
+
+        logger.debug("CryptoUtil: - temporary: " + temporary);
+        if (temporary != null) {
+            keygen.temporaryPairs(temporary);
+        }
+
+        logger.debug("CryptoUtil: - sensitive: " + sensitive);
+        if (sensitive != null) {
+            keygen.sensitivePairs(sensitive);
+        }
+
+        logger.debug("CryptoUtil: - extractable: " + extractable);
+        if (extractable != null) {
+            keygen.extractablePairs(extractable);
+        }
+
+        String usageList = usages != null ? String.join(",", Stream.of(usages).map(KeyPairGeneratorSpi.Usage::name).toArray(String[]::new)) : "";
+        logger.debug("CryptoUtil: - key usage: {}", usageList);
+
+        String usageMaskList = usagesMask != null ? String.join(",", Stream.of(usagesMask).map(KeyPairGeneratorSpi.Usage::name).toArray(String[]::new)) : "";
+        logger.debug("CryptoUtil: - key usage mask: {}", usageMaskList);
+
+        keygen.setKeyPairUsages(usages, usagesMask);
+
+        logger.debug("CryptoUtil: - key strength: " + strength);
+        keygen.initialize(strength);
+
+        return keygen.genKeyPair();
+    }
+
     public static boolean isECCKey(X509Key key) {
         String keyAlgo = key.getAlgorithm();
         if (keyAlgo.equals("EC") ||

--- a/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
+++ b/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
@@ -1075,6 +1075,48 @@ public class NSSDatabase {
                 usagesMask);
     }
 
+    public KeyPair createMLKEMKeyPair(
+            CryptoToken token,
+            int strength,
+            Boolean temporary,
+            Boolean sensitive,
+            Boolean extractable) throws Exception {
+
+        logger.debug("NSSDatabase: Creating ML-KEM key");
+        logger.debug("NSSDatabase: - strength: " + strength);
+
+        return CryptoUtil.generateMLKEMKeyPair(
+                token,
+                strength,
+                temporary,
+                sensitive,
+                extractable,
+                null,
+                null);
+    }
+
+    public KeyPair createMLKEMKeyPair(
+            CryptoToken token,
+            int strength,
+            Boolean temporary,
+            Boolean sensitive,
+            Boolean extractable,
+            Usage[] usages,
+            Usage[] usagesMask) throws Exception {
+
+        logger.debug("NSSDatabase: Creating ML-KEM key");
+        logger.debug("NSSDatabase: - strength: " + strength);
+
+        return CryptoUtil.generateMLKEMKeyPair(
+                token,
+                strength,
+                temporary,
+                sensitive,
+                extractable,
+                usages,
+                usagesMask);
+    }
+
     public KeyPair createECKeyPair(
             CryptoToken token,
             String curveName,
@@ -1386,7 +1428,10 @@ public class NSSDatabase {
         Date notAfterDate = calendar.getTime();
         logger.debug("NSSDatabase: - not after: " + notAfterDate);
 
-        String keyAlgorithm = hash + "with" + subjectKey.getAlgorithm();
+        String keyAlgorithm = subjectKey.getAlgorithm();
+        if (hash != null) {
+            keyAlgorithm = hash + "with" + keyAlgorithm;
+        }
         logger.debug("NSSDatabase: - key algorithm: " + keyAlgorithm);
 
         // convert Extensions into CertificateExtensions
@@ -1444,8 +1489,13 @@ public class NSSDatabase {
             logger.debug("NSSDatabase: - private key: " + Utils.HexEncode(privateKey.getUniqueID()));
         }
 
-        logger.debug("NSSDatabase: Private key algorithm: " + privateKey.getAlgorithm());
-        String signingAlgorithm = hash + "with" + privateKey.getAlgorithm();
+        String privateKeyAlgorithm = privateKey.getAlgorithm();
+        logger.debug("NSSDatabase: Private key algorithm: " + privateKeyAlgorithm);
+
+        String signingAlgorithm = privateKeyAlgorithm;
+        if (hash != null) {
+            signingAlgorithm = hash + "with" + privateKeyAlgorithm;
+        }
         logger.debug("NSSDatabase: Signing algorithm: " + signingAlgorithm);
 
         return CryptoUtil.signCert(privateKey, info, signingAlgorithm);

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertIssueCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertIssueCLI.java
@@ -12,11 +12,14 @@ import java.util.Calendar;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
+import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.nss.NSSDatabase;
 import org.dogtagpki.nss.NSSExtensionGenerator;
+import org.dogtagpki.util.cert.CRMFUtil;
 import org.dogtagpki.util.cert.CertUtil;
 import org.mozilla.jss.CryptoManager;
+import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.netscape.security.pkcs.PKCS10;
 import org.mozilla.jss.netscape.security.x509.Extensions;
 import org.mozilla.jss.netscape.security.x509.X500Name;
@@ -51,6 +54,10 @@ public class NSSCertIssueCLI extends CommandCLI {
         option.setArgName("path");
         options.addOption(option);
 
+        option = new Option(null, "csr-type", true, "CSR type: pkcs10 (default), crmf");
+        option.setArgName("type");
+        options.addOption(option);
+
         option = new Option(null, "ext", true, "Certificate extensions configuration");
         option.setArgName("path");
         options.addOption(option);
@@ -75,7 +82,7 @@ public class NSSCertIssueCLI extends CommandCLI {
         option.setArgName("unit");
         options.addOption(option);
 
-        option = new Option(null, "hash", true, "Hash algorithm (default is SHA256)");
+        option = new Option(null, "hash", true, "Hash function (default is SHA256 for RSA and EC key)");
         option.setArgName("hash");
         options.addOption(option);
 
@@ -93,13 +100,14 @@ public class NSSCertIssueCLI extends CommandCLI {
 
         String issuerNickname = cmd.getOptionValue("issuer");
         String csrFile = cmd.getOptionValue("csr");
+        String csrType = cmd.getOptionValue("csr-type", "pkcs10");
         String extConf = cmd.getOptionValue("ext");
         String subjectAltName = cmd.getOptionValue("subjectAltName");
         String serialNumber = cmd.getOptionValue("serial");
         String monthsValid = cmd.getOptionValue("months-valid");
         String validityLengthStr = cmd.getOptionValue("validity-length", "3");
         String validityUnitStr = cmd.getOptionValue("validity-unit", "month");
-        String hash = cmd.getOptionValue("hash", "SHA256");
+        String hash = cmd.getOptionValue("hash");
 
         if (csrFile == null) {
             throw new Exception("Missing certificate signing request");
@@ -122,9 +130,25 @@ public class NSSCertIssueCLI extends CommandCLI {
 
         String csrPEM = new String(Files.readAllBytes(Paths.get(csrFile)));
         byte[] csrBytes = CertUtil.parseCSR(csrPEM);
-        PKCS10 pkcs10 = new PKCS10(csrBytes);
-        X509Key subjectKey = pkcs10.getSubjectPublicKeyInfo();
-        X500Name subjectName = pkcs10.getSubjectName();
+
+        PKCS10 pkcs10 = null;
+        SEQUENCE crmfMsgs = null;
+        X509Key subjectKey = null;
+        X500Name subjectName = null;
+
+        if ("pkcs10".equals(csrType)) {
+            pkcs10 = new PKCS10(csrBytes);
+            subjectKey = pkcs10.getSubjectPublicKeyInfo();
+            subjectName = pkcs10.getSubjectName();
+
+        } else if ("crmf".equals(csrType)) {
+            crmfMsgs = CRMFUtil.parseCRMFMsgs(csrBytes);
+            subjectKey = CRMFUtil.getX509KeyFromCRMFMsgs(crmfMsgs);
+            subjectName = CRMFUtil.getSubjectName(crmfMsgs);
+
+        } else {
+            throw new CLIException("Invalid request type: " + csrType);
+        }
 
         NSSExtensionGenerator generator = new NSSExtensionGenerator();
         Extensions extensions = null;
@@ -153,6 +177,19 @@ public class NSSCertIssueCLI extends CommandCLI {
         }
 
         String tokenName = clientConfig.getTokenName();
+        String keyAlgorithm = subjectKey.getAlgorithm();
+
+        if (("RSA".equals(keyAlgorithm) || "EC".equals(keyAlgorithm))) {
+            if (hash == null) {
+                // by default use SHA256 for RSA and EC keys
+                hash = "SHA256";
+            }
+
+        } else { // ML-DSA and ML-KEM
+            if (hash != null) {
+                throw new CLIException("Hash function not supported for " + keyAlgorithm + " keys");
+            }
+        }
 
         X509Certificate cert = nssdb.createCertificate(
                 tokenName,

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSCertRequestCLI.java
@@ -14,6 +14,7 @@ import java.security.KeyPair;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.codec.binary.Hex;
+import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.cli.CommandCLI;
 import org.dogtagpki.nss.NSSDatabase;
 import org.dogtagpki.nss.NSSExtensionGenerator;
@@ -77,12 +78,16 @@ public class NSSCertRequestCLI extends CommandCLI {
         option.setArgName("path");
         options.addOption(option);
 
-        option = new Option(null, "key-type", true, "Key type: RSA (default), EC, MLDSA");
+        option = new Option(null, "key-type", true, "Key type: RSA (default), EC, MLDSA, MLKEM");
         option.setArgName("type");
         options.addOption(option);
 
-        option = new Option(null, "key-size", true, "Key size (RSA default: 2048, MLDSA default: 65)");
+        option = new Option(null, "key-size", true, "DEPRECATED: Key size");
         option.setArgName("size");
+        options.addOption(option);
+
+        option = new Option(null, "key-strength", true, "Key strength (RSA default: 2048, MLDSA default: 65, MLKEM default: 768)");
+        option.setArgName("strength");
         options.addOption(option);
 
         options.addOption(null, "key-wrap", false, "Generate RSA key for wrapping/unwrapping.");
@@ -110,7 +115,7 @@ public class NSSCertRequestCLI extends CommandCLI {
         option.setArgName("boolean");
         options.addOption(option);
 
-        option = new Option(null, "hash", true, "Hash algorithm (default: SHA256)");
+        option = new Option(null, "hash", true, "Hash function (default is SHA256 for RSA and EC key)");
         option.setArgName("name");
         options.addOption(option);
 
@@ -160,6 +165,15 @@ public class NSSCertRequestCLI extends CommandCLI {
         }
 
         String keyType = cmd.getOptionValue("key-type", "RSA");
+
+        String keyStrength = cmd.getOptionValue("key-strength");
+        String keySize = cmd.getOptionValue("key-size");
+
+        if (keyStrength == null && keySize != null) {
+            logger.warn("The --key-size option has been deprecated. Use --key-strength instead.");
+            keyStrength = keySize;
+        }
+
         boolean keyWrap = cmd.hasOption("key-wrap");
         String keyWrapAlg = cmd.getOptionValue(
                 "key-wrap-alg",
@@ -182,7 +196,7 @@ public class NSSCertRequestCLI extends CommandCLI {
             extractable = Boolean.parseBoolean(s);
         }
 
-        String hash = cmd.getOptionValue("hash", "SHA256");
+        String hash = cmd.getOptionValue("hash");
         String extConf = cmd.getOptionValue("ext");
         boolean skid = cmd.hasOption("skid");
         String subjectAltName = cmd.getOptionValue("subjectAltName");
@@ -211,18 +225,19 @@ public class NSSCertRequestCLI extends CommandCLI {
             keyType = keyPair.getPublic().getAlgorithm();
 
         } else if ("RSA".equalsIgnoreCase(keyType)) {
-            String keySize = cmd.getOptionValue("key-size", "2048");
+
+            if (keyStrength == null) keyStrength = "2048";
+
             keyPair = nssdb.createRSAKeyPair(
                     token,
-                    Integer.parseInt(keySize),
+                    Integer.parseInt(keyStrength),
                     keyWrap,
                     temporary,
                     sensitive,
                     extractable);
-            PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
-            keyID = "0x" + Utils.HexEncode(privateKey.getUniqueID());
 
         } else if ("EC".equalsIgnoreCase(keyType)) {
+
             keyPair = nssdb.createECKeyPair(
                     token,
                     curve,
@@ -230,22 +245,36 @@ public class NSSCertRequestCLI extends CommandCLI {
                     temporary,
                     sensitive,
                     extractable);
-            PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
-            keyID = "0x" + Utils.HexEncode(privateKey.getUniqueID());
 
         } else if ("MLDSA".equalsIgnoreCase(keyType)) {
-            String keySize = cmd.getOptionValue("key-size", "65");
+
+            if (keyStrength == null) keyStrength = "65";
+
             keyPair = nssdb.createMLDSAKeyPair(
                     token,
-                    Integer.parseInt(keySize),
+                    Integer.parseInt(keyStrength),
                     temporary,
                     sensitive,
                     extractable);
-            PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
-            keyID = "0x" + Utils.HexEncode(privateKey.getUniqueID());
+
+        } else if ("MLKEM".equalsIgnoreCase(keyType)) {
+
+            if (keyStrength == null) keyStrength = "768";
+
+            keyPair = nssdb.createMLKEMKeyPair(
+                    token,
+                    Integer.parseInt(keyStrength),
+                    temporary,
+                    sensitive,
+                    extractable);
 
         } else {
             throw new Exception("Unsupported key type: " + keyType);
+        }
+
+        if (keyID == null) {
+            PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
+            keyID = "0x" + Utils.HexEncode(privateKey.getUniqueID());
         }
 
         if (keyIDFile != null) {
@@ -275,6 +304,19 @@ public class NSSCertRequestCLI extends CommandCLI {
 
         X509Key subjectKey = CryptoUtil.createX509Key(keyPair.getPublic());
         extensions = generator.createExtensions(subjectKey);
+        String keyAlgorithm = subjectKey.getAlgorithm();
+
+        if (("RSA".equals(keyAlgorithm) || "EC".equals(keyAlgorithm))) {
+            if (hash == null) {
+                // by default use SHA256 for RSA and EC keys
+                hash = "SHA256";
+            }
+
+        } else { // ML-DSA and ML-KEM
+            if (hash != null) {
+                throw new CLIException("Hash function not supported for " + keyAlgorithm + " keys");
+            }
+        }
 
         byte[] bytes;
 
@@ -317,8 +359,24 @@ public class NSSCertRequestCLI extends CommandCLI {
             } else if ("EC".equalsIgnoreCase(keyType)) {
                 signatureAlgorithm = SignatureAlgorithm.ECSignatureWithSHA256Digest;
 
-            } else if ("MLDSA".equalsIgnoreCase(keyType)) {
-                signatureAlgorithm = SignatureAlgorithm.MLDSA;
+            } else if ("MLDSA".equalsIgnoreCase(keyType) || "ML-DSA".equalsIgnoreCase(keyType) || keyType.startsWith("ML-DSA-")) {
+                if ("44".equals(keyStrength)) {
+                    signatureAlgorithm = SignatureAlgorithm.MLDSA44;
+                } else if ("65".equals(keyStrength)) {
+                    signatureAlgorithm = SignatureAlgorithm.MLDSA65;
+                } else if ("87".equals(keyStrength)) {
+                    signatureAlgorithm = SignatureAlgorithm.MLDSA87;
+                } else {
+                    throw new CLIException("Unsupported ML-DSA key strength: " + keyStrength);
+                }
+
+            } else if ("MLKEM".equalsIgnoreCase(keyType) || "ML-KEM".equalsIgnoreCase(keyType) || keyType.startsWith("ML-KEM-")) {
+                if (pop != null) {
+                    throw new CLIException("ML-KEM does not support signature-based POP");
+                }
+
+                signatureAlgorithm = null;
+
             } else {
                 throw new Exception("Unknown algorithm: " + keyType);
             }

--- a/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/nss/NSSKeyCreateCLI.java
@@ -67,12 +67,16 @@ public class NSSKeyCreateCLI extends CommandCLI {
         option.setArgName("token");
         options.addOption(option);
 
-        option = new Option(null, "key-type", true, "Key type: RSA (default), EC, MLDSA, AES");
+        option = new Option(null, "key-type", true, "Key type: RSA (default), EC, MLDSA, MLKEM, AES");
         option.setArgName("type");
         options.addOption(option);
 
-        option = new Option(null, "key-size", true, "Key size (RSA default: 2048, AES default: 256, MLDSA default: 65)");
+        option = new Option(null, "key-size", true, "DEPRECATED: Key size");
         option.setArgName("size");
+        options.addOption(option);
+
+        option = new Option(null, "key-strength", true, "Key strength (RSA default: 2048, AES default: 256, MLDSA default: 65, MLKEM default: 768)");
+        option.setArgName("strength");
         options.addOption(option);
 
         options.addOption(null, "key-wrap", false, "Generate RSA key for wrapping/unwrapping.");
@@ -125,7 +129,15 @@ public class NSSKeyCreateCLI extends CommandCLI {
         }
 
         String keyType = cmd.getOptionValue("key-type", "RSA");
+
+        String keyStrength = cmd.getOptionValue("key-strength");
         String keySize = cmd.getOptionValue("key-size");
+
+        if (keyStrength == null && keySize != null) {
+            logger.warn("The --key-size option has been deprecated. Use --key-strength instead.");
+            keyStrength = keySize;
+        }
+
         boolean keyWrap = cmd.hasOption("key-wrap");
         String curve = cmd.getOptionValue("curve", "nistp256");
         boolean sslECDH = cmd.hasOption("ssl-ecdh");
@@ -157,13 +169,14 @@ public class NSSKeyCreateCLI extends CommandCLI {
         }
         CryptoToken token = CryptoUtil.getKeyStorageToken(tokenName);
 
-        KeyInfo keyInfo = new KeyInfo();
+        KeyPair keyPair = null;
+        SymmetricKey symmetricKey = null;
 
         logger.info("Creating " + keyType + " in token " + tokenName);
 
         if ("RSA".equalsIgnoreCase(keyType)) {
 
-            if (keySize == null) keySize = "2048";
+            if (keyStrength == null) keyStrength = "2048";
 
             KeyPairGeneratorSpi.Usage[] usages = null;
             if (opFlags != null && !opFlags.isEmpty()) {
@@ -179,21 +192,14 @@ public class NSSKeyCreateCLI extends CommandCLI {
                 usagesMask = keyWrap ? CryptoUtil.RSA_KEYPAIR_USAGES_MASK : null;
             }
 
-            KeyPair keyPair = nssdb.createRSAKeyPair(
+            keyPair = nssdb.createRSAKeyPair(
                     token,
-                    Integer.parseInt(keySize),
+                    Integer.parseInt(keyStrength),
                     temporary,
                     sensitive,
                     extractable,
                     usages,
                     usagesMask);
-
-            PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
-
-            String hexKeyID = "0x" + Utils.HexEncode(privateKey.getUniqueID());
-            keyInfo.setKeyId(new KeyId(hexKeyID));
-            keyInfo.setType(privateKey.getType().toString());
-            keyInfo.setAlgorithm(privateKey.getAlgorithm());
 
         } else if ("EC".equalsIgnoreCase(keyType)) {
 
@@ -209,7 +215,7 @@ public class NSSKeyCreateCLI extends CommandCLI {
                 usagesMask = sslECDH ? CryptoUtil.ECDH_USAGES_MASK : CryptoUtil.ECDHE_USAGES_MASK;
             }
 
-            KeyPair keyPair = nssdb.createECKeyPair(
+            keyPair = nssdb.createECKeyPair(
                     token,
                     curve,
                     temporary,
@@ -218,15 +224,9 @@ public class NSSKeyCreateCLI extends CommandCLI {
                     usages,
                     usagesMask);
 
-            PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
-
-            String hexKeyID = "0x" + Utils.HexEncode(privateKey.getUniqueID());
-            keyInfo.setKeyId(new KeyId(hexKeyID));
-            keyInfo.setType(privateKey.getType().toString());
-            keyInfo.setAlgorithm(privateKey.getAlgorithm());
-
         } else if ("MLDSA".equalsIgnoreCase(keyType)) {
-            if (keySize == null) keySize = "65";
+
+            if (keyStrength == null) keyStrength = "65";
 
             KeyPairGeneratorSpi.Usage[] usages = null;
             if (opFlags != null && !opFlags.isEmpty()) {
@@ -238,25 +238,41 @@ public class NSSKeyCreateCLI extends CommandCLI {
                 usagesMask = CryptoUtil.generateUsage(opFlagsMask);
             }
 
-            KeyPair keyPair = nssdb.createMLDSAKeyPair(
+            keyPair = nssdb.createMLDSAKeyPair(
                     token,
-                    Integer.parseInt(keySize),
+                    Integer.parseInt(keyStrength),
                     temporary,
                     sensitive,
                     extractable,
                     usages,
                     usagesMask);
 
-            PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
+        } else if ("MLKEM".equalsIgnoreCase(keyType)) {
 
-            String hexKeyID = "0x" + Utils.HexEncode(privateKey.getUniqueID());
-            keyInfo.setKeyId(new KeyId(hexKeyID));
-            keyInfo.setType(privateKey.getType().toString());
-            keyInfo.setAlgorithm(privateKey.getAlgorithm());
+            if (keyStrength == null) keyStrength = "768";
+
+            KeyPairGeneratorSpi.Usage[] usages = null;
+            if (opFlags != null && !opFlags.isEmpty()) {
+                usages = CryptoUtil.generateUsage(opFlags);
+            }
+
+            KeyPairGeneratorSpi.Usage[] usagesMask = null;
+            if (opFlagsMask != null && !opFlagsMask.isEmpty()) {
+                usagesMask = CryptoUtil.generateUsage(opFlagsMask);
+            }
+
+            keyPair = nssdb.createMLKEMKeyPair(
+                    token,
+                    Integer.parseInt(keyStrength),
+                    temporary,
+                    sensitive,
+                    extractable,
+                    usages,
+                    usagesMask);
 
         } else if ("AES".equalsIgnoreCase(keyType)) {
 
-            if (keySize == null) keySize = "256";
+            if (keyStrength == null) keyStrength = "256";
 
             if (nickname == null) {
                 throw new CLIException("Missing key nickname");
@@ -267,22 +283,35 @@ public class NSSKeyCreateCLI extends CommandCLI {
                 usages = CryptoUtil.generateSymmetricKeyUsage(opFlags);
             }
 
-            SymmetricKey symmetricKey = nssdb.createSymmetricKey(
+            symmetricKey = nssdb.createSymmetricKey(
                     token,
                     KeyGenAlgorithm.AES,
-                    Integer.parseInt(keySize),
+                    Integer.parseInt(keyStrength),
                     usages,
                     temporary,
                     sensitive);
 
             symmetricKey.setNickName(nickname);
 
+        } else {
+            throw new Exception("Unsupported key type: " + keyType);
+        }
+
+        KeyInfo keyInfo = new KeyInfo();
+
+        if (keyPair != null) {
+            PK11PrivKey privateKey = (PK11PrivKey) keyPair.getPrivate();
+
+            String hexKeyID = "0x" + Utils.HexEncode(privateKey.getUniqueID());
+            keyInfo.setKeyId(new KeyId(hexKeyID));
+            keyInfo.setType(privateKey.getType().toString());
+            keyInfo.setAlgorithm(privateKey.getAlgorithm());
+
+        } else if (symmetricKey != null) {
+
             keyInfo.setNickname(nickname);
             keyInfo.setType(symmetricKey.getType().toString());
             keyInfo.setAlgorithm(symmetricKey.getAlgorithm());
-
-        } else {
-            throw new Exception("Unsupported key type: " + keyType);
         }
 
         String keyIDFile = cmd.getOptionValue("key-id-file");

--- a/docs/changes/v11.10.0/Tools-Changes.adoc
+++ b/docs/changes/v11.10.0/Tools-Changes.adoc
@@ -1,0 +1,18 @@
+= Tools Changes =
+
+== Changes in pki nss-key-create ==
+
+The `--key-type` option now accepts `MLKEM`.
+
+The `--key-size` option has been deprecated. Use `--key-strength` instead.
+
+== Changes in pki nss-cert-request ==
+
+The `--key-type` option now accepts `MLKEM`.
+
+The `--key-size` option has been deprecated. Use `--key-strength` instead.
+
+== Changes in pki nss-cert-issue ==
+
+The command now supports both PKCS #10 and CRMF requests.
+The CSR type can be specified with the `--csr-type` option.


### PR DESCRIPTION
The `pki nss-key-create` and `pki nss-cert-request` have been updated to support ML-KEM.

The `pki nss-cert-request` and `pki nss-cert-issue` have been updated to use SHA256 only for RSA and EC. ML-DSA and ML-KEM do not use a hash function.

The `pki nss-cert-issue` has been updated to support CRMF request.

The `NSSDatabase.createCertificate()` has been updated to allow optional hash function.

A new test has been added to issue ML-DSA and ML-KEM certs using PKI CLI.

**Notes:**
* This PR is needed by #5351.
* The test result is available at https://github.com/edewata/pki/actions/runs/25708261964/job/75483569327.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ML-KEM (MLKEM) key-type support and MLKEM key-pair generation
  * Support for both PKCS#10 and CRMF CSR formats via --csr-type
  * Introduced --key-strength for key creation/cert requests; --key-size deprecated
  * Improved CSR/hash handling with algorithm-appropriate defaults and validations

* **Tests**
  * Added end-to-end PQC-enabled NSS/PKI workflow exercising certificate and key lifecycle

* **Documentation**
  * Updated tools docs to reflect new options and behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5350)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->