### PR TITLE
Fix a couple of python violations intruduced by pbmac1 feature.

### DIFF
--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1089,9 +1089,9 @@ class PKIDeployer:
 
             # Configure PKCS#12 MAC for key recovery operations
             subsystem.set_config('kra.pkcs12.macType',
-                                self.mdict.get('pki_pkcs12_mac_type', 'classic'))
+                                 self.mdict.get('pki_pkcs12_mac_type', 'classic'))
             subsystem.set_config('kra.pkcs12.macDigest',
-                                self.mdict.get('pki_pkcs12_mac_digest', 'SHA256'))
+                                 self.mdict.get('pki_pkcs12_mac_digest', 'SHA256'))
 
         if subsystem.type == 'OCSP':
 

--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -476,7 +476,9 @@ class PKISubsystem(object):
                 pkcs12_password_file=pkcs12_password_file,
                 nicknames=[nickname],
                 include_key=not no_key,
-                append=append)
+                append=append,
+                mac_type=mac_type,
+                mac_digest=mac_digest)
         finally:
             nssdb.close()
 


### PR DESCRIPTION
Address a couple of minor pylint and flake8 complaints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where PKCS#12 certificate export operations were not properly applying the configured MAC type and digest settings during the export process.

* **Refactor**
  * Reformatted system certificate configuration code for improved readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5352)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->