### PR TITLE
Fix failure in CA test with ML-DSA

### DIFF
--- a/.github/workflows/pki-nss-pqc-test.yml
+++ b/.github/workflows/pki-nss-pqc-test.yml
@@ -91,9 +91,16 @@ jobs:
               nss-key-find \
               | tee output
 
-          # key type should be ML-DSA
-          echo "ML-DSA-65" > expected
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+          # key type and algorithm should be ML-DSA
+          cat > expected << EOF
+          Type: ML-DSA-65
+          Algorithm: ML-DSA
+          EOF
+
+          sed -n \
+              -e 's/\s*\(Type:\s*\S\+\)\s*$/\1/p' \
+              -e 's/\s*\(Algorithm:\s*\S\+\)\s*$/\1/p' \
+              output > actual
 
           diff expected actual
 
@@ -104,9 +111,10 @@ jobs:
               --key-id-file $SHARED/ca_signing.key-id \
               | tee output
 
-          # key type should be ML-DSA
-          echo "ML-DSA-65" > expected
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+          sed -n \
+              -e 's/\s*\(Type:\s*\S\+\)\s*$/\1/p' \
+              -e 's/\s*\(Algorithm:\s*\S\+\)\s*$/\1/p' \
+              output > actual
 
           diff expected actual
 
@@ -117,9 +125,10 @@ jobs:
               --key-id-file $SHARED/ca_signing.key-id \
               | tee output
 
-          # key type should be ML-DSA
-          echo "ML-DSA-65" > expected
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+          sed -n \
+              -e 's/\s*\(Type:\s*\S\+\)\s*$/\1/p' \
+              -e 's/\s*\(Algorithm:\s*\S\+\)\s*$/\1/p' \
+              output > actual
 
           diff expected actual
 
@@ -130,9 +139,10 @@ jobs:
               --key-id-file $SHARED/ca_signing.key-id \
               | tee output
 
-          # key type should be ML-DSA
-          echo "ML-DSA-65" > expected
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+          sed -n \
+              -e 's/\s*\(Type:\s*\S\+\)\s*$/\1/p' \
+              -e 's/\s*\(Algorithm:\s*\S\+\)\s*$/\1/p' \
+              output > actual
 
           diff expected actual
 
@@ -142,9 +152,10 @@ jobs:
               --key-id-file $SHARED/ca_signing.key-id \
               | tee output
 
-          # key type should be ML-DSA
-          echo "ML-DSA-65" > expected
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+          sed -n \
+              -e 's/\s*\(Type:\s*\S\+\)\s*$/\1/p' \
+              -e 's/\s*\(Algorithm:\s*\S\+\)\s*$/\1/p' \
+              output > actual
 
           diff expected actual
 
@@ -256,9 +267,16 @@ jobs:
               nss-key-find \
               --nickname sslserver | tee output
 
-          # key type should be ML-DSA
-          echo "ML-DSA-65" > expected
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+          # key type and algorithm should be ML-DSA
+          cat > expected << EOF
+          Type: ML-DSA-65
+          Algorithm: ML-DSA
+          EOF
+
+          sed -n \
+              -e 's/\s*\(Type:\s*\S\+\)\s*$/\1/p' \
+              -e 's/\s*\(Algorithm:\s*\S\+\)\s*$/\1/p' \
+              output > actual
 
           diff expected actual
 
@@ -390,9 +408,16 @@ jobs:
               nss-key-find \
               --nickname audit_signing | tee output
 
-          # key type should be ML-DSA
-          echo "ML-DSA-65" > expected
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+          # key type and algorithm should be ML-DSA
+          cat > expected << EOF
+          Type: ML-DSA-65
+          Algorithm: ML-DSA
+          EOF
+
+          sed -n \
+              -e 's/\s*\(Type:\s*\S\+\)\s*$/\1/p' \
+              -e 's/\s*\(Algorithm:\s*\S\+\)\s*$/\1/p' \
+              output > actual
 
           diff expected actual
 
@@ -537,9 +562,16 @@ jobs:
               nss-key-find \
               --nickname kra_storage | tee output
 
-          # key type should be ML-KEM
-          echo "ML-KEM-768" > expected
-          sed -n 's/\s*Type:\s*\(\S\+\)\s*$/\1/p' output > actual
+          # key type and algorithm should be ML-KEM
+          cat > expected << EOF
+          Type: ML-KEM-768
+          Algorithm: ML-KEM
+          EOF
+
+          sed -n \
+              -e 's/\s*\(Type:\s*\S\+\)\s*$/\1/p' \
+              -e 's/\s*\(Algorithm:\s*\S\+\)\s*$/\1/p' \
+              output > actual
 
           diff expected actual
 

--- a/base/server/src/main/java/com/netscape/cms/logging/LogFile.java
+++ b/base/server/src/main/java/com/netscape/cms/logging/LogFile.java
@@ -520,9 +520,7 @@ public class LogFile extends LogEventListener implements IExtendedPluginInfo {
             } else if (keyAlgorithm.equalsIgnoreCase("EC")) {
                 signatureAlgorithm = "SHA-256/EC";
 
-            } else if (keyAlgorithm.equalsIgnoreCase("ML-DSA-44")
-                    || keyAlgorithm.equalsIgnoreCase("ML-DSA-65")
-                    || keyAlgorithm.equalsIgnoreCase("ML-DSA-87")) {
+            } else if (keyAlgorithm.equalsIgnoreCase("ML-DSA")) {
                 signatureAlgorithm = keyAlgorithm;
 
             } else {


### PR DESCRIPTION
The `PK11PrivKey.getAlgorithm()` in JSS was updated recently to return the algorithm family name (e.g. `ML-DSA`) instead of the full algorithm name (e.g. `ML-DSA-<strength>`) which have caused the CA test with ML-DSA to fail due to `NoSuchAlgorithmException` in `LogFile.setupSigning()`.

The code has been modified to handle the algorithm family name properly so that the test will complete successfully.

The PKI CLI test with PQC has been updated to validate the key algorithm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added recognition of ML-DSA as a standalone cryptographic algorithm variant.

* **Chores**
  * Enhanced Post-Quantum Cryptography key validation to verify both key type and algorithm attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->