### PR TITLE
Add ML-KEM PQC support to hsmCompatVerify tools

### DIFF
--- a/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -667,7 +667,7 @@ public class CryptoUtil {
      * Performs ML-KEM encapsulation to generate a shared secret.
      *
      * @param publicKey ML-KEM public key
-     * @param keySize Derived key size in bytes (typically 32 for AES-256)
+     * @param keySize Derived key size in bits (e.g., 128 or 256 for AES)
      * @return KEMEncapsulation containing shared secret and ciphertext
      * @throws Exception if encapsulation fails
      */
@@ -675,25 +675,30 @@ public class CryptoUtil {
         if (publicKey == null) {
             throw new IllegalArgumentException("publicKey is null");
         }
-        if (keySize <= 0) {
-            throw new IllegalArgumentException("keySize must be positive");
+        // Max 512 bits for future-proofing (current max usage is AES-256)
+        if (keySize <= 0 || keySize > 512) {
+            throw new IllegalArgumentException("keySize must be between 1 and 512 bits");
+        }
+        if (keySize % 8 != 0) {
+            throw new IllegalArgumentException("keySize must be a multiple of 8");
         }
 
         logger.debug("CryptoUtil: ML-KEM encapsulation");
-        logger.debug("CryptoUtil: - Key size: " + keySize + " bytes");
+        logger.debug("CryptoUtil: - Key size: " + keySize + " bits");
 
+        int keySizeBytes = keySize / 8;
         javax.crypto.KEM kem = javax.crypto.KEM.getInstance("ML-KEM", "Mozilla-JSS");
         javax.crypto.KEM.Encapsulator encapsulator = kem.newEncapsulator(publicKey);
         javax.crypto.KEM.Encapsulated encapsulated = encapsulator.encapsulate(
-            0,          // offset
-            keySize,    // derived key size in bytes
-            "AES-ECB"   // algorithm for derived key
+            0,              // offset
+            keySizeBytes,   // derived key size in bytes
+            "AES-ECB"       // algorithm for derived key
         );
 
         SymmetricKey sharedSecret = (SymmetricKey) encapsulated.key();
         byte[] ciphertext = encapsulated.encapsulation();
 
-        logger.debug("CryptoUtil: - Shared secret size: " + keySize + " bytes");
+        logger.debug("CryptoUtil: - Shared secret size: " + keySizeBytes + " bytes");
         logger.debug("CryptoUtil: - Ciphertext size: " + ciphertext.length + " bytes");
 
         return new KEMEncapsulation(sharedSecret, ciphertext);
@@ -704,7 +709,7 @@ public class CryptoUtil {
      *
      * @param privateKey ML-KEM private key
      * @param ciphertext KEM ciphertext from encapsulation
-     * @param keySize Derived key size in bytes (must match encapsulation)
+     * @param keySize Derived key size in bits (must match encapsulation, e.g., 128 or 256)
      * @return Recovered shared secret (symmetric key)
      * @throws Exception if decapsulation fails
      */
@@ -719,21 +724,26 @@ public class CryptoUtil {
         if (ciphertext == null) {
             throw new IllegalArgumentException("ciphertext is null");
         }
-        if (keySize <= 0) {
-            throw new IllegalArgumentException("keySize must be positive");
+        // Max 512 bits for future-proofing (current max usage is AES-256)
+        if (keySize <= 0 || keySize > 512) {
+            throw new IllegalArgumentException("keySize must be between 1 and 512 bits");
+        }
+        if (keySize % 8 != 0) {
+            throw new IllegalArgumentException("keySize must be a multiple of 8");
         }
 
         logger.debug("CryptoUtil: ML-KEM decapsulation");
-        logger.debug("CryptoUtil: - Key size: " + keySize + " bytes");
+        logger.debug("CryptoUtil: - Key size: " + keySize + " bits");
         logger.debug("CryptoUtil: - Ciphertext size: " + ciphertext.length + " bytes");
 
+        int keySizeBytes = keySize / 8;
         javax.crypto.KEM kem = javax.crypto.KEM.getInstance("ML-KEM", "Mozilla-JSS");
         javax.crypto.KEM.Decapsulator decapsulator = kem.newDecapsulator(privateKey);
         SymmetricKey sharedSecret = (SymmetricKey) decapsulator.decapsulate(
             ciphertext,
-            0,          // offset
-            keySize,    // derived key size in bytes
-            "AES-ECB"   // algorithm for derived key
+            0,              // offset
+            keySizeBytes,   // derived key size in bytes
+            "AES-ECB"       // algorithm for derived key
         );
 
         logger.debug("CryptoUtil: - Shared secret recovered");

--- a/base/tools/src/main/java/com/netscape/cmstools/hsmCompatVerifyClnt.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/hsmCompatVerifyClnt.java
@@ -132,11 +132,17 @@ public class hsmCompatVerifyClnt {
             String outputPrefix = cmd.getOptionValue("output", defaultOutput);
 
             // Optional parameters
-            String algorithm = cmd.getOptionValue("algorithm", DEFAULT_ALGORITHM);
+            boolean pqcMode = cmd.hasOption("pqc");
+            String pqcKemAlgorithm = cmd.getOptionValue("pqc-kem-algorithm", "mlkem768");
+
+            // User key type: controls what type of user key to generate (separate from transport)
+            String userKeyType = cmd.getOptionValue("user-key-type", pqcMode ? "ML-KEM" : DEFAULT_ALGORITHM);
+            String algorithm = userKeyType; // For backward compatibility with existing code
             int keyLength = Integer.parseInt(cmd.getOptionValue("l", String.valueOf(DEFAULT_KEY_LENGTH)));
             String curve = cmd.getOptionValue("c", "nistp256");
             boolean sslECDH = Boolean.parseBoolean(cmd.getOptionValue("x", "false"));
-            boolean temporary = Boolean.parseBoolean(cmd.getOptionValue("t", algorithm.equalsIgnoreCase("rsa") ? "false" : "true"));
+            boolean temporary = Boolean.parseBoolean(cmd.getOptionValue("t",
+                algorithm.equalsIgnoreCase("rsa") ? "false" : "true"));
             int sensitive = Integer.parseInt(cmd.getOptionValue("s", "-1"));
             int extractable = Integer.parseInt(cmd.getOptionValue("e", "-1"));
             String keywrapAlg = cmd.getOptionValue("w", DEFAULT_KEYWRAP_ALG);
@@ -149,31 +155,53 @@ public class hsmCompatVerifyClnt {
             System.out.println("  --client-db-path " + clientDB);
             System.out.println("  --transport-cert " + transportCertFile);
             System.out.println("  --output " + outputPrefix);
-            System.out.println("  --algorithm " + algorithm);
-            if (algorithm.equalsIgnoreCase("rsa")) {
+
+            if (pqcMode) {
+                System.out.println("  --pqc (PQC mode enabled - ML-KEM transport/storage)");
+                System.out.println("  --pqc-kem-algorithm " + pqcKemAlgorithm);
+            }
+
+            System.out.println("  --user-key-type " + userKeyType);
+            if (userKeyType.equalsIgnoreCase("ML-KEM")) {
+                System.out.println("    User key: ML-KEM-" + pqcKemAlgorithm.replace("mlkem", ""));
+            } else if (userKeyType.equalsIgnoreCase("rsa")) {
                 System.out.println("  --key-length " + keyLength);
-            } else {
+            } else if (userKeyType.equalsIgnoreCase("ec")) {
                 System.out.println("  --curve " + curve);
                 if (sslECDH) {
                     System.out.println("  --ssl-ecdh " + sslECDH);
                 }
             }
+
             System.out.println("  --temporary " + temporary);
             System.out.println("  --sensitive " + sensitive);
             System.out.println("  --extractable " + extractable);
-            System.out.println("  --keywrap-alg \"" + keywrapAlg + "\"");
-            System.out.println("  RSA session key wrap: " + (useOAEP ? "RSA-OAEP" : "RSA (PKCS#1 v1.5)"));
-            if (useOAEP) {
-                System.out.println("  --oaep");
+
+            if (!pqcMode) {
+                System.out.println("  --keywrap-alg \"" + keywrapAlg + "\"");
+                System.out.println("  RSA session key wrap: " + (useOAEP ? "RSA-OAEP" : "RSA (PKCS#1 v1.5)"));
+                if (useOAEP) {
+                    System.out.println("  --oaep");
+                }
+            } else {
+                System.out.println("  Key archival: ML-KEM encapsulation (no session key wrap)");
             }
+
             System.out.println("  --verbose " + (verbose ? "enabled" : "disabled"));
             System.out.println();
 
             hsmCompatVerifyClnt client = new hsmCompatVerifyClnt();
             client.autoYes = autoYes;
-            client.run(clientDB, clientPasswd, transportCertFile, outputPrefix,
-                      algorithm, keyLength, curve, sslECDH, temporary, sensitive, extractable,
-                      keywrapAlg, useOAEP, verbose);
+
+            if (pqcMode) {
+                client.runArchivalPQC(clientDB, clientPasswd, transportCertFile, outputPrefix,
+                                     userKeyType, pqcKemAlgorithm, keyLength, curve, sslECDH,
+                                     temporary, sensitive, extractable, verbose);
+            } else {
+                client.runArchival(clientDB, clientPasswd, transportCertFile, outputPrefix,
+                                  algorithm, keyLength, curve, sslECDH, temporary, sensitive, extractable,
+                                  keywrapAlg, useOAEP, verbose);
+            }
 
         } catch (Exception e) {
             System.err.println();
@@ -245,7 +273,27 @@ public class hsmCompatVerifyClnt {
         option.setArgName("boolean");
         options.addOption(option);
 
-        option = new Option("t", "temporary", true, "Temporary (default: true for EC, false for RSA)");
+        // PQC Options
+        options.addOption(Option.builder()
+                .longOpt("pqc")
+                .desc("Enable PQC mode (ML-KEM for transport/storage)")
+                .build());
+
+        options.addOption(Option.builder()
+                .longOpt("pqc-kem-algorithm")
+                .hasArg()
+                .argName("algorithm")
+                .desc("PQC KEM algorithm for transport/storage: mlkem512, mlkem768, mlkem1024 (default: mlkem768)")
+                .build());
+
+        options.addOption(Option.builder()
+                .longOpt("user-key-type")
+                .hasArg()
+                .argName("type")
+                .desc("User key type: RSA, EC, ML-KEM (default: ML-KEM if --pqc, RSA otherwise)")
+                .build());
+
+        option = new Option("t", "temporary", true, "Temporary (default: true for EC/ML-KEM, false for RSA)");
         option.setArgName("boolean");
         options.addOption(option);
 
@@ -317,15 +365,11 @@ public class hsmCompatVerifyClnt {
                 true);
     }
 
-    private void run(String clientDB, String clientPasswd, String transportCertFile,
-                     String outputPrefix, String algorithm, int keyLength, String curve,
-                     boolean sslECDH, boolean temporary, int sensitive, int extractable,
-                     String keywrapAlg, boolean useOAEP, boolean verbose) throws Exception {
-
-        log("=== KRA Compatibility Verification - Client Side ===", verbose);
-        log("Generating keys and creating wrapped output for KRA archival testing", verbose);
-        log("", verbose);
-
+    /**
+     * Helper method: Initialize NSS database and login
+     * @return CryptoToken (internal key storage token)
+     */
+    private CryptoToken initializeNSSDatabase(String clientDB, String clientPasswd, boolean verbose) throws Exception {
         // Check if client NSS database exists
         java.io.File clientDBDir = new java.io.File(clientDB);
         if (!clientDBDir.exists()) {
@@ -338,7 +382,6 @@ public class hsmCompatVerifyClnt {
         }
 
         // Step 1: Initialize NSS
-        // Adopted from: CRMFPopClient.java (NSS initialization)
         log("Step 1: Initializing client NSS database", verbose);
         log("  Client DB: " + clientDB, verbose);
         org.mozilla.jss.CryptoManager.initialize(clientDB);
@@ -368,7 +411,6 @@ public class hsmCompatVerifyClnt {
             log("", verbose);
 
             // Ask if user wants to delete existing and regenerate (default: No, keep existing)
-            // With --yes flag, promptYesNo automatically returns true (delete and regenerate)
             if (promptYesNo("Delete existing and regenerate? (y/n, 'n' keeps existing): ")) {
                 log("Deleting existing keys and certificates...", verbose);
 
@@ -402,8 +444,16 @@ public class hsmCompatVerifyClnt {
             }
         }
 
-        // Step 2: Load transport certificate
-        // Adopted from: CRMFPopClient.java (loading transport cert for key archival)
+        return token;
+    }
+
+    /**
+     * Helper method: Load transport certificate from PEM file
+     * @return X509Certificate (transport certificate)
+     */
+    private org.mozilla.jss.crypto.X509Certificate loadTransportCertificate(
+            String transportCertFile, boolean verbose) throws Exception {
+
         log("", verbose);
         log("Step 2: Loading KRA transport certificate", verbose);
         log("  Transport cert: " + transportCertFile, verbose);
@@ -431,9 +481,29 @@ public class hsmCompatVerifyClnt {
         } else {
             transportCertData = certBytes;
         }
+
+        org.mozilla.jss.CryptoManager manager = org.mozilla.jss.CryptoManager.getInstance();
         org.mozilla.jss.crypto.X509Certificate transportCert = manager.importCACertPackage(transportCertData);
-        log("  - Transport certificate loaded", verbose);
+        log("  - Transport certificate imported", verbose);
         log("    Subject: " + transportCert.getSubjectDN(), verbose);
+
+        return transportCert;
+    }
+
+    private void runArchival(String clientDB, String clientPasswd, String transportCertFile,
+                            String outputPrefix, String algorithm, int keyLength, String curve,
+                            boolean sslECDH, boolean temporary, int sensitive, int extractable,
+                            String keywrapAlg, boolean useOAEP, boolean verbose) throws Exception {
+
+        log("=== KRA Compatibility Verification - Client Side ===", verbose);
+        log("Generating keys and creating wrapped output for KRA archival testing", verbose);
+        log("", verbose);
+
+        // Step 1: Initialize NSS (using helper method)
+        CryptoToken token = initializeNSSDatabase(clientDB, clientPasswd, verbose);
+
+        // Step 2: Load transport certificate (using helper method)
+        org.mozilla.jss.crypto.X509Certificate transportCert = loadTransportCertificate(transportCertFile, verbose);
 
         // Step 3: Generate key pair
         // Adopted from: CRMFPopClient.java (key pair generation)
@@ -557,6 +627,165 @@ public class hsmCompatVerifyClnt {
         log("", verbose);
         log("Next step:", verbose);
         log("  Run hsmCompatVerifyServ to verify HSM archival/recovery with these files", verbose);
+    }
+
+    private void runArchivalPQC(String clientDB, String clientPasswd, String transportCertFile,
+                                String outputPrefix, String userKeyType, String kemAlgorithm,
+                                int keyLength, String curve, boolean sslECDH, boolean temporary,
+                                int sensitive, int extractable, boolean verbose) throws Exception {
+
+        log("=== KRA Compatibility Verification - Client Side (PQC) ===", verbose);
+        log("Transport/Storage: ML-KEM-" + kemAlgorithm.replace("mlkem", ""), verbose);
+        log("User key type: " + userKeyType, verbose);
+        log("Generating user keys with ML-KEM transport and creating wrapped output for KRA archival testing", verbose);
+        log("", verbose);
+
+        // Step 1: Initialize NSS (using helper method)
+        CryptoToken token = initializeNSSDatabase(clientDB, clientPasswd, verbose);
+
+        // Step 2: Load transport certificate (using helper method)
+        org.mozilla.jss.crypto.X509Certificate transportCert = loadTransportCertificate(transportCertFile, verbose);
+
+        // Import the transport public key into the token as a PKCS#11 object
+        // This is necessary for ML-KEM encapsulation to work properly
+        java.security.PublicKey transportPubKey = transportCert.getPublicKey();
+        token.importPublicKey(transportPubKey, false);  // false = not permanent
+        log("  - Transport public key imported into token", verbose);
+
+        // Step 3: Generate user key pair (RSA, EC, or ML-KEM)
+        log("", verbose);
+        log("Step 3: Generating user key pair", verbose);
+        log("  Algorithm: " + userKeyType, verbose);
+
+        KeyPair keyPair;
+        if ("RSA".equalsIgnoreCase(userKeyType)) {
+            log("  Key length: " + keyLength, verbose);
+            log("  Temporary: " + temporary, verbose);
+            log("  Sensitive: " + sensitive, verbose);
+            log("  Extractable: " + extractable, verbose);
+            keyPair = CryptoUtil.generateRSAKeyPair(
+                    token,
+                    keyLength,
+                    temporary,
+                    sensitive == -1 ? null : sensitive == 1,
+                    extractable == -1 ? null : extractable == 1,
+                    null,  // usages - let token decide
+                    null); // usagesMask - let token decide
+        } else if ("EC".equalsIgnoreCase(userKeyType)) {
+            log("  Curve: " + curve, verbose);
+            log("  SSL ECDH: " + sslECDH, verbose);
+            log("  Temporary: " + temporary, verbose);
+            log("  Sensitive: " + sensitive, verbose);
+            log("  Extractable: " + extractable, verbose);
+            keyPair = CryptoUtil.generateECCKeyPair(
+                    token,
+                    curve,
+                    temporary,
+                    sensitive == -1 ? null : sensitive == 1,
+                    extractable == -1 ? null : extractable == 1,
+                    null,  // usages - let token decide
+                    sslECDH ? CryptoUtil.ECDH_USAGES_MASK : CryptoUtil.ECDHE_USAGES_MASK); // usagesMask
+        } else if ("ML-KEM".equalsIgnoreCase(userKeyType)) {
+            log("  Algorithm: ML-KEM-" + kemAlgorithm.replace("mlkem", ""), verbose);
+
+            // Map algorithm to size
+            int kemParamSize;
+            switch (kemAlgorithm.toLowerCase()) {
+                case "mlkem512":
+                    kemParamSize = 512;
+                    break;
+                case "mlkem768":
+                    kemParamSize = 768;
+                    break;
+                case "mlkem1024":
+                    kemParamSize = 1024;
+                    break;
+                default:
+                    throw new Exception("Unsupported ML-KEM algorithm: " + kemAlgorithm);
+            }
+
+            log("  Temporary: " + temporary, verbose);
+            log("  Sensitive: " + sensitive, verbose);
+            log("  Extractable: " + extractable, verbose);
+
+            KeyPairGenerator keygen = token.getKeyPairGenerator(KeyPairAlgorithm.MLKEM);
+            keygen.initialize(kemParamSize);
+            if (temporary) {
+                keygen.temporaryPairs(true);
+            }
+            // TODO: Add sensitive/extractable flags when JSS supports them for ML-KEM
+            keyPair = keygen.genKeyPair();
+        } else {
+            throw new IllegalArgumentException(
+                    "Unsupported --user-key-type value: " + userKeyType + ". Valid values: RSA, EC, ML-KEM");
+        }
+        log("  - Key pair generated", verbose);
+
+        // Step 4: ML-KEM Encapsulation
+        log("", verbose);
+        log("Step 4: ML-KEM encapsulation for archival", verbose);
+        log("  Using transport public key for encapsulation", verbose);
+
+        javax.crypto.KEM kem = javax.crypto.KEM.getInstance("ML-KEM", "Mozilla-JSS");
+        javax.crypto.KEM.Encapsulator encapsulator = kem.newEncapsulator(transportPubKey);
+
+        // Encapsulate: generate 32-byte (256-bit) shared secret for AES-256 key wrapping
+        javax.crypto.KEM.Encapsulated encapsulated = encapsulator.encapsulate(0, 32, "AES-ECB");
+        org.mozilla.jss.crypto.SymmetricKey sharedSecret = (org.mozilla.jss.crypto.SymmetricKey) encapsulated.key();
+        byte[] kemCiphertext = encapsulated.encapsulation();
+
+        log("  - ML-KEM encapsulation completed", verbose);
+        log("    Shared secret size: 32 bytes (AES-256)", verbose);
+        log("    KEM ciphertext size: " + kemCiphertext.length + " bytes", verbose);
+
+        // Step 5: Wrap user's private key with shared secret using AES-KWP
+        log("", verbose);
+        log("Step 5: Wrapping private key with ML-KEM shared secret", verbose);
+        log("  Using AES-KWP (Key Wrap with Padding)", verbose);
+
+        byte[] wrappedPrivateKey = CryptoUtil.wrapUsingSymmetricKey(
+            token,
+            sharedSecret,
+            (org.mozilla.jss.crypto.PrivateKey) keyPair.getPrivate(),
+            null,  // No IV for AES-KWP
+            org.mozilla.jss.crypto.KeyWrapAlgorithm.AES_KEY_WRAP_PAD_KWP
+        );
+
+        log("  - Private key wrapped", verbose);
+        log("    Wrapped key size: " + wrappedPrivateKey.length + " bytes", verbose);
+
+        // Step 6: Write output files
+        log("", verbose);
+        log("Step 6: Writing output files", verbose);
+
+        String kemCiphertextFile = outputPrefix + "-kem-ciphertext.bin";
+        String wrappedPrivateFile = outputPrefix + "-wrapped-private.bin";
+        String publicKeyFile = outputPrefix + "-public.der";
+
+        try (FileOutputStream fos = new FileOutputStream(kemCiphertextFile)) {
+            fos.write(kemCiphertext);
+        }
+        log("  - Wrote: " + kemCiphertextFile + " (" + kemCiphertext.length + " bytes)", verbose);
+
+        try (FileOutputStream fos = new FileOutputStream(wrappedPrivateFile)) {
+            fos.write(wrappedPrivateKey);
+        }
+        log("  - Wrote: " + wrappedPrivateFile + " (" + wrappedPrivateKey.length + " bytes)", verbose);
+
+        PublicKey publicKey = keyPair.getPublic();
+        try (FileOutputStream fos = new FileOutputStream(publicKeyFile)) {
+            fos.write(publicKey.getEncoded());
+        }
+        log("  - Wrote: " + publicKeyFile + " (" + publicKey.getEncoded().length + " bytes)", verbose);
+
+        log("", verbose);
+        log("SUCCESS: Client-side ML-KEM key generation and archival completed!", verbose);
+        log("", verbose);
+        log("Next step:", verbose);
+        log("  Run hsmCompatVerifyServ --pqc to simulate KRA archival:", verbose);
+        log("    - Decapsulate using transport private key", verbose);
+        log("    - Re-encapsulate using storage public key", verbose);
+        log("    - Generate LDIF for archival verification", verbose);
     }
 
     private void log(String message, boolean verbose) {

--- a/base/tools/src/main/java/com/netscape/cmstools/hsmCompatVerifyServ.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/hsmCompatVerifyServ.java
@@ -135,6 +135,9 @@ public class hsmCompatVerifyServ {
 
     public static final String TOOL_NAME = "hsmCompatVerifyServ";
 
+    // Hidden test flag: decrypt wrapped user private key to raw bytes (for debugging)
+    private static boolean testDecryptUser = false;
+
     // Default key usage flags for transport and storage keys (matches standard KRA behavior)
     // Based on: base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java:RSA_KEYPAIR_USAGES
     private static final String DEFAULT_OPFLAGS = "encrypt,decrypt,wrap,unwrap,sign,sign_recover";
@@ -193,6 +196,21 @@ public class hsmCompatVerifyServ {
         // Setup Control
         options.addOption(null, "setup-only", false, "Only run setup, don't test");
         options.addOption(null, "yes", false, "Automatically regenerate existing certificates without prompting (non-interactive)");
+
+        // PQC Options
+        options.addOption(null, "pqc", false, "Enable PQC mode (ML-DSA for CA, ML-KEM for KRA)");
+
+        option = new Option(null, "pqc-ca-algorithm", true, "PQC CA algorithm: ml-dsa-44, ml-dsa-65, ml-dsa-87 (default: ml-dsa-65)");
+        option.setArgName("algorithm");
+        options.addOption(option);
+
+        option = new Option(null, "pqc-kem-algorithm", true, "PQC KEM algorithm: ml-kem-512, ml-kem-768, ml-kem-1024 (default: ml-kem-768)");
+        option.setArgName("algorithm");
+        options.addOption(option);
+
+        option = new Option(null, "user-key-type", true, "User key type: RSA, EC, ML-KEM (default: ML-KEM if --pqc, RSA otherwise)");
+        option.setArgName("type");
+        options.addOption(option);
 
         // CA Options
         option = new Option(null, "ca-key-algorithm", true, "CA key algorithm: rsa or ec (default: rsa)");
@@ -268,6 +286,10 @@ public class hsmCompatVerifyServ {
         option.setArgName("file");
         options.addOption(option);
 
+        option = new Option(null, "kem-ciphertext", true, "KEM ciphertext file (from hsmCompatVerifyClnt --pqc)");
+        option.setArgName("file");
+        options.addOption(option);
+
         option = new Option(null, "wrapped-private", true, "Wrapped private key file (from hsmCompatVerifyClnt)");
         option.setArgName("file");
         options.addOption(option);
@@ -340,7 +362,9 @@ public class hsmCompatVerifyServ {
         option.setArgName("type");
         options.addOption(option);
 
-        options.addOption(null, "legacyPKCS12", false, "Use legacy PKCS#12 format (PBE_SHA1_DES3_CBC). Default: non-legacy (AES-256-KWP)");
+        option = new Option(null, "pkcs12-mode", true, "PKCS#12 encryption mode: kwp (AES-KWP, default), cbc (AES-256-CBC), or legacy (3DES-CBC)");
+        option.setArgName("mode");
+        options.addOption(option);
 
         options.addOption("v", "verbose", false, "Run in verbose mode");
         options.addOption(null, "help", false, "Show help message");
@@ -366,6 +390,12 @@ public class hsmCompatVerifyServ {
         System.out.println("Setup Control:");
         System.out.println("      --setup-only              Only run setup, don't verify");
         System.out.println("      --yes                     Automatically regenerate existing certificates (non-interactive)");
+        System.out.println();
+        System.out.println("PQC Options:");
+        System.out.println("      --pqc                     Enable PQC mode (ML-DSA for CA, ML-KEM for transport/storage)");
+        System.out.println("      --pqc-ca-algorithm <alg>  PQC CA algorithm: ml-dsa-44, ml-dsa-65, ml-dsa-87 (default: ml-dsa-65)");
+        System.out.println("      --pqc-kem-algorithm <alg> PQC KEM algorithm for transport/storage: ml-kem-512, ml-kem-768, ml-kem-1024 (default: ml-kem-768)");
+        System.out.println("      --user-key-type <type>    User key type: RSA, EC, ML-KEM (default: ML-KEM if --pqc, RSA otherwise)");
         System.out.println();
         System.out.println("CA Certificate Options:");
         System.out.println("      --ca-key-algorithm <alg>  CA key algorithm: rsa or ec (default: rsa)");
@@ -485,6 +515,14 @@ public class hsmCompatVerifyServ {
     }
 
     public static void main(String args[]) throws Exception {
+        // Check for hidden test flag (not shown in --help)
+        for (String arg : args) {
+            if ("--test-decrypt-user".equals(arg)) {
+                testDecryptUser = true;
+                break;
+            }
+        }
+
         Options options = createOptions();
         CommandLine cmd = null;
 
@@ -508,7 +546,40 @@ public class hsmCompatVerifyServ {
         boolean autoYes = cmd.hasOption("yes");
         boolean archiveOnly = cmd.hasOption("archive-only");
         boolean recoverOnly = cmd.hasOption("recover-only");
-        boolean legacyPKCS12 = cmd.hasOption("legacyPKCS12");
+
+        // PKCS#12 mode: kwp (default), cbc, or legacy
+        String pkcs12Mode = cmd.getOptionValue("pkcs12-mode", "kwp").toLowerCase();
+        if (!pkcs12Mode.equals("kwp") && !pkcs12Mode.equals("cbc") && !pkcs12Mode.equals("legacy")) {
+            System.err.println("ERROR: Invalid --pkcs12-mode value: " + pkcs12Mode);
+            System.err.println("Valid values: kwp, cbc, legacy");
+            return;
+        }
+
+        // PQC options
+        boolean pqcMode = cmd.hasOption("pqc");
+        String pqcCaAlgorithm = cmd.getOptionValue("pqc-ca-algorithm", "ml-dsa-65");
+        String pqcKemAlgorithm = cmd.getOptionValue("pqc-kem-algorithm", "ml-kem-768");
+
+        // User key type: controls what type of user key to expect (separate from transport)
+        String userKeyType = cmd.getOptionValue("user-key-type", pqcMode ? "ML-KEM" : "RSA");
+
+        // Validate PQC algorithm values
+        if (pqcMode) {
+            if (!pqcCaAlgorithm.equals("ml-dsa-44") &&
+                !pqcCaAlgorithm.equals("ml-dsa-65") &&
+                !pqcCaAlgorithm.equals("ml-dsa-87")) {
+                printError("Invalid --pqc-ca-algorithm value: " + pqcCaAlgorithm);
+                System.err.println("       Valid values: ml-dsa-44, ml-dsa-65, ml-dsa-87");
+                System.exit(1);
+            }
+            if (!pqcKemAlgorithm.equals("ml-kem-512") &&
+                !pqcKemAlgorithm.equals("ml-kem-768") &&
+                !pqcKemAlgorithm.equals("ml-kem-1024")) {
+                printError("Invalid --pqc-kem-algorithm value: " + pqcKemAlgorithm);
+                System.err.println("       Valid values: ml-kem-512, ml-kem-768, ml-kem-1024");
+                System.exit(1);
+            }
+        }
 
         // Validate rsa-keywrap value
         if (!rsaKeywrap.equals("RSA") && !rsaKeywrap.equals("RSA-OAEP")) {
@@ -556,17 +627,20 @@ public class hsmCompatVerifyServ {
         String caKeySize = cmd.getOptionValue("ca-key-size");
         String caSubject = cmd.getOptionValue("ca-subject", "CN=Test CA,O=Dogtag");
         int caValidity = Integer.parseInt(cmd.getOptionValue("ca-validity", "3650"));
-        String caNickname = cmd.getOptionValue("ca-nickname", "test CA Signing Certificate");
+        String caNickname = cmd.getOptionValue("ca-nickname",
+            pqcMode ? "test PQC CA Signing Certificate" : "test CA Signing Certificate");
 
         // Transport options
         String transportSubject = cmd.getOptionValue("transport-subject", "CN=test KRA Transport,O=Dogtag");
         int transportValidity = Integer.parseInt(cmd.getOptionValue("transport-validity", "365"));
-        String transportNickname = cmd.getOptionValue("transport-nickname", "test KRA Transport Certificate");
+        String transportNickname = cmd.getOptionValue("transport-nickname",
+            pqcMode ? "test PQC KRA Transport Certificate" : "test KRA Transport Certificate");
 
         // Storage options
         String storageSubject = cmd.getOptionValue("storage-subject", "CN=test KRA Storage,O=Dogtag");
         int storageValidity = Integer.parseInt(cmd.getOptionValue("storage-validity", "365"));
-        String storageNickname = cmd.getOptionValue("storage-nickname", "test KRA Storage Certificate");
+        String storageNickname = cmd.getOptionValue("storage-nickname",
+            pqcMode ? "test PQC KRA Storage Certificate" : "test KRA Storage Certificate");
 
         // Key usage options (for HSM-specific requirements)
         String transportOpFlagsStr = cmd.getOptionValue("transport-opflags", DEFAULT_OPFLAGS);
@@ -581,7 +655,9 @@ public class hsmCompatVerifyServ {
         String ldifFile = cmd.getOptionValue("ldif-file", clientDB + "/kra-archived-key.ldif");
 
         // Test input files (from hsmCompatVerifyClnt)
+        // For PQC mode: uses kem-ciphertext instead of wrapped-session
         String wrappedSessionFile = cmd.getOptionValue("wrapped-session", clientDB + "/kra-test-wrapped-session.bin");
+        String kemCiphertextFile = cmd.getOptionValue("kem-ciphertext", clientDB + "/kra-test-kem-ciphertext.bin");
         String wrappedPrivateFile = cmd.getOptionValue("wrapped-private", clientDB + "/kra-test-wrapped-private.bin");
         String publicKeyFile = cmd.getOptionValue("public-key", clientDB + "/kra-test-public.der");
         String ivFile = cmd.getOptionValue("iv-file", clientDB + "/kra-test-iv.bin");
@@ -599,12 +675,6 @@ public class hsmCompatVerifyServ {
         String outputFile = cmd.getOptionValue("o");
         if (outputFile == null) {
             outputFile = clientDB + "/kra-recovered.p12";
-        } else {
-            // If relative path, resolve it relative to client-db-path
-            java.io.File outputFileObj = new java.io.File(outputFile);
-            if (!outputFileObj.isAbsolute()) {
-                outputFile = clientDB + "/" + outputFile;
-            }
         }
         String recoveryPasswd = cmd.getOptionValue("r");
         String recoveryPasswdFile = cmd.getOptionValue("recovery-passwd-file");
@@ -657,10 +727,20 @@ public class hsmCompatVerifyServ {
                 }
             } else {
                 // Archive mode (with or without recovery) - check that wrapped key files exist
-                if (!new java.io.File(wrappedSessionFile).exists()) {
-                    printError("Wrapped session key file not found: " + wrappedSessionFile + "\n" +
-                              "Run hsmCompatVerifyClnt first to generate test keys.");
-                    System.exit(1);
+                if (pqcMode) {
+                    // PQC mode: check for KEM ciphertext instead of wrapped session key
+                    if (!new java.io.File(kemCiphertextFile).exists()) {
+                        printError("KEM ciphertext file not found: " + kemCiphertextFile + "\n" +
+                                  "Run hsmCompatVerifyClnt --pqc first to generate test keys.");
+                        System.exit(1);
+                    }
+                } else {
+                    // Non-PQC mode: check for wrapped session key
+                    if (!new java.io.File(wrappedSessionFile).exists()) {
+                        printError("Wrapped session key file not found: " + wrappedSessionFile + "\n" +
+                                  "Run hsmCompatVerifyClnt first to generate test keys.");
+                        System.exit(1);
+                    }
                 }
                 if (!new java.io.File(wrappedPrivateFile).exists()) {
                     printError("Wrapped private key file not found: " + wrappedPrivateFile + "\n" +
@@ -690,46 +770,83 @@ public class hsmCompatVerifyServ {
             tool.setAutoYes(autoYes);
 
             if (setupOnly) {
-                // Print setup configuration
-                System.out.println("=== hsmCompatVerifyServ Setup Configuration ===");
-                System.out.println("Parameters (including defaults):");
-                System.out.println("  --setup-only");
-                System.out.println("  --pkiserv-db-path " + pkiservDB);
-                System.out.println("  --hsm-token \"" + hsmToken + "\"");
-                System.out.println("  --ca-key-algorithm " + caKeyAlgorithm);
-                if (caKeySize != null) {
-                    System.out.println("  --ca-key-size " + caKeySize);
-                } else {
-                    System.out.println("  --ca-key-size " + (caKeyAlgorithm.equalsIgnoreCase("ec") ? "nistp256" : "4096") + " (default)");
-                }
-                System.out.println("  --ca-subject \"" + caSubject + "\"");
-                System.out.println("  --ca-validity " + caValidity);
-                System.out.println("  --ca-nickname \"" + caNickname + "\"");
-                System.out.println("  --transport-subject \"" + transportSubject + "\"");
-                System.out.println("  --transport-validity " + transportValidity);
-                System.out.println("  --transport-nickname \"" + transportNickname + "\"");
-                System.out.println("  --transport-opflags \"" + transportOpFlagsStr + "\"");
-                System.out.println("  --storage-subject \"" + storageSubject + "\"");
-                System.out.println("  --storage-validity " + storageValidity);
-                System.out.println("  --storage-nickname \"" + storageNickname + "\"");
-                System.out.println("  --storage-opflags \"" + storageOpFlagsStr + "\"");
-                if (autoYes) {
-                    System.out.println("  --yes");
-                }
-                System.out.println("  --verbose " + (verbose ? "enabled" : "disabled"));
-                System.out.println();
+                if (pqcMode) {
+                    // PQC Setup
+                    System.out.println("=== hsmCompatVerifyServ PQC Setup Configuration ===");
+                    System.out.println("Parameters (including defaults):");
+                    System.out.println("  --setup-only");
+                    System.out.println("  --pqc");
+                    System.out.println("  --pkiserv-db-path " + pkiservDB);
+                    System.out.println("  --hsm-token \"" + hsmToken + "\"");
+                    System.out.println("  --pqc-ca-algorithm " + pqcCaAlgorithm);
+                    System.out.println("  --pqc-kem-algorithm " + pqcKemAlgorithm);
+                    System.out.println("  --ca-subject \"" + caSubject + "\"");
+                    System.out.println("  --ca-validity " + caValidity);
+                    System.out.println("  --ca-nickname \"" + caNickname + "\"");
+                    System.out.println("  --transport-subject \"" + transportSubject + "\"");
+                    System.out.println("  --transport-validity " + transportValidity);
+                    System.out.println("  --transport-nickname \"" + transportNickname + "\"");
+                    System.out.println("  --storage-subject \"" + storageSubject + "\"");
+                    System.out.println("  --storage-validity " + storageValidity);
+                    System.out.println("  --storage-nickname \"" + storageNickname + "\"");
+                    if (autoYes) {
+                        System.out.println("  --yes");
+                    }
+                    System.out.println("  --verbose " + (verbose ? "enabled" : "disabled"));
+                    System.out.println();
 
-                tool.runSetup(
-                    pkiservDB, pkiservPasswd,
-                    hsmToken, hsmTokenPasswd,
-                    caKeyAlgorithm, caKeySize, caSubject, caValidity, caNickname,
-                    transportSubject, transportValidity, transportNickname,
-                    transportOpFlagsStr, transportOpFlagsMaskStr,
-                    storageSubject, storageValidity, storageNickname,
-                    storageOpFlagsStr, storageOpFlagsMaskStr
-                );
-                System.out.println();
-                System.out.println("SUCCESS: Setup completed!");
+                    tool.runSetupPQC(
+                        pkiservDB, pkiservPasswd,
+                        hsmToken, hsmTokenPasswd,
+                        pqcCaAlgorithm, pqcKemAlgorithm,
+                        caSubject, caValidity, caNickname,
+                        transportSubject, transportValidity, transportNickname,
+                        storageSubject, storageValidity, storageNickname
+                    );
+                    System.out.println();
+                    System.out.println("SUCCESS: PQC Setup completed!");
+                } else {
+                    // Traditional RSA/EC Setup
+                    System.out.println("=== hsmCompatVerifyServ Setup Configuration ===");
+                    System.out.println("Parameters (including defaults):");
+                    System.out.println("  --setup-only");
+                    System.out.println("  --pkiserv-db-path " + pkiservDB);
+                    System.out.println("  --hsm-token \"" + hsmToken + "\"");
+                    System.out.println("  --ca-key-algorithm " + caKeyAlgorithm);
+                    if (caKeySize != null) {
+                        System.out.println("  --ca-key-size " + caKeySize);
+                    } else {
+                        System.out.println("  --ca-key-size " + (caKeyAlgorithm.equalsIgnoreCase("ec") ? "nistp256" : "4096") + " (default)");
+                    }
+                    System.out.println("  --ca-subject \"" + caSubject + "\"");
+                    System.out.println("  --ca-validity " + caValidity);
+                    System.out.println("  --ca-nickname \"" + caNickname + "\"");
+                    System.out.println("  --transport-subject \"" + transportSubject + "\"");
+                    System.out.println("  --transport-validity " + transportValidity);
+                    System.out.println("  --transport-nickname \"" + transportNickname + "\"");
+                    System.out.println("  --transport-opflags \"" + transportOpFlagsStr + "\"");
+                    System.out.println("  --storage-subject \"" + storageSubject + "\"");
+                    System.out.println("  --storage-validity " + storageValidity);
+                    System.out.println("  --storage-nickname \"" + storageNickname + "\"");
+                    System.out.println("  --storage-opflags \"" + storageOpFlagsStr + "\"");
+                    if (autoYes) {
+                        System.out.println("  --yes");
+                    }
+                    System.out.println("  --verbose " + (verbose ? "enabled" : "disabled"));
+                    System.out.println();
+
+                    tool.runSetup(
+                        pkiservDB, pkiservPasswd,
+                        hsmToken, hsmTokenPasswd,
+                        caKeyAlgorithm, caKeySize, caSubject, caValidity, caNickname,
+                        transportSubject, transportValidity, transportNickname,
+                        transportOpFlagsStr, transportOpFlagsMaskStr,
+                        storageSubject, storageValidity, storageNickname,
+                        storageOpFlagsStr, storageOpFlagsMaskStr
+                    );
+                    System.out.println();
+                    System.out.println("SUCCESS: Setup completed!");
+                }
             } else {
                 // Print test configuration
                 System.out.println("=== hsmCompatVerifyServ Verification Configuration ===");
@@ -757,28 +874,64 @@ public class hsmCompatVerifyServ {
                     System.out.println("  --p12-output " + outputFile);
                 }
                 System.out.println("  --keywrap-alg \"" + keywrapAlg + "\"");
-                System.out.println("  --rsa-keywrap " + rsaKeywrap);
+                if (!pqcMode) {
+                    System.out.println("  --rsa-keywrap " + rsaKeywrap);
+                }
+                if (pqcMode) {
+                    System.out.println("  --pqc");
+                    System.out.println("  --pqc-ca-algorithm " + pqcCaAlgorithm);
+                    System.out.println("  --pqc-kem-algorithm " + pqcKemAlgorithm);
+                    System.out.println("  --user-key-type " + userKeyType);
+                }
                 System.out.println("  --verbose " + (verbose ? "enabled" : "disabled"));
+                if (autoYes) {
+                    System.out.println("  --yes");
+                }
+                System.out.println("  --pkcs12-mode " + pkcs12Mode);
                 System.out.println();
 
-                tool.runTest(
-                    pkiservDB,
-                    clientDB,
-                    wrappedSessionFile, wrappedPrivateFile, publicKeyFile, ivFile,
-                    hsmToken, hsmTokenPasswd,
-                    caNickname, transportNickname, storageNickname,
-                    subjectDN,
-                    outputFile, recoveryPasswd,
-                    keywrapAlg,
-                    archiveOnly,
-                    recoverOnly,
-                    ldifFile,
-                    legacyPKCS12
-                );
+                if (pqcMode) {
+                    // PQC mode: use ML-KEM transport/storage
+                    tool.runTestPQC(
+                        pkiservDB,
+                        clientDB,
+                        kemCiphertextFile, wrappedPrivateFile, publicKeyFile,
+                        hsmToken, hsmTokenPasswd,
+                        caNickname, transportNickname, storageNickname,
+                        subjectDN,
+                        outputFile, recoveryPasswd,
+                        keywrapAlg,
+                        archiveOnly,
+                        recoverOnly,
+                        ldifFile,
+                        pkcs12Mode,
+                        userKeyType,
+                        pqcKemAlgorithm
+                    );
+                } else {
+                    // Non-PQC mode: traditional RSA session key wrapping
+                    tool.runTest(
+                        pkiservDB,
+                        clientDB,
+                        wrappedSessionFile, wrappedPrivateFile, publicKeyFile, ivFile,
+                        hsmToken, hsmTokenPasswd,
+                        caNickname, transportNickname, storageNickname,
+                        subjectDN,
+                        outputFile, recoveryPasswd,
+                        keywrapAlg,
+                        archiveOnly,
+                        recoverOnly,
+                        ldifFile,
+                        pkcs12Mode
+                    );
+                }
                 System.out.println();
                 if (archiveOnly) {
                     System.out.println("SUCCESS: Archival completed - LDIF file created!");
                     System.out.println("LDIF file: " + ldifFile);
+                    if (pqcMode) {
+                        System.out.println("Mode: PQC (ML-KEM)");
+                    }
                     System.out.println("Next: Run hsmCompatVerifyServ with --recover-only to verify recovery");
                 } else {
                     System.out.println("SUCCESS: KRA compatibility verification completed!");
@@ -958,6 +1111,170 @@ public class hsmCompatVerifyServ {
         // Export storage certificate for other use
         log("");
         log("Step 7: Exporting storage certificate for other use");
+        String storageCertFile = pkiservDB + "/kra_storage.pem";
+        byte[] storageCertBytes = storageCert.getEncoded();
+        String storageCertPEM = org.mozilla.jss.netscape.security.util.Cert.HEADER + "\n" +
+                java.util.Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(storageCertBytes) + "\n" +
+                org.mozilla.jss.netscape.security.util.Cert.FOOTER;
+        java.nio.file.Files.write(java.nio.file.Paths.get(storageCertFile), storageCertPEM.getBytes());
+        log("  - Storage certificate exported to: " + storageCertFile);
+    }
+
+    /**
+     * PQC Setup Phase - Creates ML-DSA CA and ML-KEM KRA certificates
+     *
+     * Creates three certificate/key pairs on the HSM:
+     * 1. CA signing certificate with ML-DSA (self-signed)
+     * 2. KRA transport certificate with ML-KEM (signed by CA)
+     * 3. KRA storage certificate with ML-KEM (signed by CA)
+     *
+     * Also stores public certificates in PKI server NSS DB for reference.
+     */
+    public void runSetupPQC(
+        String pkiservDB,
+        String pkiservPasswd,
+        String hsmToken,
+        String hsmTokenPasswd,
+        String pqcCaAlgorithm,
+        String pqcKemAlgorithm,
+        String caSubject,
+        int caValidity,
+        String caNickname,
+        String transportSubject,
+        int transportValidity,
+        String transportNickname,
+        String storageSubject,
+        int storageValidity,
+        String storageNickname
+    ) throws Exception {
+
+        log("=== KRA HSM Compatibility Verification - PQC Setup Phase ===");
+        log("Creating PQC PKI infrastructure on HSM");
+        log("");
+
+        // Check if NSS DB exists
+        log("Step 1: Checking NSS database");
+        log("  Path: " + pkiservDB);
+
+        java.io.File dbDir = new java.io.File(pkiservDB);
+        if (!dbDir.exists()) {
+            log("  - Creating NSS database directory");
+            dbDir.mkdirs();
+        }
+
+        boolean dbExists = new java.io.File(pkiservDB + "/cert9.db").exists() &&
+                          new java.io.File(pkiservDB + "/key4.db").exists();
+
+        if (!dbExists) {
+            log("  - Initializing new NSS database");
+            // Create new database with password
+            // Write password to temporary file for certutil
+            java.io.File tmpPwdFile = java.io.File.createTempFile("nsspwd", ".txt");
+            tmpPwdFile.deleteOnExit();
+            java.nio.file.Files.write(tmpPwdFile.toPath(), pkiservPasswd.getBytes());
+
+            try {
+                ProcessBuilder pb = new ProcessBuilder(
+                    "certutil", "-N", "-d", "sql:" + pkiservDB, "-f", tmpPwdFile.getAbsolutePath()
+                );
+                pb.redirectErrorStream(true);
+                Process p = pb.start();
+                int exitCode = p.waitFor();
+                if (exitCode != 0) {
+                    java.io.BufferedReader reader = new java.io.BufferedReader(
+                        new java.io.InputStreamReader(p.getInputStream()));
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        log("    certutil: " + line);
+                    }
+                    throw new Exception("Failed to create NSS database (exit code: " + exitCode + ")");
+                }
+                log("  - New NSS database created with password");
+            } finally {
+                tmpPwdFile.delete();
+            }
+        } else {
+            log("  - Using existing NSS database");
+        }
+
+        // Initialize CryptoManager
+        log("");
+        log("Step 2: Initializing CryptoManager");
+        CryptoManager.initialize(pkiservDB);
+        CryptoManager manager = CryptoManager.getInstance();
+
+        // Initialize HSM token
+        log("");
+        log("Step 3: Initializing HSM token");
+        log("  Token: " + hsmToken);
+
+        CryptoToken hsmTokenObj = CryptoUtil.getKeyStorageToken(hsmToken);
+        if (hsmTokenObj == null) {
+            throw new Exception("HSM token not found: " + hsmToken);
+        }
+
+        Password hsmPassword = new Password(hsmTokenPasswd.toCharArray());
+        try {
+            hsmTokenObj.login(hsmPassword);
+            log("  - HSM token login successful");
+        } finally {
+            hsmPassword.clear();
+        }
+
+        // Check for and clean up existing certificates from previous runs
+        cleanupExistingCerts(manager, hsmTokenObj, caNickname, transportNickname, storageNickname);
+
+        // Create CA certificate with ML-DSA
+        log("");
+        log("Step 4: Creating CA signing certificate on HSM");
+        log("  Algorithm: " + pqcCaAlgorithm.toUpperCase());
+        X509Certificate caCert = createSelfSignedCertPQC(
+            hsmTokenObj, manager, caNickname, caSubject, caValidity,
+            pqcCaAlgorithm
+        );
+        log("  - CA Signing Certificate created: " + caNickname);
+
+        // Create KRA transport certificate with ML-KEM
+        log("");
+        log("Step 5: Creating KRA transport certificate on HSM");
+        log("  Algorithm: " + pqcKemAlgorithm.toUpperCase());
+        X509Certificate transportCert = createSignedCertPQC(
+            hsmTokenObj, manager, transportNickname, transportSubject, transportValidity,
+            caCert, caNickname, pqcCaAlgorithm, pqcKemAlgorithm, "Transport Certificate"
+        );
+        log("  - KRA Transport Certificate created: " + transportNickname);
+
+        // Create KRA storage certificate with ML-KEM
+        log("");
+        log("Step 6: Creating KRA storage certificate on HSM");
+        log("  Algorithm: " + pqcKemAlgorithm.toUpperCase());
+        X509Certificate storageCert = createSignedCertPQC(
+            hsmTokenObj, manager, storageNickname, storageSubject, storageValidity,
+            caCert, caNickname, pqcCaAlgorithm, pqcKemAlgorithm, "Storage Certificate"
+        );
+        log("  - KRA Storage Certificate created: " + storageNickname);
+
+        log("");
+        log("=== Setup Summary ===");
+        log("+ CA certificate: " + caNickname + " (" + pqcCaAlgorithm.toUpperCase() + ")");
+        log("+ Transport certificate: " + transportNickname + " (" + pqcKemAlgorithm.toUpperCase() + ")");
+        log("+ Storage certificate: " + storageNickname + " (" + pqcKemAlgorithm.toUpperCase() + ")");
+        log("+ All certificates created on HSM token: " + hsmToken);
+
+        // Export transport certificate for use by client
+        log("");
+        log("Step 7: Exporting transport certificate for client use");
+        String transportCertFile = pkiservDB + "/kra_transport.pem";
+        byte[] transportCertBytes = transportCert.getEncoded();
+        String transportCertPEM = org.mozilla.jss.netscape.security.util.Cert.HEADER + "\n" +
+                java.util.Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(transportCertBytes) + "\n" +
+                org.mozilla.jss.netscape.security.util.Cert.FOOTER;
+        java.nio.file.Files.write(java.nio.file.Paths.get(transportCertFile), transportCertPEM.getBytes());
+        log("  - Transport certificate exported to: " + transportCertFile);
+
+        // Export storage certificate
+        log("");
+        log("Step 8: Exporting storage certificate for other use");
         String storageCertFile = pkiservDB + "/kra_storage.pem";
         byte[] storageCertBytes = storageCert.getEncoded();
         String storageCertPEM = org.mozilla.jss.netscape.security.util.Cert.HEADER + "\n" +
@@ -1219,6 +1536,164 @@ public class hsmCompatVerifyServ {
     }
 
     /**
+     * Creates a self-signed PQC certificate on the HSM (ML-DSA CA).
+     * Uses CryptoUtil for ML-DSA key generation and signing.
+     *
+     * @param token The crypto token (HSM or internal)
+     * @param manager The CryptoManager instance
+     * @param nickname Certificate nickname
+     * @param subject Certificate subject DN
+     * @param validityDays Validity period in days
+     * @param mldsaAlgorithm ML-DSA algorithm: ml-dsa-44, ml-dsa-65, or ml-dsa-87
+     */
+    private X509Certificate createSelfSignedCertPQC(
+        CryptoToken token,
+        CryptoManager manager,
+        String nickname,
+        String subject,
+        int validityDays,
+        String mldsaAlgorithm
+    ) throws Exception {
+
+        // Map algorithm name to parameter strength and signature algorithm using CryptoUtil
+        int paramStrength = CryptoUtil.getMLDSAStrength(mldsaAlgorithm);
+        SignatureAlgorithm sigAlg = CryptoUtil.getMLDSASignatureAlgorithm(mldsaAlgorithm);
+
+        // Generate ML-DSA key pair using CryptoUtil
+        KeyPair keyPair = CryptoUtil.generateMLDSAKeyPair(token, paramStrength, null, null, null, null, null);
+        PublicKey publicKey = keyPair.getPublic();
+        org.mozilla.jss.crypto.PrivateKey privateKey = (org.mozilla.jss.crypto.PrivateKey) keyPair.getPrivate();
+
+        // Prepare certificate parameters
+        SecureRandom random = new SecureRandom();
+        BigInteger serialNumber = new BigInteger(128, random);
+        X500Name subjectName = new X500Name(subject);
+        Date notBefore = new Date();
+        Date notAfter = new Date(notBefore.getTime() + (validityDays * 24L * 60 * 60 * 1000));
+        X509Key x509Key = CryptoUtil.createX509Key(publicKey);
+
+        // Create CA certificate extensions (includes SKID, AKID, Basic Constraints, Key Usage)
+        CertificateExtensions extensions = createCACertExtensions(x509Key);
+
+        // Create certificate info with extensions
+        X509CertInfo certInfo = CryptoUtil.createX509CertInfo(
+            x509Key,
+            serialNumber,
+            new CertificateIssuerName(subjectName),
+            subjectName,
+            notBefore,
+            notAfter,
+            sigAlg.toString(),
+            extensions
+        );
+
+        // Sign with ML-DSA private key using CryptoUtil
+        X509CertImpl cert = CryptoUtil.signCert(privateKey, certInfo, sigAlg);
+
+        // Import certificate
+        org.mozilla.jss.crypto.X509Certificate jssCert =
+            manager.importUserCACertPackage(cert.getEncoded(), nickname);
+
+        // Set trust flags for CA certificate
+        org.mozilla.jss.pkcs11.PK11Cert pkcs11Cert = (org.mozilla.jss.pkcs11.PK11Cert) jssCert;
+        pkcs11Cert.setSSLTrust(
+            org.mozilla.jss.pkcs11.PK11Cert.TRUSTED_CA |
+            org.mozilla.jss.pkcs11.PK11Cert.TRUSTED_CLIENT_CA |
+            org.mozilla.jss.pkcs11.PK11Cert.VALID_CA
+        );
+
+        return jssCert;
+    }
+
+    /**
+     * Creates a signed PQC certificate on the HSM (ML-KEM transport/storage).
+     * Uses CryptoUtil for ML-KEM key generation and ML-DSA signing.
+     *
+     * @param token The crypto token (HSM or internal)
+     * @param manager The CryptoManager instance
+     * @param nickname Certificate nickname
+     * @param subject Certificate subject DN
+     * @param validityDays Validity period in days
+     * @param issuerCert CA certificate
+     * @param issuerNickname CA certificate nickname
+     * @param mldsaAlgorithm ML-DSA algorithm used by CA
+     * @param mlkemAlgorithm ML-KEM algorithm: ml-kem-512, ml-kem-768, or ml-kem-1024
+     * @param certType Description of certificate type (for logging)
+     */
+    private X509Certificate createSignedCertPQC(
+        CryptoToken token,
+        CryptoManager manager,
+        String nickname,
+        String subject,
+        int validityDays,
+        X509Certificate issuerCert,
+        String issuerNickname,
+        String mldsaAlgorithm,
+        String mlkemAlgorithm,
+        String certType
+    ) throws Exception {
+
+        // Map ML-KEM algorithm name to parameter strength using CryptoUtil
+        int kemStrength = CryptoUtil.getMLKEMStrength(mlkemAlgorithm);
+
+        // Generate ML-KEM key pair using CryptoUtil
+        KeyPair keyPair = CryptoUtil.generateMLKEMKeyPair(token, kemStrength, null, null, null, null, null);
+        PublicKey publicKey = keyPair.getPublic();
+
+        // Prepare certificate parameters
+        SecureRandom random = new SecureRandom();
+        BigInteger serialNumber = new BigInteger(128, random);
+        X500Name subjectName = new X500Name(subject);
+        X500Name issuerName = new X500Name(issuerCert.getSubjectDN().toString());
+        Date notBefore = new Date();
+        Date notAfter = new Date(notBefore.getTime() + (validityDays * 24L * 60 * 60 * 1000));
+
+        // Determine CA signature algorithm using CryptoUtil
+        SignatureAlgorithm sigAlg = CryptoUtil.getMLDSASignatureAlgorithm(mldsaAlgorithm);
+
+        // Add extensions
+        CertificateExtensions extensions = new CertificateExtensions();
+
+        // Basic Constraints: CA=false
+        extensions.set(
+            BasicConstraintsExtension.NAME,
+            new BasicConstraintsExtension(false, false, -1)
+        );
+
+        // Key Usage: For ML-KEM, we need keyAgreement (for KEM operations)
+        // Note: Exact usage bits may need adjustment based on final NIST/IETF standards
+        boolean[] keyUsageBits = new boolean[9];
+        keyUsageBits[4] = true;  // keyAgreement (for KEM/key establishment)
+        extensions.set(
+            KeyUsageExtension.NAME,
+            new KeyUsageExtension(keyUsageBits)
+        );
+
+        // Create certificate info with extensions
+        X509Key x509Key = CryptoUtil.createX509Key(publicKey);
+        X509CertInfo certInfo = CryptoUtil.createX509CertInfo(
+            x509Key,
+            serialNumber,
+            new CertificateIssuerName(issuerName),
+            subjectName,
+            notBefore,
+            notAfter,
+            sigAlg.toString(),
+            extensions
+        );
+
+        // Find CA private key and sign using CryptoUtil
+        PrivateKey caPrivateKey = manager.findPrivKeyByCert(issuerCert);
+        X509CertImpl cert = CryptoUtil.signCert(caPrivateKey, certInfo, sigAlg);
+
+        // Import certificate
+        org.mozilla.jss.crypto.X509Certificate jssCert =
+            manager.importCertPackage(cert.getEncoded(), nickname);
+
+        return jssCert;
+    }
+
+    /**
      * Displays certificate information for user review.
      */
     private void displayCertInfo(X509Certificate cert) {
@@ -1380,63 +1855,10 @@ public class hsmCompatVerifyServ {
     }
 
     /**
-     * Test phase: Runs archival and/or recovery workflow
-     *
-     * This method supports three modes:
-     * 1. Archival only (archiveOnly=true): Archive keys to LDIF and stop
-     * 2. Recovery only (recoverOnly=true): Read from LDIF and recover to PKCS#12
-     * 3. Combined (neither flag): Full archival+recovery workflow (creates LDIF + recovers to PKCS#12)
-     *
-     * Adopted from: CRMFPopClient, EnrollmentService, RecoveryService,
-     * TransportKeyUnit, StorageKeyUnit (see detailed comments inline)
-     *
-     * @param pkiservDB PKI system NSS database path - REQUIRED for HSM access.
-     *                    CryptoManager must be initialized with this database because
-     *                    it contains the modutil configuration that loads the
-     *                    HSM PKCS#11 module. Without this, the HSM token won't be found.
-     * @param clientDB Client NSS database directory (base path for wrapped key files and p12 output)
-     * @param wrappedSessionFile Wrapped session key file (from hsmCompatVerifyClnt, null for recovery mode)
-     * @param wrappedPrivateFile Wrapped private key file (from hsmCompatVerifyClnt, null for recovery mode)
-     * @param publicKeyFile Public key file in DER format (from hsmCompatVerifyClnt, null for recovery mode)
-     * @param archiveOnly If true, create LDIF and stop (archival only mode, no recovery)
-     * @param recoverOnly If true, read from existing LDIF file (recovery only mode, no archival)
-     * @param ldifFile LDIF file path for archival output or recovery input
+     * Helper method: Initialize NSS database
+     * @return CryptoManager instance
      */
-    public void runTest(
-        String pkiservDB,
-        String clientDB,
-        String wrappedSessionFile,
-        String wrappedPrivateFile,
-        String publicKeyFile,
-        String ivFile,
-        String hsmToken,
-        String hsmTokenPasswd,
-        String caNickname,
-        String transportNickname,
-        String storageNickname,
-        String subjectDN,
-        String outputFile,
-        String recoveryPasswd,
-        String keywrapAlg,
-        boolean archiveOnly,
-        boolean recoverOnly,
-        String ldifFile,
-        boolean legacyPKCS12
-    ) throws Exception {
-
-        log("=== KRA HSM Compatibility Verification - Verification Phase ===");
-        if (recoverOnly) {
-            log("Mode: Recovery from LDIF file");
-        } else if (archiveOnly) {
-            log("Mode: Archival to LDIF file (no recovery)");
-        } else {
-            log("Mode: Full archival and recovery workflow");
-        }
-        log("");
-
-        // Step 1: Initialize NSS with PKI server DB (for HSM access via modutil)
-        // The PKI server DB has HSM module configured via modutil, allowing access to HSM
-        // Adopted from: base/tools/src/main/java/com/netscape/cmstools/CRMFPopClient.java:410-428
+    private CryptoManager initializeNSS(String pkiservDB) throws Exception {
         log("Step 1: Initializing NSS database");
         log("  PKI Server DB: " + pkiservDB + " (for HSM access)");
 
@@ -1444,8 +1866,14 @@ public class hsmCompatVerifyServ {
         CryptoManager.initialize(pkiservDB);
         CryptoManager manager = CryptoManager.getInstance();
 
-        // Step 2: Initialize HSM
-        // Adopted from: base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java:248-253
+        return manager;
+    }
+
+    /**
+     * Helper method: Initialize and login to HSM token
+     * @return CryptoToken (HSM token object)
+     */
+    private CryptoToken initializeHSM(String hsmToken, String hsmTokenPasswd) throws Exception {
         log("");
         log("Step 2: Initializing HSM");
         log("  HSM Token: " + hsmToken);
@@ -1465,8 +1893,18 @@ public class hsmCompatVerifyServ {
             hsmPassword.clear();
         }
 
-        // Step 3: Load CA, transport, and storage certificates from HSM
-        // Adopted from: base/kra/src/main/java/com/netscape/kra/TransportKeyUnit.java:80-109
+        return hsmTokenObj;
+    }
+
+    /**
+     * Helper method: Load certificates and private keys from HSM
+     * @return Object array: [X509Certificate caCert, X509Certificate transportCert,
+     *                        X509Certificate storageCert, PrivateKey transportPrivateKey,
+     *                        PrivateKey storagePrivateKey]
+     */
+    private Object[] loadCertificatesAndKeys(CryptoManager manager, CryptoToken hsmTokenObj,
+                                             String caNickname, String transportNickname,
+                                             String storageNickname) throws Exception {
         log("");
         log("Step 3: Loading CA and KRA certificates from HSM");
         log("  CA cert: " + caNickname);
@@ -1510,6 +1948,75 @@ public class hsmCompatVerifyServ {
         }
         log("  - Storage private key found on HSM");
 
+        return new Object[] {caCert, transportCert, storageCert, transportPrivateKey, storagePrivateKey};
+    }
+
+    /**
+     * Test phase: Runs archival and/or recovery workflow
+     *
+     * This method supports three modes:
+     * 1. Archival only (archiveOnly=true): Archive keys to LDIF and stop
+     * 2. Recovery only (recoverOnly=true): Read from LDIF and recover to PKCS#12
+     * 3. Combined (neither flag): Full archival+recovery workflow (creates LDIF + recovers to PKCS#12)
+     *
+     * Adopted from: CRMFPopClient, EnrollmentService, RecoveryService,
+     * TransportKeyUnit, StorageKeyUnit (see detailed comments inline)
+     *
+     * @param pkiservDB PKI system NSS database path - REQUIRED for HSM access.
+     *                    CryptoManager must be initialized with this database because
+     *                    it contains the modutil configuration that loads the
+     *                    HSM PKCS#11 module. Without this, the HSM token won't be found.
+     * @param clientDB Client NSS database directory (base path for wrapped key files and p12 output)
+     * @param wrappedSessionFile Wrapped session key file (from hsmCompatVerifyClnt, null for recovery mode)
+     * @param wrappedPrivateFile Wrapped private key file (from hsmCompatVerifyClnt, null for recovery mode)
+     * @param publicKeyFile Public key file in DER format (from hsmCompatVerifyClnt, null for recovery mode)
+     * @param archiveOnly If true, create LDIF and stop (archival only mode, no recovery)
+     * @param recoverOnly If true, read from existing LDIF file (recovery only mode, no archival)
+     * @param ldifFile LDIF file path for archival output or recovery input
+     */
+    public void runTest(
+        String pkiservDB,
+        String clientDB,
+        String wrappedSessionFile,
+        String wrappedPrivateFile,
+        String publicKeyFile,
+        String ivFile,
+        String hsmToken,
+        String hsmTokenPasswd,
+        String caNickname,
+        String transportNickname,
+        String storageNickname,
+        String subjectDN,
+        String outputFile,
+        String recoveryPasswd,
+        String keywrapAlg,
+        boolean archiveOnly,
+        boolean recoverOnly,
+        String ldifFile,
+        String pkcs12Mode
+    ) throws Exception {
+
+        log("=== KRA HSM Compatibility Verification - Verification Phase ===");
+        if (recoverOnly) {
+            log("Mode: Recovery from LDIF file");
+        } else if (archiveOnly) {
+            log("Mode: Archival to LDIF file (no recovery)");
+        } else {
+            log("Mode: Full archival and recovery workflow");
+        }
+        log("");
+
+        // Step 1-3: Initialize NSS, HSM, and load certificates (using helper methods)
+        CryptoManager manager = initializeNSS(pkiservDB);
+        CryptoToken hsmTokenObj = initializeHSM(hsmToken, hsmTokenPasswd);
+        Object[] certsAndKeys = loadCertificatesAndKeys(manager, hsmTokenObj, caNickname, transportNickname, storageNickname);
+
+        X509Certificate caCert = (X509Certificate) certsAndKeys[0];
+        X509Certificate transportCert = (X509Certificate) certsAndKeys[1];
+        X509Certificate storageCert = (X509Certificate) certsAndKeys[2];
+        PrivateKey transportPrivateKey = (PrivateKey) certsAndKeys[3];
+        PrivateKey storagePrivateKey = (PrivateKey) certsAndKeys[4];
+
         // Determine RSA wrap algorithm (based on --oaep flag)
         KeyWrapAlgorithm rsaWrapAlg = useOAEP ? KeyWrapAlgorithm.RSA_OAEP : KeyWrapAlgorithm.RSA;
         KeyWrapAlgorithm keyWrapAlgorithm = KeyWrapAlgorithm.fromString(keywrapAlg);
@@ -1549,23 +2056,16 @@ public class hsmCompatVerifyServ {
                     storageIvSpec = new org.mozilla.jss.crypto.IVParameterSpec(ivBytes);
                 }
 
-                // Create user certificate using owner name from LDIF (or use provided subjectDN)
-                String certSubjectDN = (String) ldifData.get("ownerName");
-                if (certSubjectDN == null || certSubjectDN.isEmpty()) {
-                    certSubjectDN = subjectDN != null ? subjectDN : "CN=Recovered User";
-                }
-
+                // Get user certificate from LDIF
                 log("");
-                log("Step 4a: Creating user certificate signed by CA");
-                userCert = createUserCert(
-                    hsmTokenObj,
-                    manager,
-                    caCert,
-                    caNickname,
-                    certSubjectDN,
-                    userPublicKey
-                );
-                log("  - User certificate created and signed by CA");
+                log("Step 4a: Loading user certificate from LDIF");
+                userCert = (X509CertImpl) ldifData.get("certificate");
+                if (userCert == null) {
+                    throw new Exception("Certificate not found in LDIF - cannot recover key without certificate");
+                }
+                log("  - User certificate loaded from LDIF");
+                log("    Subject: " + userCert.getSubjectDN());
+                log("    Serial: " + userCert.getSerialNumber());
 
                 // Step 7: KRA recovery - unwrap from storage on HSM
                 log("");
@@ -1623,11 +2123,11 @@ public class hsmCompatVerifyServ {
                     hsmTokenObj,
                     recoveryPasswd,
                     recordOutputFile,
-                    legacyPKCS12
+                    pkcs12Mode
                 );
 
                 log("  - PKCS#12 file created: " + recordOutputFile);
-                log("  - PKCS#12 format: " + (legacyPKCS12 ? "Legacy (PBE_SHA1_DES3_CBC)" : "Non-legacy (AES-KWP)"));
+                log("  - PKCS#12 format: " + getPKCS12ModeDescription(pkcs12Mode));
                 log("  - Using token: " + hsmTokenObj.getName());
 
                 outputFiles.add(recordOutputFile);
@@ -1822,7 +2322,7 @@ public class hsmCompatVerifyServ {
                 rsaWrapAlg,
                 keyWrapAlgorithm,
                 storageIvSpec,
-                subjectDN
+                false  // isPQC
             );
 
             log("  - LDIF file created: " + ldifFile);
@@ -1882,11 +2382,11 @@ public class hsmCompatVerifyServ {
                 hsmTokenObj,
                 recoveryPasswd,
                 outputFile,
-                legacyPKCS12
+                pkcs12Mode
             );
 
             log("  - PKCS#12 file created: " + outputFile);
-            log("  - PKCS#12 format: " + (legacyPKCS12 ? "Legacy (PBE_SHA1_DES3_CBC)" : "Non-legacy (AES-KWP)"));
+            log("  - PKCS#12 format: " + getPKCS12ModeDescription(pkcs12Mode));
             log("  - Using token: " + hsmTokenObj.getName());
 
             // Verification Summary
@@ -1912,6 +2412,380 @@ public class hsmCompatVerifyServ {
             }
             log("+ PKCS#12 file: " + outputFile);
         }
+    }
+
+    /**
+     * Test phase for PQC (ML-KEM): Runs archival workflow with ML-KEM encapsulation
+     *
+     * This method performs ML-KEM-based key archival:
+     * 1. Decapsulate KEM ciphertext with transport private key → recover shared secret
+     * 2. Unwrap user private key with shared secret
+     * 3. Re-encapsulate with storage public key → new shared secret
+     * 4. Wrap user private key with new shared secret
+     * 5. Generate LDIF for archival
+     *
+     * @param pkiservDB PKI system NSS database path (for HSM access)
+     * @param clientDB Client NSS database directory (base path for wrapped key files)
+     * @param kemCiphertextFile KEM ciphertext file (from hsmCompatVerifyClnt --pqc)
+     * @param wrappedPrivateFile Wrapped private key file (from hsmCompatVerifyClnt --pqc)
+     * @param publicKeyFile Public key file in DER format (ML-KEM public key)
+     * @param hsmToken HSM token name
+     * @param hsmTokenPasswd HSM token password
+     * @param caNickname CA certificate nickname
+     * @param transportNickname Transport certificate nickname
+     * @param storageNickname Storage certificate nickname
+     * @param subjectDN Subject DN for user certificate
+     * @param outputFile Output PKCS#12 file (for future recovery testing)
+     * @param recoveryPasswd PKCS#12 password
+     * @param keywrapAlg Key wrap algorithm (AES-KWP)
+     * @param archiveOnly If true, create LDIF and stop (archival only mode)
+     * @param ldifFile LDIF file path for archival output
+     * @param pkcs12Mode PKCS#12 encryption mode (kwp, pbes2, or legacy)
+     * @param kemAlgorithm ML-KEM algorithm (mlkem512/768/1024)
+     */
+    public void runTestPQC(
+        String pkiservDB,
+        String clientDB,
+        String kemCiphertextFile,
+        String wrappedPrivateFile,
+        String publicKeyFile,
+        String hsmToken,
+        String hsmTokenPasswd,
+        String caNickname,
+        String transportNickname,
+        String storageNickname,
+        String subjectDN,
+        String outputFile,
+        String recoveryPasswd,
+        String keywrapAlg,
+        boolean archiveOnly,
+        boolean recoverOnly,
+        String ldifFile,
+        String pkcs12Mode,
+        String userKeyType,
+        String kemAlgorithm
+    ) throws Exception {
+
+        log("=== KRA HSM Compatibility Verification - PQC Mode (ML-KEM Transport) ===");
+        log("Transport/Storage: ML-KEM-" + kemAlgorithm.replace("mlkem", ""));
+        log("User key type: " + userKeyType);
+        if (archiveOnly) {
+            log("Mode: Archival to LDIF file (no recovery)");
+        } else if (recoverOnly) {
+            log("Mode: Recovery from LDIF file (no archival)");
+        } else {
+            log("Mode: Full archival and recovery workflow");
+        }
+        log("");
+
+        // Step 1-3: Initialize NSS, HSM, and load certificates (using helper methods)
+        CryptoManager manager = initializeNSS(pkiservDB);
+        CryptoToken hsmTokenObj = initializeHSM(hsmToken, hsmTokenPasswd);
+        Object[] certsAndKeys = loadCertificatesAndKeys(manager, hsmTokenObj, caNickname, transportNickname, storageNickname);
+
+        X509Certificate caCert = (X509Certificate) certsAndKeys[0];
+        X509Certificate transportCert = (X509Certificate) certsAndKeys[1];
+        X509Certificate storageCert = (X509Certificate) certsAndKeys[2];
+        PrivateKey transportPrivateKey = (PrivateKey) certsAndKeys[3];
+        PrivateKey storagePrivateKey = (PrivateKey) certsAndKeys[4];
+
+        KeyWrapAlgorithm keyWrapAlgorithm = KeyWrapAlgorithm.fromString(keywrapAlg);
+
+        // Step 4: Load wrapped keys and ML-KEM public key
+        byte[] kemCiphertext;
+        byte[] wrappedUserPrivate;
+        PublicKey userPublicKey;
+        X509CertImpl userCert;
+
+        log("");
+        if (archiveOnly) {
+            // Archive mode: Load from client-generated .bin/.der files
+            log("Step 4: Loading wrapped keys from files (generated by hsmCompatVerifyClnt --pqc)");
+            log("  KEM ciphertext: " + kemCiphertextFile);
+            log("  Wrapped private key: " + wrappedPrivateFile);
+            log("  Public key: " + publicKeyFile);
+
+            kemCiphertext = java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(kemCiphertextFile));
+            log("  - KEM ciphertext loaded (" + kemCiphertext.length + " bytes)");
+
+            wrappedUserPrivate = java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(wrappedPrivateFile));
+            log("  - Wrapped private key loaded (" + wrappedUserPrivate.length + " bytes)");
+
+            byte[] publicKeyBytes = java.nio.file.Files.readAllBytes(java.nio.file.Paths.get(publicKeyFile));
+
+            // Load public key using appropriate KeyFactory based on user key type
+            java.security.KeyFactory keyFactory;
+            if ("RSA".equalsIgnoreCase(userKeyType)) {
+                keyFactory = java.security.KeyFactory.getInstance("RSA");
+            } else if ("EC".equalsIgnoreCase(userKeyType)) {
+                keyFactory = java.security.KeyFactory.getInstance("EC");
+            } else if ("ML-KEM".equalsIgnoreCase(userKeyType)) {
+                keyFactory = java.security.KeyFactory.getInstance("ML-KEM", "Mozilla-JSS");
+            } else {
+                throw new Exception("Unsupported user key type: " + userKeyType);
+            }
+
+            userPublicKey = keyFactory.generatePublic(
+                new java.security.spec.X509EncodedKeySpec(publicKeyBytes)
+            );
+            log("  - " + userKeyType + " public key loaded (" + publicKeyBytes.length + " bytes)");
+
+            // Step 4a: Create user certificate signed by CA
+            log("");
+            log("Step 4a: Creating user certificate signed by CA");
+            log("  Subject DN: " + subjectDN);
+
+            userCert = createUserCert(
+                hsmTokenObj,
+                manager,
+                caCert,
+                caNickname,
+                subjectDN,
+                userPublicKey
+            );
+            log("  - User certificate created and signed by CA");
+        } else {
+            // Recovery mode: Load from LDIF file
+            log("Step 4: Reading archived key data from LDIF file");
+            log("  LDIF file: " + ldifFile);
+
+            java.util.List<Map<String, Object>> keyRecords = readLDIFFile(ldifFile);
+            if (keyRecords.isEmpty()) {
+                throw new Exception("No key records found in LDIF file");
+            }
+
+            // For now, process first record (could be extended for multiple records)
+            Map<String, Object> ldifData = keyRecords.get(0);
+
+            log("  Serial: " + ldifData.get("serialno"));
+            log("  Owner: " + ldifData.get("ownerName"));
+
+            // Extract data from LDIF
+            // For PQC: wrappedSessionKey contains KEM ciphertext (not wrapped session key)
+            kemCiphertext = (byte[]) ldifData.get("wrappedSessionKey");
+            wrappedUserPrivate = (byte[]) ldifData.get("wrappedPrivateKey");
+            userPublicKey = (PublicKey) ldifData.get("publicKey");
+
+            log("  - KEM ciphertext loaded from LDIF (" + kemCiphertext.length + " bytes)");
+            log("  - Wrapped private key loaded from LDIF (" + wrappedUserPrivate.length + " bytes)");
+            log("  - " + userKeyType + " public key loaded from LDIF");
+            log("    Public key algorithm: " + userPublicKey.getAlgorithm());
+
+            // Step 4a: Get user certificate from LDIF
+            log("");
+            log("Step 4a: Loading user certificate from LDIF");
+            userCert = (X509CertImpl) ldifData.get("certificate");
+            if (userCert == null) {
+                throw new Exception("Certificate not found in LDIF - cannot recover key without certificate");
+            }
+            log("  - User certificate loaded from LDIF");
+            log("    Subject: " + userCert.getSubjectDN());
+            log("    Serial: " + userCert.getSerialNumber());
+        }
+
+        // Step 5: ML-KEM Decapsulation - recover shared secret
+        log("");
+        SymmetricKey recoveredSharedSecret;
+
+        if (archiveOnly) {
+            // Archive mode: Decapsulate transport KEM ciphertext (from client)
+            log("Step 5: ML-KEM decapsulation with transport private key");
+            log("  Decapsulating transport KEM ciphertext to recover shared secret");
+
+            recoveredSharedSecret = CryptoUtil.decapsulateMLKEM(transportPrivateKey, kemCiphertext, 32);
+            log("  - Shared secret recovered via ML-KEM decapsulation (transport)");
+            log("    Shared secret size: 32 bytes (AES-256)");
+        } else {
+            // Recovery mode: Decapsulate storage KEM ciphertext (from LDIF)
+            log("Step 5: ML-KEM decapsulation with storage private key");
+            log("  Decapsulating storage KEM ciphertext to recover shared secret");
+
+            recoveredSharedSecret = CryptoUtil.decapsulateMLKEM(storagePrivateKey, kemCiphertext, 32);
+            log("  - Shared secret recovered via ML-KEM decapsulation (storage)");
+            log("    Shared secret size: 32 bytes (AES-256)");
+        }
+
+        // Step 5a: Unwrap user private key with recovered shared secret
+        log("");
+        log("Step 5a: Unwrapping user private key");
+        log("  Using recovered shared secret with " + keyWrapAlgorithm);
+
+        // TEST: Try DECRYPT instead of UNWRAP (for Bob's investigation)
+        // Hidden flag: --test-decrypt-user
+        if (testDecryptUser) {
+            // Decrypt just reverses the encryption and returns raw bytes
+            // Unwrap tries to import the result as a PrivateKey object
+            log("");
+            log("TEST: Attempting DECRYPT instead of UNWRAP");
+            try {
+                // Use AES_256_ECB like Marco's TestKeyEncDec.java
+                org.mozilla.jss.crypto.Cipher cipher = hsmTokenObj.getCipherContext(
+                    org.mozilla.jss.crypto.EncryptionAlgorithm.AES_256_ECB);
+                cipher.initDecrypt(recoveredSharedSecret);  // initDecrypt, not initUnwrap!
+                byte[] decryptedBytes = cipher.doFinal(wrappedUserPrivate);
+                log("  - Decrypt succeeded! Decrypted data size: " + decryptedBytes.length + " bytes");
+                // Show all bytes in hex for Bob
+                StringBuilder hex = new StringBuilder();
+                for (int i = 0; i < decryptedBytes.length; i++) {
+                    hex.append(String.format("%02x", decryptedBytes[i]));
+                    if (i % 16 == 15) hex.append("\n    ");
+                    else if (i % 4 == 3) hex.append(" ");
+                }
+                log("  - All decrypted bytes (hex):");
+                log("    " + hex.toString());
+            } catch (Exception e) {
+                log("  - Decrypt failed: " + e.getMessage());
+                e.printStackTrace();
+            }
+            log("");
+        }
+
+        PrivateKey unwrappedUserPrivate = CryptoUtil.unwrap(
+            hsmTokenObj,
+            userPublicKey,
+            false,  // permanent - try permanent keys for ML-KEM PKCS#12 export
+            recoveredSharedSecret,
+            wrappedUserPrivate,
+            keyWrapAlgorithm,
+            null   // No IV for AES-KWP
+        );
+        log("  - User private key unwrapped on HSM (permanent)");
+
+        // If recovery-only mode, skip archival and jump to PKCS#12 creation
+        if (recoverOnly) {
+            log("");
+            log("Step 6: Creating PKCS#12 file with recovered key");
+
+            createPKCS12(
+                userCert,
+                unwrappedUserPrivate,
+                hsmTokenObj,
+                recoveryPasswd,
+                outputFile,
+                pkcs12Mode
+            );
+            log("  - PKCS#12 file created: " + outputFile);
+            log("  - PKCS#12 format: " + getPKCS12ModeDescription(pkcs12Mode));
+
+            log("");
+            log("=== Recovery Summary (PQC Mode) ===");
+            log("+ ML-KEM decapsulation: Recovered storage shared secret");
+            log("+ User private key: Unwrapped from archive");
+            log("+ PKCS#12 file created with recovered key and certificate");
+            log("");
+            log("SUCCESS: Recovery completed - PKCS#12 file created!");
+            log("PKCS#12 file: " + outputFile);
+            log("Password: " + recoveryPasswd);
+            return;  // Done with recovery
+        }
+
+        // Step 6: KRA archival - re-encapsulate with storage key
+        log("");
+        log("Step 6: KRA archival - ML-KEM encapsulation with storage key");
+
+        // Import storage public key into token for ML-KEM encapsulation
+        java.security.PublicKey storagePubKey = storageCert.getPublicKey();
+        hsmTokenObj.importPublicKey(storagePubKey, false);
+        log("  - Storage public key imported into token");
+
+        // Encapsulate with storage public key using CryptoUtil
+        CryptoUtil.KEMEncapsulation storageEncapsulation = CryptoUtil.encapsulateMLKEM(storagePubKey, 32);
+        SymmetricKey storageSharedSecret = storageEncapsulation.sharedSecret;
+        byte[] storageKemCiphertext = storageEncapsulation.ciphertext;
+
+        log("  - ML-KEM encapsulation completed with storage public key");
+        log("    Storage shared secret size: 32 bytes (AES-256)");
+        log("    Storage KEM ciphertext size: " + storageKemCiphertext.length + " bytes");
+
+        // Wrap user private key with storage shared secret
+        byte[] archivedUserPrivate = CryptoUtil.wrapUsingSymmetricKey(
+            hsmTokenObj,
+            storageSharedSecret,
+            unwrappedUserPrivate,
+            null,  // No IV for AES-KWP
+            keyWrapAlgorithm
+        );
+        log("  - User private key wrapped with storage shared secret");
+        log("  (User key is now 'archived')");
+
+        // Step 6a: Create LDIF file with archived data
+        log("");
+        log("Step 6a: Creating LDIF file with archived key data (PQC mode)");
+
+        createLDIFFile(
+            ldifFile,
+            userCert,
+            userPublicKey,
+            archivedUserPrivate,
+            storageKemCiphertext,  // KEM ciphertext instead of wrapped session key
+            null,  // No RSA wrap algorithm for PQC
+            keyWrapAlgorithm,
+            null,  // No IV for AES-KWP
+            true   // isPQC flag
+        );
+
+        log("  - LDIF file created: " + ldifFile);
+        log("");
+        log("=== Archival Summary (PQC Mode) ===");
+        log("+ ML-KEM decapsulation: Recovered shared secret from transport");
+        log("+ ML-KEM encapsulation: Generated new shared secret for storage");
+        log("+ User private key: Unwrapped and re-wrapped for archival");
+        log("+ LDIF file created with archived key data");
+
+        if (archiveOnly) {
+            return;  // Stop here in archival-only mode
+        }
+
+        // Step 7: KRA recovery - ML-KEM decapsulation with storage key
+        log("");
+        log("Step 7: KRA recovery - ML-KEM decapsulation with storage key");
+
+        // Decapsulate storage KEM ciphertext with storage private key using CryptoUtil
+        SymmetricKey recoveredStorageSharedSecret = CryptoUtil.decapsulateMLKEM(storagePrivateKey, storageKemCiphertext, 32);
+
+        log("  - Storage shared secret recovered via ML-KEM decapsulation");
+        log("    Shared secret size: " + recoveredStorageSharedSecret.getLength() + " bytes (AES-256)");
+
+        // Step 7a: Unwrap user private key with recovered storage shared secret
+        log("");
+        log("Step 7a: Unwrapping user private key from archive");
+        log("  Using recovered storage shared secret with " + keyWrapAlgorithm);
+
+        PrivateKey recoveredUserPrivate = CryptoUtil.unwrap(
+            hsmTokenObj,
+            userPublicKey,
+            true,  // temporary
+            recoveredStorageSharedSecret,
+            archivedUserPrivate,
+            keyWrapAlgorithm,
+            null   // No IV for AES-KWP
+        );
+        log("  - User private key recovered from archive on HSM");
+
+        // Step 8: Create PKCS#12 file with recovered key and CA-signed certificate
+        log("");
+        log("Step 8: Creating PKCS#12 file");
+
+        createPKCS12(
+            userCert,
+            recoveredUserPrivate,
+            hsmTokenObj,
+            recoveryPasswd,
+            outputFile,
+            pkcs12Mode
+        );
+        log("  - PKCS#12 file created: " + outputFile);
+        log("  - PKCS#12 format: " + getPKCS12ModeDescription(pkcs12Mode));
+
+        log("");
+        log("=== Recovery Summary (PQC Mode) ===");
+        log("+ ML-KEM decapsulation: Recovered storage shared secret");
+        log("+ User private key: Unwrapped from archive");
+        log("+ PKCS#12 file created with recovered key and certificate");
+        log("");
+        log("SUCCESS: Recovery completed - PKCS#12 file created!");
+        log("PKCS#12 file: " + outputFile);
+        log("Password: " + recoveryPasswd);
     }
 
     /**
@@ -1952,14 +2826,21 @@ public class hsmCompatVerifyServ {
         Date notAfter = new Date(notBefore.getTime() + (365L * 24L * 60L * 60L * 1000L));  // 1 year validity
         X509Key x509key = CryptoUtil.createX509Key(userPublicKey);
 
-        // Determine signature algorithm based on CA cert's key type
+        // Determine signature algorithm based on CA cert's signature algorithm
+        // For PQC, the public key algorithm is generic (e.g., "ML-DSA"), but we need
+        // the specific variant (e.g., "ML-DSA-65") which is stored in the cert's sigAlgName
+        String algName = caCert.getSigAlgName();
+
+        // For RSA/EC CAs, we might need to map to specific algorithm names
         String caKeyType = caCert.getPublicKey().getAlgorithm();
-        String algName;
-        if (caKeyType.equalsIgnoreCase("EC")) {
-            algName = "SHA256withEC";
-        } else {
+        if (caKeyType.equalsIgnoreCase("RSA") && !algName.contains("RSA")) {
             algName = "SHA256withRSA";
+        } else if (caKeyType.equalsIgnoreCase("EC") && !algName.contains("EC")) {
+            algName = "SHA256withEC";
         }
+        // For ML-DSA, use the signature algorithm directly from the CA cert
+
+        log("  Signature algorithm: " + algName + " (CA key type: " + caKeyType + ")");
 
         // Create certificate extensions for user cert
         CertificateExtensions extensions = createUserCertExtensions(x509key, caCert);
@@ -2040,7 +2921,12 @@ public class hsmCompatVerifyServ {
      * Adopted from: base/kra/src/main/java/com/netscape/kra/RecoveryService.java:564-724
      * (createPFX method with PrivateKey parameter)
      *
-     * Differences: Simplified, no request object, no audit logging, always legacy PKCS#12
+     * Differences: Simplified, no request object, no audit logging
+     *
+     * @param pkcs12Mode PKCS#12 encryption mode:
+     *   - "kwp": AES-KWP (fails for ML-KEM keys currently)
+     *   - "pbes2": PKCS#5 v2 PBKDF2+AES-256-CBC (FIPS-compliant, like pk12util)
+     *   - "legacy": PBE_SHA1_DES3_CBC (not recommended for FIPS HSMs)
      */
     private void createPKCS12(
         X509CertImpl cert,
@@ -2048,7 +2934,7 @@ public class hsmCompatVerifyServ {
         CryptoToken token,
         String password,
         String outputFile,
-        boolean legacyPKCS12
+        String pkcs12Mode
     ) throws Exception {
 
         Password pass = new Password(password.toCharArray());
@@ -2072,7 +2958,7 @@ public class hsmCompatVerifyServ {
             SEQUENCE safeContents = new SEQUENCE();
 
             ASN1Value key;
-            if (legacyPKCS12) {
+            if (pkcs12Mode.equals("legacy")) {
                 // Legacy PKCS#12: PBE_SHA1_DES3_CBC
                 // Compatible with older systems but may fail on some HSMs (e.g., Thales FIPS 140-3)
                 PasswordConverter passConverter = new PasswordConverter();
@@ -2089,20 +2975,51 @@ public class hsmCompatVerifyServ {
                     privateKey,
                     token
                 );
-            } else {
-                // Non-legacy PKCS#12: AES Key Wrap with Padding (AES-KWP)
+            } else if (pkcs12Mode.equals("cbc")) {
+                // AES-256-CBC with PBKDF2
+                // This matches KRA's default non-legacy algorithm (kra.nonLegacyAlg="AES/CBC/NoPadding")
+                // Uses getCryptoStore().getEncryptedPrivateKeyInfo() which automatically applies PBKDF2
+                // FIPS-compliant, works with ML-KEM keys
+                String nonLegacyAlg = "AES/CBC/NoPadding";
+                EncryptionAlgorithm encAlg = EncryptionAlgorithm.fromString(nonLegacyAlg);
+                if (encAlg == null) {
+                    encAlg = EncryptionAlgorithm.AES_256_CBC;
+                }
+
+                byte[] epkiBytes = token.getCryptoStore().getEncryptedPrivateKeyInfo(
+                    null, // No password converter for non-legacy (PBKDF2 mode)
+                    pass,
+                    encAlg,
+                    0, // Use default iterations (2000 for PBKDF2)
+                    privateKey
+                );
+                key = new ANY(epkiBytes);
+            } else {  // pkcs12Mode.equals("kwp")
+                // AES Key Wrap with Padding (AES-KWP)
                 // This matches the recommended KRA settings for HSM compatibility:
                 //   keyWrap.useOAEP=true
                 //   kra.legacyPKCS12=false
                 //   kra.nonLegacyAlg=AES/None/PKCS5Padding/Kwp/256
                 // AES-KWP is secure, modern, and compatible with HSMs in FIPS mode
                 // Unlike AES-CBC, KWP doesn't require an IV, avoiding HSM compatibility issues
+                // Note: Currently fails for ML-KEM keys (NSS limitation)
                 String nonLegacyAlg = "AES/None/PKCS5Padding/Kwp/256";
                 EncryptionAlgorithm encAlg = EncryptionAlgorithm.fromString(nonLegacyAlg);
                 if (encAlg == null) {
                     // Fallback to AES-256-CBC if KWP is not available
                     encAlg = EncryptionAlgorithm.AES_256_CBC;
                 }
+
+                // Debug: Check key properties before export
+                System.out.println("DEBUG: About to export key to PKCS#12");
+                System.out.println("  Key algorithm: " + privateKey.getAlgorithm());
+                System.out.println("  Key format: " + privateKey.getFormat());
+                if (privateKey instanceof org.mozilla.jss.pkcs11.PK11PrivKey) {
+                    org.mozilla.jss.pkcs11.PK11PrivKey pk11Key = (org.mozilla.jss.pkcs11.PK11PrivKey) privateKey;
+                    System.out.println("  Owning token: " + pk11Key.getOwningToken().getName());
+                }
+                System.out.println("  Encryption algorithm: " + encAlg);
+
                 byte[] epkiBytes = token.getCryptoStore().getEncryptedPrivateKeyInfo(
                     null, // No password converter for non-legacy
                     pass,
@@ -2134,6 +3051,25 @@ public class hsmCompatVerifyServ {
 
         } finally {
             pass.clear();
+        }
+    }
+
+    /**
+     * Returns a human-readable description of the PKCS#12 encryption mode.
+     *
+     * @param pkcs12Mode The PKCS#12 mode ("kwp", "cbc", or "legacy")
+     * @return User-friendly description of the encryption mode
+     */
+    private String getPKCS12ModeDescription(String pkcs12Mode) {
+        switch (pkcs12Mode) {
+            case "kwp":
+                return "AES-256-KWP";
+            case "cbc":
+                return "AES-256-CBC (PBKDF2)";
+            case "legacy":
+                return "Legacy (PBE_SHA1_DES3_CBC)";
+            default:
+                return "Unknown (" + pkcs12Mode + ")";
         }
     }
 
@@ -2373,12 +3309,13 @@ public class hsmCompatVerifyServ {
         X509CertImpl cert,
         PublicKey publicKey,
         byte[] wrappedPrivateKey,
-        byte[] wrappedSessionKey,
-        KeyWrapAlgorithm sessionKeyWrapAlg,
+        byte[] wrappedSessionKey,  // For PQC: KEM ciphertext
+        KeyWrapAlgorithm sessionKeyWrapAlg,  // For PQC: null
         KeyWrapAlgorithm payloadWrapAlg,
         org.mozilla.jss.crypto.IVParameterSpec ivSpec,
-        String ownerName
+        boolean isPQC
     ) throws Exception {
+        String ownerName = cert.getSubjectDN().toString();
 
         java.text.SimpleDateFormat ldapDateFormat = new java.text.SimpleDateFormat("yyyyMMddHHmmss'Z'");
         ldapDateFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
@@ -2432,17 +3369,29 @@ public class hsmCompatVerifyServ {
         // Public key data (base64-encoded)
         ldif.append("publicKeyData:: ").append(java.util.Base64.getEncoder().encodeToString(publicKeyData)).append("\n");
 
+        // Certificate data (base64-encoded DER)
+        byte[] certData = cert.getEncoded();
+        ldif.append("archivedUserCert:: ").append(java.util.Base64.getEncoder().encodeToString(certData)).append("\n");
+
         // Request type - required by KRATool to identify record type
         // "enrollment" starts with "CA" which matches KRA_LDIF_CA_KEY_RECORD
         ldif.append("extdata-requesttype: enrollment\n");
 
         // Metadata - wrapping algorithms and parameters
         // These match what KRA stores in the metaInfo field
-        ldif.append("metaInfo: sessionKeyWrapAlgorithm:").append(sessionKeyWrapAlg.toString()).append("\n");
-        ldif.append("metaInfo: payloadEncrypted:false\n");
-        ldif.append("metaInfo: sessionKeyKeyGenAlgorithm:AES\n");
-        ldif.append("metaInfo: sessionKeyType:AES\n");
-        ldif.append("metaInfo: sessionKeyLength:128\n");
+        if (isPQC) {
+            // PQC mode: use KEM instead of session key wrapping
+            ldif.append("metaInfo: kemAlgorithm:ML-KEM\n");
+            ldif.append("metaInfo: kemMode:encapsulate\n");
+            ldif.append("metaInfo: payloadEncrypted:false\n");
+        } else {
+            // Non-PQC mode: traditional RSA session key wrapping
+            ldif.append("metaInfo: sessionKeyWrapAlgorithm:").append(sessionKeyWrapAlg.toString()).append("\n");
+            ldif.append("metaInfo: payloadEncrypted:false\n");
+            ldif.append("metaInfo: sessionKeyKeyGenAlgorithm:AES\n");
+            ldif.append("metaInfo: sessionKeyType:AES\n");
+            ldif.append("metaInfo: sessionKeyLength:128\n");
+        }
         // Payload wrap algorithm OID (AES KeyWrap OIDs from NIST)
         String payloadWrapOID;
         if (payloadWrapAlg.toString().contains("KeyWrap/Padding")) {
@@ -2502,6 +3451,7 @@ public class hsmCompatVerifyServ {
         Map<String, Object> currentRecord = null;
         String privateKeyDataB64 = null;
         String publicKeyDataB64 = null;
+        String archivedUserCertB64 = null;
         String sessionKeyWrapAlg = null;
         String payloadWrapAlg = null;
         String payloadWrapIV = null;
@@ -2536,6 +3486,13 @@ public class hsmCompatVerifyServ {
                         new java.security.spec.X509EncodedKeySpec(publicKeyData)
                     );
 
+                    // Decode certificate if present
+                    X509CertImpl cert = null;
+                    if (archivedUserCertB64 != null) {
+                        byte[] certData = java.util.Base64.getDecoder().decode(archivedUserCertB64);
+                        cert = new X509CertImpl(certData);
+                    }
+
                     // Parse IV if present
                     byte[] iv = null;
                     if (payloadWrapIV != null) {
@@ -2546,6 +3503,7 @@ public class hsmCompatVerifyServ {
                     currentRecord.put("wrappedPrivateKey", wrappedPrivateKey);
                     currentRecord.put("wrappedSessionKey", wrappedSessionKey);
                     currentRecord.put("publicKey", publicKey);
+                    currentRecord.put("certificate", cert);
                     currentRecord.put("sessionKeyWrapAlg", sessionKeyWrapAlg);
                     currentRecord.put("payloadWrapAlg", payloadWrapAlg);
                     currentRecord.put("payloadWrapIV", iv);
@@ -2558,6 +3516,7 @@ public class hsmCompatVerifyServ {
                 // Reset for next record
                 privateKeyDataB64 = null;
                 publicKeyDataB64 = null;
+                archivedUserCertB64 = null;
                 sessionKeyWrapAlg = null;
                 payloadWrapAlg = null;
                 payloadWrapIV = null;
@@ -2579,6 +3538,8 @@ public class hsmCompatVerifyServ {
                 privateKeyDataB64 = line.substring("privateKeyData:: ".length());
             } else if (line.startsWith("publicKeyData:: ")) {
                 publicKeyDataB64 = line.substring("publicKeyData:: ".length());
+            } else if (line.startsWith("archivedUserCert:: ")) {
+                archivedUserCertB64 = line.substring("archivedUserCert:: ".length());
             } else if (line.startsWith("metaInfo: sessionKeyWrapAlgorithm:")) {
                 sessionKeyWrapAlg = line.substring("metaInfo: sessionKeyWrapAlgorithm:".length());
             } else if (line.startsWith("metaInfo: payloadWrapAlgorithm:")) {

--- a/base/tools/src/main/java/com/netscape/cmstools/hsmCompatVerifyServ.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/hsmCompatVerifyServ.java
@@ -2592,7 +2592,7 @@ public class hsmCompatVerifyServ {
             log("Step 5: ML-KEM decapsulation with transport private key");
             log("  Decapsulating transport KEM ciphertext to recover shared secret");
 
-            recoveredSharedSecret = CryptoUtil.decapsulateMLKEM(transportPrivateKey, kemCiphertext, 32);
+            recoveredSharedSecret = CryptoUtil.decapsulateMLKEM(transportPrivateKey, kemCiphertext, 256);
             log("  - Shared secret recovered via ML-KEM decapsulation (transport)");
             log("    Shared secret size: 32 bytes (AES-256)");
         } else {
@@ -2600,7 +2600,7 @@ public class hsmCompatVerifyServ {
             log("Step 5: ML-KEM decapsulation with storage private key");
             log("  Decapsulating storage KEM ciphertext to recover shared secret");
 
-            recoveredSharedSecret = CryptoUtil.decapsulateMLKEM(storagePrivateKey, kemCiphertext, 32);
+            recoveredSharedSecret = CryptoUtil.decapsulateMLKEM(storagePrivateKey, kemCiphertext, 256);
             log("  - Shared secret recovered via ML-KEM decapsulation (storage)");
             log("    Shared secret size: 32 bytes (AES-256)");
         }
@@ -2689,7 +2689,7 @@ public class hsmCompatVerifyServ {
         log("  - Storage public key imported into token");
 
         // Encapsulate with storage public key using CryptoUtil
-        CryptoUtil.KEMEncapsulation storageEncapsulation = CryptoUtil.encapsulateMLKEM(storagePubKey, 32);
+        CryptoUtil.KEMEncapsulation storageEncapsulation = CryptoUtil.encapsulateMLKEM(storagePubKey, 256);
         SymmetricKey storageSharedSecret = storageEncapsulation.sharedSecret;
         byte[] storageKemCiphertext = storageEncapsulation.ciphertext;
 
@@ -2741,7 +2741,7 @@ public class hsmCompatVerifyServ {
         log("Step 7: KRA recovery - ML-KEM decapsulation with storage key");
 
         // Decapsulate storage KEM ciphertext with storage private key using CryptoUtil
-        SymmetricKey recoveredStorageSharedSecret = CryptoUtil.decapsulateMLKEM(storagePrivateKey, storageKemCiphertext, 32);
+        SymmetricKey recoveredStorageSharedSecret = CryptoUtil.decapsulateMLKEM(storagePrivateKey, storageKemCiphertext, 256);
 
         log("  - Storage shared secret recovered via ML-KEM decapsulation");
         log("    Shared secret size: " + recoveredStorageSharedSecret.getLength() + " bytes (AES-256)");


### PR DESCRIPTION
Adds comprehensive ML-KEM (FIPS 203) support to hsmCompatVerify verification tools:
   Depends on #5363 (CryptoUtil ML-KEM bits fix)

**PQC Mode:**
- --pqc flag enables ML-DSA for CA and ML-KEM for transport/storage
- --pqc-ca-algorithm: ml-dsa-44, ml-dsa-65, ml-dsa-87 (default: ml-dsa-65)
- --pqc-kem-algorithm: ml-kem-512, ml-kem-768, ml-kem-1024 (default: ml-kem-768)
- Uses NIST FIPS 203/204 standard hyphenated algorithm names

**User Key Type Support:**
- --user-key-type: RSA, EC, or ML-KEM (default: ML-KEM if --pqc, RSA otherwise)
- Allows verifying ML-KEM transport with different user key types
- Isolates ML-KEM transport functionality from user key operations

**PKCS#12 Modes:**
- --pkcs12-mode: kwp (AES-KWP), cbc (AES-256-CBC PBKDF2), legacy (3DES-CBC)
- Default: kwp
- Supports ML-KEM key export to PKCS#12

**CryptoUtil Integration:**
- Uses CryptoUtil.getMLDSAStrength() for algorithm name mapping
- Uses CryptoUtil.getMLDSASignatureAlgorithm() for signature algorithms
- Uses CryptoUtil.getMLKEMStrength() for KEM strength mapping
- Uses CryptoUtil.encapsulateMLKEM() for key wrapping
- Uses CryptoUtil.decapsulateMLKEM() for key unwrapping (3 occurrences)
- Replaces ~100 lines of switch statements and KEM boilerplate with helper calls

**Bug Fixes:**
- Fix --p12-output path handling to respect relative paths from CWD
- Add ML-KEM recognition to CryptoUtil.unwrap()

**Verification Improvements:**
- --test-decrypt-user flag for debugging wrapped key data
- Enhanced configuration output for PQC-specific options
- Hides non-applicable options in PQC mode

This enables end-to-end verification of ML-KEM key encapsulation for KRA transport and storage certificates, validating the PQC migration path.

IDM-6295, IDM-5815, IDM-5475
Assisted-by: Claude