### PR TITLE
Update CRMFPopClient to support PQC

### DIFF
--- a/.github/workflows/ca-profile-caInternalAuthDRMstorageCert-test.yml
+++ b/.github/workflows/ca-profile-caInternalAuthDRMstorageCert-test.yml
@@ -1,0 +1,284 @@
+name: CA with caInternalAuthDRMstorageCert profile
+# This test will perform the following operations:
+# - install CA
+# - create SD session
+# - enroll cert using CRMFPopClient without POP
+# - enroll cert using PKI CLI with CRMF request without POP
+# - remove SD session
+# - remove CA
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
+
+          docker exec pki dnf install -y jq dumpasn1
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_ca_signing_key_type=mldsa \
+              -D pki_ca_signing_key_algorithm=ML-DSA-65 \
+              -D pki_ca_signing_key_size=65 \
+              -D pki_ca_signing_signing_algorithm=ML-DSA-65 \
+              -D pki_ocsp_signing_key_type=mldsa \
+              -D pki_ocsp_signing_key_algorithm=ML-DSA-65 \
+              -D pki_ocsp_signing_key_size=65 \
+              -D pki_ocsp_signing_signing_algorithm=ML-DSA-65 \
+              -D pki_audit_signing_key_type=mldsa \
+              -D pki_audit_signing_key_algorithm=ML-DSA-65 \
+              -D pki_audit_signing_key_size=65 \
+              -D pki_audit_signing_signing_algorithm=ML-DSA-65 \
+              -D pki_sslserver_key_type=mldsa \
+              -D pki_sslserver_key_algorithm=ML-DSA-65 \
+              -D pki_sslserver_key_size=65 \
+              -D pki_sslserver_signing_algorithm=ML-DSA-65 \
+              -D pki_subsystem_key_type=mldsa \
+              -D pki_subsystem_key_algorithm=ML-DSA-65 \
+              -D pki_subsystem_key_size=65 \
+              -D pki_subsystem_signing_algorithm=ML-DSA-65 \
+              -D pki_admin_key_type=mldsa \
+              -D pki_admin_key_size=65 \
+              -D pki_admin_key_algorithm=ML-DSA-65 \
+              -v
+
+      - name: Configure caInternalAuthDRMstorageCert profile
+        run: |
+          # allow ML-KEM-768
+          # NOTE: update this step once PR #5338 is merged
+          docker exec pki sed -i \
+              -e "s/^\(.*\.keyParameters\)=.*$/\1=1024,2048,3072,4096,768/" \
+              /var/lib/pki/pki-tomcat/ca/profiles/ca/caInternalAuthDRMstorageCert.cfg
+
+          # restart CA
+          docker exec pki pki-server ca-redeploy --wait
+
+      - name: Set up CA admin
+        run: |
+          docker exec pki pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Create SD session
+        run: |
+          # authenticate as security domain admin
+          docker exec pki curl \
+              -k \
+              -s \
+              -H "Accept: application/json" \
+              --user caadmin:Secret.123 \
+              --cookie-jar cookies \
+              https://pki.example.com:8443/ca/v2/account/login \
+              | python -m json.tool
+
+          # create security domain session
+          docker exec pki curl \
+              -k \
+              -s \
+              --cookie cookies \
+              "https://pki.example.com:8443/ca/v2/securityDomain/installToken?hostname=pki.example.com&subsystem=CA" \
+              | python -m json.tool \
+              | tee session.json
+
+          # TODO: implement pki sd-session-create
+          # docker exec pki pki \
+          #     -u caadmin \
+          #     -w Secret.123 \
+          #     sd-session-create \
+          #     --session-file session.json
+
+          # store install token
+          jq -r '.token' session.json > install-token
+
+      - name: Enroll cert using CRMFPopClient without POP
+        run: |
+          # generate CRMF request
+          docker exec pki CRMFPopClient \
+              -d /root/.dogtag/nssdb \
+              -p "" \
+              -a mlkem \
+              -l 768 \
+              -t false \
+              -f caInternalAuthDRMstorageCert \
+              -n "CN=test-CRMFPopClient-without-POP" \
+              -q POP_NONE \
+              -o test-CRMFPopClient-without-POP.csr
+
+          docker exec pki certutil -K -d /root/.dogtag/nssdb
+
+          docker exec pki cat test-CRMFPopClient-without-POP.csr
+
+          docker exec pki AtoB test-CRMFPopClient-without-POP.csr test-CRMFPopClient-without-POP.der
+          docker exec pki dumpasn1 test-CRMFPopClient-without-POP.der
+
+          # issue cert
+          docker exec pki pki \
+              ca-cert-issue \
+              --install-token $SHARED/install-token \
+              --request-type crmf \
+              --profile caInternalAuthDRMstorageCert \
+              --subject CN=test-CRMFPopClient-without-POP \
+              --csr-file test-CRMFPopClient-without-POP.csr \
+              --output-file test-CRMFPopClient-without-POP.crt
+
+          docker exec pki openssl x509 -text -noout -in test-CRMFPopClient-without-POP.crt
+
+          # import cert
+          docker exec pki pki nss-cert-import \
+              --cert test-CRMFPopClient-without-POP.crt \
+              test-CRMFPopClient-without-POP
+
+          docker exec pki certutil -K -d /root/.dogtag/nssdb
+
+          docker exec pki pki nss-cert-show test-CRMFPopClient-without-POP | tee output
+
+          # normalize output
+          sed \
+              -e '/^ *Serial Number:/d' \
+              -e '/^ *Not Valid Before:/d' \
+              -e '/^ *Not Valid After:/d' \
+              output > actual
+
+          # the cert should match the key (trust attributes must be u,u,u)
+          cat > expected << EOF
+            Nickname: test-CRMFPopClient-without-POP
+            Subject DN: CN=test-CRMFPopClient-without-POP
+            Issuer DN: CN=CA Signing Certificate,OU=pki-tomcat,O=EXAMPLE
+            Trust Flags: u,u,u
+          EOF
+
+          diff expected actual
+
+      - name: Enroll cert using PKI CLI with CRMF request without POP
+        run: |
+          # generate CRMF request
+          docker exec pki pki nss-cert-request \
+              --type crmf \
+              --key-type MLKEM \
+              --subject "CN=test-PKI-CLI-CRMF-without-POP" \
+              --csr test-PKI-CLI-CRMF-without-POP.csr
+
+          docker exec pki cat test-PKI-CLI-CRMF-without-POP.csr
+
+          docker exec pki AtoB test-PKI-CLI-CRMF-without-POP.csr test-PKI-CLI-CRMF-without-POP.der
+          docker exec pki dumpasn1 test-PKI-CLI-CRMF-without-POP.der
+
+          # issue cert
+          docker exec pki pki \
+              ca-cert-issue \
+              --install-token $SHARED/install-token \
+              --request-type crmf \
+              --profile caInternalAuthDRMstorageCert \
+              --subject CN=test-PKI-CLI-CRMF-without-POP \
+              --csr-file test-PKI-CLI-CRMF-without-POP.csr \
+              --output-file test-PKI-CLI-CRMF-without-POP.crt
+
+          docker exec pki openssl x509 -text -noout -in test-PKI-CLI-CRMF-without-POP.crt
+
+          # import cert
+          docker exec pki pki nss-cert-import \
+              --cert test-PKI-CLI-CRMF-without-POP.crt \
+              test-PKI-CLI-CRMF-without-POP
+
+          docker exec pki pki nss-cert-show test-PKI-CLI-CRMF-without-POP | tee output
+
+          # normalize output
+          sed \
+              -e '/^ *Serial Number:/d' \
+              -e '/^ *Not Valid Before:/d' \
+              -e '/^ *Not Valid After:/d' \
+              output > actual
+
+          # the cert should match the key (trust attributes must be u,u,u)
+          cat > expected << EOF
+            Nickname: test-PKI-CLI-CRMF-without-POP
+            Subject DN: CN=test-PKI-CLI-CRMF-without-POP
+            Issuer DN: CN=CA Signing Certificate,OU=pki-tomcat,O=EXAMPLE
+            Trust Flags: u,u,u
+          EOF
+
+          diff expected actual
+
+      - name: Remove SD session
+        run: |
+          # remove security domain session
+          # TODO: implement REST API
+
+          # TODO: implement pki sd-session-del
+          # docker exec pki pki \
+          #     -u caadmin \
+          #     -w Secret.123 \
+          #     sd-session-del \
+          #     --session-file session.json
+
+      - name: Remove CA
+        run: |
+          docker exec pki pkidestroy -s CA -v
+
+      - name: Check for core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;

--- a/.github/workflows/ca-profile-caInternalAuthTransportCert-test.yml
+++ b/.github/workflows/ca-profile-caInternalAuthTransportCert-test.yml
@@ -1,0 +1,284 @@
+name: CA with caInternalAuthTransportCert profile
+# This test will perform the following operations:
+# - install CA
+# - create SD session
+# - enroll cert using CRMFPopClient without POP
+# - enroll cert using PKI CLI with CRMF request without POP
+# - remove SD session
+# - remove CA
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=ds.example.com \
+              --network=example \
+              --network-alias=ds.example.com \
+              --password=Secret.123 \
+              ds
+
+      - name: Set up PKI container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              pki
+
+          docker exec pki dnf install -y jq dumpasn1
+
+      - name: Install CA
+        run: |
+          docker exec pki pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://ds.example.com:3389 \
+              -D pki_ca_signing_key_type=mldsa \
+              -D pki_ca_signing_key_algorithm=ML-DSA-65 \
+              -D pki_ca_signing_key_size=65 \
+              -D pki_ca_signing_signing_algorithm=ML-DSA-65 \
+              -D pki_ocsp_signing_key_type=mldsa \
+              -D pki_ocsp_signing_key_algorithm=ML-DSA-65 \
+              -D pki_ocsp_signing_key_size=65 \
+              -D pki_ocsp_signing_signing_algorithm=ML-DSA-65 \
+              -D pki_audit_signing_key_type=mldsa \
+              -D pki_audit_signing_key_algorithm=ML-DSA-65 \
+              -D pki_audit_signing_key_size=65 \
+              -D pki_audit_signing_signing_algorithm=ML-DSA-65 \
+              -D pki_sslserver_key_type=mldsa \
+              -D pki_sslserver_key_algorithm=ML-DSA-65 \
+              -D pki_sslserver_key_size=65 \
+              -D pki_sslserver_signing_algorithm=ML-DSA-65 \
+              -D pki_subsystem_key_type=mldsa \
+              -D pki_subsystem_key_algorithm=ML-DSA-65 \
+              -D pki_subsystem_key_size=65 \
+              -D pki_subsystem_signing_algorithm=ML-DSA-65 \
+              -D pki_admin_key_type=mldsa \
+              -D pki_admin_key_size=65 \
+              -D pki_admin_key_algorithm=ML-DSA-65 \
+              -v
+
+      - name: Configure caInternalAuthTransportCert profile
+        run: |
+          # allow ML-KEM-768
+          # NOTE: update this step once PR #5338 is merged
+          docker exec pki sed -i \
+              -e "s/^\(.*\.keyParameters\)=.*$/\1=1024,2048,3072,4096,768/" \
+              /var/lib/pki/pki-tomcat/ca/profiles/ca/caInternalAuthTransportCert.cfg
+
+          # restart CA
+          docker exec pki pki-server ca-redeploy --wait
+
+      - name: Set up CA admin
+        run: |
+          docker exec pki pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
+
+          docker exec pki pki nss-cert-import \
+              --cert ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          docker exec pki pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --pkcs12-password Secret.123
+
+      - name: Create SD session
+        run: |
+          # authenticate as security domain admin
+          docker exec pki curl \
+              -k \
+              -s \
+              -H "Accept: application/json" \
+              --user caadmin:Secret.123 \
+              --cookie-jar cookies \
+              https://pki.example.com:8443/ca/v2/account/login \
+              | python -m json.tool
+
+          # create security domain session
+          docker exec pki curl \
+              -k \
+              -s \
+              --cookie cookies \
+              "https://pki.example.com:8443/ca/v2/securityDomain/installToken?hostname=pki.example.com&subsystem=CA" \
+              | python -m json.tool \
+              | tee session.json
+
+          # TODO: implement pki sd-session-create
+          # docker exec pki pki \
+          #     -u caadmin \
+          #     -w Secret.123 \
+          #     sd-session-create \
+          #     --session-file session.json
+
+          # store install token
+          jq -r '.token' session.json > install-token
+
+      - name: Enroll cert using CRMFPopClient without POP
+        run: |
+          # generate CRMF request
+          docker exec pki CRMFPopClient \
+              -d /root/.dogtag/nssdb \
+              -p "" \
+              -a mlkem \
+              -l 768 \
+              -t false \
+              -f caInternalAuthTransportCert \
+              -n "CN=test-CRMFPopClient-without-POP" \
+              -q POP_NONE \
+              -o test-CRMFPopClient-without-POP.csr
+
+          docker exec pki certutil -K -d /root/.dogtag/nssdb
+
+          docker exec pki cat test-CRMFPopClient-without-POP.csr
+
+          docker exec pki AtoB test-CRMFPopClient-without-POP.csr test-CRMFPopClient-without-POP.der
+          docker exec pki dumpasn1 test-CRMFPopClient-without-POP.der
+
+          # issue cert
+          docker exec pki pki \
+              ca-cert-issue \
+              --install-token $SHARED/install-token \
+              --request-type crmf \
+              --profile caInternalAuthTransportCert \
+              --subject CN=test-CRMFPopClient-without-POP \
+              --csr-file test-CRMFPopClient-without-POP.csr \
+              --output-file test-CRMFPopClient-without-POP.crt
+
+          docker exec pki openssl x509 -text -noout -in test-CRMFPopClient-without-POP.crt
+
+          # import cert
+          docker exec pki pki nss-cert-import \
+              --cert test-CRMFPopClient-without-POP.crt \
+              test-CRMFPopClient-without-POP
+
+          docker exec pki certutil -K -d /root/.dogtag/nssdb
+
+          docker exec pki pki nss-cert-show test-CRMFPopClient-without-POP | tee output
+
+          # normalize output
+          sed \
+              -e '/^ *Serial Number:/d' \
+              -e '/^ *Not Valid Before:/d' \
+              -e '/^ *Not Valid After:/d' \
+              output > actual
+
+          # the cert should match the key (trust attributes must be u,u,u)
+          cat > expected << EOF
+            Nickname: test-CRMFPopClient-without-POP
+            Subject DN: CN=test-CRMFPopClient-without-POP
+            Issuer DN: CN=CA Signing Certificate,OU=pki-tomcat,O=EXAMPLE
+            Trust Flags: u,u,u
+          EOF
+
+          diff expected actual
+
+      - name: Enroll cert using PKI CLI with CRMF request without POP
+        run: |
+          # generate CRMF request
+          docker exec pki pki nss-cert-request \
+              --type crmf \
+              --key-type MLKEM \
+              --subject "CN=test-PKI-CLI-CRMF-without-POP" \
+              --csr test-PKI-CLI-CRMF-without-POP.csr
+
+          docker exec pki cat test-PKI-CLI-CRMF-without-POP.csr
+
+          docker exec pki AtoB test-PKI-CLI-CRMF-without-POP.csr test-PKI-CLI-CRMF-without-POP.der
+          docker exec pki dumpasn1 test-PKI-CLI-CRMF-without-POP.der
+
+          # issue cert
+          docker exec pki pki \
+              ca-cert-issue \
+              --install-token $SHARED/install-token \
+              --request-type crmf \
+              --profile caInternalAuthTransportCert \
+              --subject CN=test-PKI-CLI-CRMF-without-POP \
+              --csr-file test-PKI-CLI-CRMF-without-POP.csr \
+              --output-file test-PKI-CLI-CRMF-without-POP.crt
+
+          docker exec pki openssl x509 -text -noout -in test-PKI-CLI-CRMF-without-POP.crt
+
+          # import cert
+          docker exec pki pki nss-cert-import \
+              --cert test-PKI-CLI-CRMF-without-POP.crt \
+              test-PKI-CLI-CRMF-without-POP
+
+          docker exec pki pki nss-cert-show test-PKI-CLI-CRMF-without-POP | tee output
+
+          # normalize output
+          sed \
+              -e '/^ *Serial Number:/d' \
+              -e '/^ *Not Valid Before:/d' \
+              -e '/^ *Not Valid After:/d' \
+              output > actual
+
+          # the cert should match the key (trust attributes must be u,u,u)
+          cat > expected << EOF
+            Nickname: test-PKI-CLI-CRMF-without-POP
+            Subject DN: CN=test-PKI-CLI-CRMF-without-POP
+            Issuer DN: CN=CA Signing Certificate,OU=pki-tomcat,O=EXAMPLE
+            Trust Flags: u,u,u
+          EOF
+
+          diff expected actual
+
+      - name: Remove SD session
+        run: |
+          # remove security domain session
+          # TODO: implement REST API
+
+          # TODO: implement pki sd-session-del
+          # docker exec pki pki \
+          #     -u caadmin \
+          #     -w Secret.123 \
+          #     sd-session-del \
+          #     --session-file session.json
+
+      - name: Remove CA
+        run: |
+          docker exec pki pkidestroy -s CA -v
+
+      - name: Check for core dumps
+        if: failure()
+        run: |
+          docker exec pki ls -l
+          docker exec pki find / -path /proc -prune -o -name "hs_err_pid*.log" -exec cat {} \;
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check CA debug log
+        if: always()
+        run: |
+          docker exec pki find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;

--- a/.github/workflows/ca-profile-tests.yml
+++ b/.github/workflows/ca-profile-tests.yml
@@ -18,6 +18,16 @@ jobs:
     needs: build
     uses: ./.github/workflows/ca-profile-caDirPinUserCert-test.yml
 
+  ca-profile-caInternalAuthDRMstorageCert-test:
+    name: CA with caInternalAuthDRMstorageCert profile
+    needs: build
+    uses: ./.github/workflows/ca-profile-caInternalAuthDRMstorageCert-test.yml
+
+  ca-profile-caInternalAuthTransportCert-test:
+    name: CA with caInternalAuthTransportCert profile
+    needs: build
+    uses: ./.github/workflows/ca-profile-caInternalAuthTransportCert-test.yml
+
   ca-profile-caServerCert-test:
     name: CA with caServerCert profile
     needs: build

--- a/base/ca/src/main/java/com/netscape/cms/profile/constraint/KeyConstraint.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/constraint/KeyConstraint.java
@@ -90,7 +90,7 @@ public class KeyConstraint extends EnrollConstraint {
     @Override
     public IDescriptor getConfigDescriptor(Locale locale, String name) {
         if (name.equals(CONFIG_KEY_TYPE)) {
-            return new Descriptor(IDescriptor.CHOICE, "-,RSA,EC,MLDSA",
+            return new Descriptor(IDescriptor.CHOICE, "-,RSA,EC,MLDSA,MLKEM",
                     "RSA",
                     CMS.getUserMessage(locale, "CMS_PROFILE_KEY_TYPE"));
         } else if (name.equals(CONFIG_KEY_PARAMETERS)) {
@@ -108,19 +108,29 @@ public class KeyConstraint extends EnrollConstraint {
     @Override
     public void validate(Request request, X509CertInfo info)
             throws ERejectException {
+
+        logger.info("KeyConstraint: Validating key constraint");
+
         try {
             CertificateX509Key infokey = (CertificateX509Key) info.get(X509CertInfo.KEY);
             X509Key key = (X509Key) infokey.get(CertificateX509Key.KEY);
             String alg = key.getAlgorithmId().getName().toUpperCase();
-            logger.info("KeyConstraint: Key algorithnm: " + alg);
+            logger.info("KeyConstraint: - key algorithm: {}", alg);
 
             String value = getConfig(CONFIG_KEY_TYPE);
-            logger.info("KeyConstraint: Key type: " + value);
+            logger.info("KeyConstraint: - key type: {}", value);
 
             String keyType = value;
 
             if (!isOptional(value)) {
-                String algKey = alg.startsWith("ML-DSA-") ? "MLDSA" : alg;
+                String algKey;
+                if (alg.startsWith("ML-DSA-")) {
+                    algKey = "MLDSA";
+                } else if (alg.startsWith("ML-KEM-")) {
+                    algKey = "MLKEM";
+                } else {
+                    algKey = alg;
+                }
                 if (!algKey.equals(value)) {
                     logger.error("Invalid key type: " + value);
                     throw new ERejectException(
@@ -139,6 +149,8 @@ public class KeyConstraint extends EnrollConstraint {
                 keySize = getDSAKeyLen(key);
             } else if (alg.startsWith("ML-DSA-")) {
                 keySize = Integer.parseInt(alg.replaceFirst("^ML-DSA-", ""));
+            } else if (alg.startsWith("ML-KEM-")) {
+                keySize = Integer.parseInt(alg.replaceFirst("^ML-KEM-", ""));
             } else if (alg.equals("EC")) {
                 //EC key case.
             } else {
@@ -196,7 +208,7 @@ public class KeyConstraint extends EnrollConstraint {
                 }
 
             } else {
-                logger.info("KeySize is {}", keySize);
+                logger.info("KeyConstraint: - key size: {}", keySize);
                 if (!arrayContainsString(keyParams, Integer.toString(keySize))) {
                     throw new ERejectException(
                             CMS.getUserMessage(

--- a/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java
@@ -41,6 +41,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.common.CAInfoClient;
 import org.dogtagpki.nss.NSSDatabase;
 import org.dogtagpki.util.cert.CRMFUtil;
@@ -112,8 +113,8 @@ public class CRMFPopClient {
         option.setArgName("algorithm");
         options.addOption(option);
 
-        option = new Option("l", true, "Key length");
-        option.setArgName("length");
+        option = new Option("l", true, "Key strength");
+        option.setArgName("strength");
         options.addOption(option);
 
         option = new Option("c", true, "ECC curve name");
@@ -191,15 +192,17 @@ public class CRMFPopClient {
         System.out.println("                               - true: enabled");
         System.out.println("                               - false: disabled");
         System.out.println("  -y                           Add SubjectKeyIdentifier extension in case of CMC SharedSecret requests (default: false when not specified); To be used with 'request.useSharedSecret=true' when running CMCRequest.");
-        System.out.println("  -a <rsa|ec>                  Key algorithm (default: rsa)");
+        System.out.println("  -a <rsa|ec|mldsa|mlkem>      Key algorithm (default: rsa)");
         System.out.println("                               - rsa: RSA");
         System.out.println("                               - ec: ECC");
+        System.out.println("                               - mldsa: ML-DSA");
+        System.out.println("                               - mlkem: ML-KEM");
         System.out.println("  -f <profile>                 Certificate profile");
         System.out.println("                               - RSA default: caEncUserCert");
         System.out.println("                               - ECC default: caEncECUserCert");
-        System.out.println("  -q <POP option>              POP option (default: POP_SUCCESS)");
-        System.out.println("                               - POP_NONE: without POP");
-        System.out.println("                               - POP_SUCCESS: with valid POP");
+        System.out.println("  -q <POP option>              POP option");
+        System.out.println("                               - POP_NONE: without POP (default for ML-KEM)");
+        System.out.println("                               - POP_SUCCESS: with valid POP (default for other algorithms)");
         System.out.println("                               - POP_FAIL: with invalid POP (for testing)");
         System.out.println("  -w <keywrap algorithm>       Algorithm to use for key wrapping");
         System.out.println("                               - default: \"AES KeyWrap/Padding\"");
@@ -210,8 +213,11 @@ public class CRMFPopClient {
         System.out.println("  -v, --verbose                Run in verbose mode.");
         System.out.println("      --help                   Show help message.");
         System.out.println();
-        System.out.println("With RSA algorithm the following options can be specified:");
-        System.out.println("  -l <length>                  Key length (default: 2048)");
+        System.out.println("With RSA/ML-DSA/ML-KEM algorithm the following options can be specified:");
+        System.out.println("  -l <strength>                Key strength");
+        System.out.println("                               - RSA default: 2048");
+        System.out.println("                               - ML-DSA default: 65");
+        System.out.println("                               - ML-KEM default: 768");
         System.out.println(" -oaep                         Use OAEP key wrap algorithm");
         System.out.println();
         System.out.println("With ECC algorithm the following options can be specified:");
@@ -288,7 +294,7 @@ public class CRMFPopClient {
         String tokenName = cmd.getOptionValue("h");
 
         String algorithm = cmd.getOptionValue("a", "rsa");
-        int keySize = Integer.parseInt(cmd.getOptionValue("l", "2048"));
+        String keyStrength = cmd.getOptionValue("l");
 
         String profileID = cmd.getOptionValue("f");
         String subjectDN = cmd.getOptionValue("n");
@@ -297,7 +303,7 @@ public class CRMFPopClient {
         // if transportCertFilename is not specified then assume no key archival
         String transportCertFilename = cmd.getOptionValue("b");
 
-        String popOption = cmd.getOptionValue("q", "POP_SUCCESS");
+        String popOption = cmd.getOptionValue("q");
 
         String curve = cmd.getOptionValue("c", "nistp256");
         boolean sslECDH = Boolean.parseBoolean(cmd.getOptionValue("x", "false"));
@@ -345,7 +351,7 @@ public class CRMFPopClient {
             System.exit(1);
          }
 
-        if (algorithm.equals("rsa")) {
+        if (algorithm.equals("rsa") || algorithm.equals("mldsa") || algorithm.equals("mlkem")) {
             if (cmd.hasOption("c")) {
                 printError("Illegal parameter for RSA: -c");
                 System.exit(1);
@@ -387,11 +393,28 @@ public class CRMFPopClient {
             System.exit(1);
         }
 
-        if (!popOption.equals("POP_SUCCESS") &&
-                !popOption.equals("POP_FAIL") &&
-                !popOption.equals("POP_NONE")) {
+        Boolean withPop;
+
+        if (popOption == null) {
+            if (algorithm.equals("mlkem")) {
+                withPop = null; // by default ML-KEM uses POP_NONE
+            } else {
+                withPop = true; // by default other algs use POP_SUCCESS
+            }
+
+        } else if (popOption.equals("POP_SUCCESS")) {
+            withPop = true;
+
+        } else if (popOption.equals("POP_FAIL")) {
+            withPop = false;
+
+        } else if (popOption.equals("POP_NONE")) {
+            withPop = null;
+
+        } else {
             printError("Invalid POP option: "+ popOption);
             System.exit(1);
+            return;
         }
 
         if (profileID == null) {
@@ -464,9 +487,11 @@ public class CRMFPopClient {
 
             if (algorithm.equals("rsa")) {
 
+                if (keyStrength == null) keyStrength = "2048";
+
                 keyPair = nssdb.createRSAKeyPair(
                         token,
-                        keySize,
+                        Integer.parseInt(keyStrength),
                         true, // key wrap
                         temporary,
                         null, // sensitive
@@ -481,6 +506,28 @@ public class CRMFPopClient {
                         temporary,
                         sensitive == -1 ? null : sensitive == 1,
                         extractable == -1 ? null : extractable == 1);
+
+            } else if (algorithm.equals("mldsa")) {
+
+                if (keyStrength == null) keyStrength = "65";
+
+                keyPair = nssdb.createMLDSAKeyPair(
+                        token,
+                        Integer.parseInt(keyStrength),
+                        temporary,
+                        null, // sensitive
+                        true); // extractable
+
+            } else if (algorithm.equals("mlkem")) {
+
+                if (keyStrength == null) keyStrength = "768";
+
+                keyPair = nssdb.createMLKEMKeyPair(
+                        token,
+                        Integer.parseInt(keyStrength),
+                        temporary,
+                        null, // sensitive
+                        true); // extractable
 
             } else {
                 throw new Exception("Unknown algorithm: " + algorithm);
@@ -520,17 +567,26 @@ public class CRMFPopClient {
             } else if (algorithm.equals("ec")) {
                 signatureAlgorithm = SignatureAlgorithm.ECSignatureWithSHA256Digest;
 
+            } else if (algorithm.equals("mldsa")) {
+                if ("44".equals(keyStrength)) {
+                    signatureAlgorithm = SignatureAlgorithm.MLDSA44;
+                } else if ("65".equals(keyStrength)) {
+                    signatureAlgorithm = SignatureAlgorithm.MLDSA65;
+                } else if ("87".equals(keyStrength)) {
+                    signatureAlgorithm = SignatureAlgorithm.MLDSA87;
+                } else {
+                    throw new CLIException("Unsupported ML-DSA key strength: " + keyStrength);
+                }
+
+            } else if (algorithm.equals("mlkem")) {
+                if (withPop != null) {
+                    throw new CLIException("ML-KEM does not support signature-based POP");
+                }
+
+                signatureAlgorithm = null;
+
             } else {
                 throw new Exception("Unknown algorithm: " + algorithm);
-            }
-
-            Boolean withPop = null; // POP_NONE
-
-            if (popOption.equals("POP_SUCCESS")) {
-                withPop = true;
-
-            } else if (popOption.equals("POP_FAIL")) {
-                withPop = false;
             }
 
             Extensions extensions = new Extensions();

--- a/docs/changes/v11.10.0/Tools-Changes.adoc
+++ b/docs/changes/v11.10.0/Tools-Changes.adoc
@@ -16,3 +16,7 @@ The `--key-size` option has been deprecated. Use `--key-strength` instead.
 
 The command now supports both PKCS #10 and CRMF requests.
 The CSR type can be specified with the `--csr-type` option.
+
+== Changes in CRMFPopClient ==
+
+The command now supports both `ML-DSA` and `ML-KEM` keys.


### PR DESCRIPTION
The `CRMFPopClient` has been updated to support creating a CRMF request with ML-DSA or ML-KEM key.

The `KeyConstraint` has been updated to support ML-KEM.

New tests have been added to install CA with ML-DSA then enroll storage and transport certs with ML-KEM which can be used for KRA installation later. The enrollment is done using a CRMF request without POP created with `CRMFPopClient` and `pki` CLI. The enrollment is also done using profiles that use security domain session (i.e. install token) for authentication.

**Note:**
* This PR has a dependency on #5350.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ML-KEM (post-quantum cryptography) key generation and certificate support across PKI tools
  * Enabled CRMF certificate request format support in certificate issuance operations
  * Enhanced `pki nss-key-create` to accept `--key-strength` parameter for ML-KEM keys
  
* **Documentation**
  * Updated CLI tool documentation for new ML-KEM capabilities and deprecated `--key-size` option

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5351)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->