### PR TITLE
Add ML-KEM storage support to KRA key archival

### DIFF
--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -143,7 +143,14 @@ kra.storageUnit.wrapping.0.payloadEncryptionIV=AQEBAQEBAQE=
 kra.storageUnit.wrapping.0.payloadWrapAlgorithm=DES3/CBC/Pad
 kra.storageUnit.wrapping.0.payloadWrapIV=AQEBAQEBAQE=
 kra.storageUnit.wrapping.0.sessionKeyType=DESede
-kra.storageUnit.wrapping.1.sessionKeyLength=128
+kra.storageUnit.wrapping._000=##
+kra.storageUnit.wrapping._001=## wrapping.1 settings apply to RSA, EC, and ML-KEM storage certs
+kra.storageUnit.wrapping._002=## For ML-KEM: sessionKeyWrapAlgorithm and sessionKeyKeyGenAlgorithm
+kra.storageUnit.wrapping._003=## are not used (ML-KEM uses encapsulation, not wrapping/generation)
+kra.storageUnit.wrapping._004=## payloadEncryption* fields only used when kra.allowEncDecrypt.archival=true
+kra.storageUnit.wrapping._005=## (ML-KEM does not support allowEncDecrypt.archival)
+kra.storageUnit.wrapping._006=##
+kra.storageUnit.wrapping.1.sessionKeyLength=256
 kra.storageUnit.wrapping.1.sessionKeyWrapAlgorithm=RSA
 kra.storageUnit.wrapping.1.payloadEncryptionPadding=PKCS5Padding
 kra.storageUnit.wrapping.1.sessionKeyKeyGenAlgorithm=AES
@@ -155,6 +162,20 @@ kra.storageUnit.wrapping.1.sessionKeyType=AES
 kra.storageUnit.wrapping.choice=1
 kra.storageUnit.nickName=
 kra.transportUnit.nickName=
+kra._000=##
+kra._001=## Key Wrapping and PKCS#12 Security Settings
+kra._002=##
+kra._003=## For improved security, the following settings are recommended:
+kra._004=##
+kra._005=## 1. Use OAEP for RSA session key wrapping (applies to RSA storage certs only)
+kra._006=##    ML-KEM storage certs use encapsulation, not RSA wrapping
+keyWrap.useOAEP=true
+kra._007=##
+kra._008=## 2. Use AES-256-KWP for PKCS#12 encryption (applies to all storage certs)
+kra._009=##    Legacy mode uses DES3, which is less secure
+kra.legacyPKCS12=false
+kra.nonLegacyAlg=AES/None/PKCS5Padding/Kwp/256
+kra._010=##
 log._000=##
 log._001=## Logging
 log._002=##

--- a/base/kra/src/main/java/com/netscape/kra/AsymKeyGenService.java
+++ b/base/kra/src/main/java/com/netscape/kra/AsymKeyGenService.java
@@ -325,7 +325,8 @@ public class AsymKeyGenService implements IService {
         }
 
         try {
-            record.setWrappingParams(params, allowEncDecrypt_archival);
+            String storageKeyAlg = storageUnit.getPublicKey().getAlgorithm();
+            record.setWrappingParams(params, allowEncDecrypt_archival, storageKeyAlg);
         } catch (Exception e) {
             errmsg = "Unable to store wrapping parameters: " + e.getMessage();
             logger.error("AsymKeyGenService: " + errmsg);

--- a/base/kra/src/main/java/com/netscape/kra/EnrollmentService.java
+++ b/base/kra/src/main/java/com/netscape/kra/EnrollmentService.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.util.Arrays;
@@ -72,6 +73,7 @@ import com.netscape.cmscore.logging.Auditor;
 import com.netscape.cmscore.request.Request;
 import com.netscape.cmscore.security.JssSubsystem;
 import com.netscape.cmscore.util.StatsSubsystem;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
  * A class represents archival request processor. It
@@ -407,9 +409,12 @@ public class EnrollmentService implements IService {
 
             //
             // privateKeyData ::= SEQUENCE {
-            //                       sessionKey OCTET_STRING,
-            //                       encKey OCTET_STRING,
-            //                    }
+            //     sessionKey OCTET_STRING,  // RSA/EC storage: wrapped session key
+            //                               // ML-KEM storage: KEM ciphertext
+            //     encKey OCTET_STRING,      // User private key wrapped with session key/shared secret
+            // }
+            //
+            // Note: allowEncDecrypt_archival is not supported for ML-KEM storage at this time.
             //
             if (statsSub != null) {
                 statsSub.startTiming("encrypt_user_key");
@@ -421,6 +426,12 @@ public class EnrollmentService implements IService {
                 params = mStorageUnit.getWrappingParams(allowEncDecrypt_archival);
 
                 if (allowEncDecrypt_archival == true) {
+                    String storageAlg = mStorageUnit.getPublicKey().getAlgorithm();
+                    if (CryptoUtil.isAlgorithmMLKEM(storageAlg)) {
+                        String msg = "allowEncDecrypt_archival not supported with ML-KEM storage certificate";
+                        logger.error("EnrollmentService: " + msg);
+                        throw new EKRAException(msg);
+                    }
                     logger.info("EnrollmentService: Encrypting internal private key");
                     privateKeyData = mStorageUnit.encryptInternalPrivate(unwrapped, params);
                 } else {
@@ -508,6 +519,18 @@ public class EnrollmentService implements IService {
                 rec.set(KeyRecord.ATTR_META_INFO, metaInfo);
                 // key size does not apply to EC
                 rec.setKeySize(-1);
+            } else if (CryptoUtil.isAlgorithmMLKEM(keyAlg)) {
+                // ML-KEM keys: extract strength parameter
+                try {
+                    int strength = CryptoUtil.getMLKEMStrength(keyAlg);
+                    rec.setKeySize(Integer.valueOf(strength));
+
+                    logger.debug("EnrollmentService: ML-KEM key archived - algorithm: " + keyAlg + ", strength: " + strength);
+
+                } catch (NoSuchAlgorithmException e) {
+                    logger.warn("EnrollmentService: Unable to determine ML-KEM strength: " + e.getMessage(), e);
+                    rec.setKeySize(-1);
+                }
             }
 
             // if record already has a serial number, yell out.

--- a/base/kra/src/main/java/com/netscape/kra/EnrollmentService.java
+++ b/base/kra/src/main/java/com/netscape/kra/EnrollmentService.java
@@ -558,7 +558,8 @@ public class EnrollmentService implements IService {
             }
 
             try {
-                rec.setWrappingParams(params, allowEncDecrypt_archival);
+                String storageKeyAlg = mStorageUnit.getPublicKey().getAlgorithm();
+                rec.setWrappingParams(params, allowEncDecrypt_archival, storageKeyAlg);
             } catch (Exception e) {
                 logger.error("EnrollmentService: Unable to store wrapping parameters: " + e.getMessage(), e);
                 // TODO(alee) Set correct audit message here

--- a/base/kra/src/main/java/com/netscape/kra/NetkeyKeygenService.java
+++ b/base/kra/src/main/java/com/netscape/kra/NetkeyKeygenService.java
@@ -606,7 +606,8 @@ public class NetkeyKeygenService implements IService {
                         throw new Exception("Unable to generate next serial number");
                     }
 
-                    rec.setWrappingParams(params, allowEncDecrypt_archival);
+                    String storageKeyAlg = mStorageUnit.getPublicKey().getAlgorithm();
+                    rec.setWrappingParams(params, allowEncDecrypt_archival, storageKeyAlg);
 
                     logger.debug("NetkeyKeygenService: before addKeyRecord");
                     rec.set(KeyRecord.ATTR_ID, serialNo);

--- a/base/kra/src/main/java/com/netscape/kra/SecurityDataProcessor.java
+++ b/base/kra/src/main/java/com/netscape/kra/SecurityDataProcessor.java
@@ -335,7 +335,8 @@ public class SecurityDataProcessor {
         }
 
         try {
-            rec.setWrappingParams(params, doEncrypt);
+            String storageKeyAlg = storageUnit.getPublicKey().getAlgorithm();
+            rec.setWrappingParams(params, doEncrypt, storageKeyAlg);
         } catch (Exception e) {
             logger.error("Unable to store wrapping parameters: " + e.getMessage(), e);
 

--- a/base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java
+++ b/base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java
@@ -1115,15 +1115,50 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
             logger.debug("StorageKeyUnit.encryptInternalPrivate");
             CryptoToken internalToken = getInternalToken();
 
-            // (1) generate session key
-            SymmetricKey sk = CryptoUtil.generateKey(
-                    internalToken,
-                    params.getSkKeyGenAlgorithm(),
-                    params.getSkLength(),
-                    null,
-                    false);
+            PublicKey storagePubKey = getPublicKey();
+            String storageAlg = storagePubKey.getAlgorithm();
 
-            // (2) wrap private key with session key
+            SymmetricKey sk;
+            byte[] session;
+
+            // Check if storage cert is ML-KEM (PQC)
+            if (CryptoUtil.isAlgorithmMLKEM(storageAlg)) {
+                logger.debug("StorageKeyUnit.encryptInternalPrivate: Using ML-KEM storage cert");
+
+                // ML-KEM requires the public key to be imported as a
+                // PKCS#11 object on the token for PK11_Encapsulate
+                internalToken.importPublicKey(storagePubKey, false);
+
+                // (1) ML-KEM encapsulation to generate shared secret
+                CryptoUtil.KEMEncapsulation kemResult = CryptoUtil.encapsulateMLKEM(
+                        storagePubKey,
+                        params.getSkLength());
+
+                sk = kemResult.sharedSecret;
+                session = kemResult.ciphertext;
+
+                logger.debug("StorageKeyUnit.encryptInternalPrivate: ML-KEM encapsulation complete");
+
+            } else {
+                // (1) RSA/EC: generate session key
+                logger.debug("StorageKeyUnit.encryptInternalPrivate: Using RSA/EC storage cert");
+
+                sk = CryptoUtil.generateKey(
+                        internalToken,
+                        params.getSkKeyGenAlgorithm(),
+                        params.getSkLength(),
+                        null,
+                        false);
+
+                // (3) wrap session with storage public
+                session = CryptoUtil.wrapUsingPublicKey(
+                        internalToken,
+                        storagePubKey,
+                        sk,
+                        params.getSkWrapAlgorithm());
+            }
+
+            // (2) wrap private key with session key (or shared secret for ML-KEM)
             byte[] pri = CryptoUtil.encryptUsingSymmetricKey(
                     internalToken,
                     sk,
@@ -1131,17 +1166,11 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
                     params.getPayloadEncryptionAlgorithm(),
                     params.getPayloadEncryptionIV());
 
-            // (3) wrap session with storage public
-            byte[] session = CryptoUtil.wrapUsingPublicKey(
-                    internalToken,
-                    getPublicKey(),
-                    sk,
-                    params.getSkWrapAlgorithm());
-
             // use MY own structure for now:
             // SEQUENCE {
-            //     encryptedSession OCTET STRING,
-            //     encryptedPrivate OCTET STRING
+            //     encryptedSession OCTET STRING,  // RSA/EC: wrapped session key
+            //                                     // ML-KEM: KEM ciphertext
+            //     encryptedPrivate OCTET STRING   // Private key wrapped with session key/shared secret
             // }
 
             DerOutputStream tmp = new DerOutputStream();
@@ -1176,21 +1205,57 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
             logger.debug("StorageKeyUnit.wrap interal.");
             CryptoToken token = getToken();
 
-            SymmetricKey.Usage usages[] = new SymmetricKey.Usage[2];
-            usages[0] = SymmetricKey.Usage.WRAP;
-            usages[1] = SymmetricKey.Usage.UNWRAP;
+            PublicKey storagePubKey = getPublicKey();
+            String storageAlg = storagePubKey.getAlgorithm();
 
-            // (1) generate session key
-            SymmetricKey sk = CryptoUtil.generateKey(
-                    token,
-                    params.getSkKeyGenAlgorithm(),
-                    params.getSkLength(),
-                    usages,
-                    true);
+            SymmetricKey sk;
+            byte[] session;
 
-            // (2) wrap private key with session key
-            // KeyWrapper wrapper = internalToken.getKeyWrapper(
+            // Check if storage cert is ML-KEM (PQC)
+            if (CryptoUtil.isAlgorithmMLKEM(storageAlg)) {
+                logger.debug("StorageKeyUnit:wrap() Using ML-KEM storage cert");
 
+                // ML-KEM requires the public key to be imported as a
+                // PKCS#11 object on the token for PK11_Encapsulate
+                token.importPublicKey(storagePubKey, false);
+
+                // (1) ML-KEM encapsulation to generate shared secret
+                CryptoUtil.KEMEncapsulation kemResult = CryptoUtil.encapsulateMLKEM(
+                        storagePubKey,
+                        params.getSkLength());
+
+                sk = kemResult.sharedSecret;
+                session = kemResult.ciphertext;
+
+                logger.debug("StorageKeyUnit:wrap() ML-KEM encapsulation complete - ciphertext size: "
+                        + session.length + " bytes");
+
+            } else {
+                // (1) RSA/EC: generate session key
+                logger.debug("StorageKeyUnit:wrap() Using RSA/EC storage cert");
+
+                SymmetricKey.Usage usages[] = new SymmetricKey.Usage[2];
+                usages[0] = SymmetricKey.Usage.WRAP;
+                usages[1] = SymmetricKey.Usage.UNWRAP;
+
+                sk = CryptoUtil.generateKey(
+                        token,
+                        params.getSkKeyGenAlgorithm(),
+                        params.getSkLength(),
+                        usages,
+                        true);
+
+                // (3) wrap session key with storage public key
+                session = CryptoUtil.wrapUsingPublicKey(
+                        token,
+                        storagePubKey,
+                        sk,
+                        params.getSkWrapAlgorithm());
+
+                logger.debug("StorageKeyUnit:wrap() session key wrapped");
+            }
+
+            // (2) wrap private key with session key (or shared secret for ML-KEM)
             byte pri[] = null;
 
             if (priKey != null) {
@@ -1211,17 +1276,11 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
 
             logger.debug("StorageKeyUnit:wrap() privKey wrapped");
 
-            byte[] session = CryptoUtil.wrapUsingPublicKey(
-                    token,
-                    getPublicKey(),
-                    sk,
-                    params.getSkWrapAlgorithm());
-            logger.debug("StorageKeyUnit:wrap() session key wrapped");
-
             // use MY own structure for now:
             // SEQUENCE {
-            //     encryptedSession OCTET STRING,
-            //     encryptedPrivate OCTET STRING
+            //     encryptedSession OCTET STRING,  // RSA/EC: wrapped session key
+            //                                     // ML-KEM: KEM ciphertext
+            //     encryptedPrivate OCTET STRING   // User private key wrapped with session key/shared secret
             // }
 
             DerOutputStream tmp = new DerOutputStream();

--- a/base/kra/src/main/java/com/netscape/kra/SymKeyGenService.java
+++ b/base/kra/src/main/java/com/netscape/kra/SymKeyGenService.java
@@ -276,7 +276,8 @@ public class SymKeyGenService implements IService {
         }
 
         try {
-            rec.setWrappingParams(params, allowEncDecrypt_archival);
+            String storageKeyAlg = mStorageUnit.getPublicKey().getAlgorithm();
+            rec.setWrappingParams(params, allowEncDecrypt_archival, storageKeyAlg);
         } catch (Exception e) {
             String message = "Unable to store wrapping parameters: " + e.getMessage();
             logger.error("SymKeyGenService: " + message, e);

--- a/base/server/src/main/java/com/netscape/cms/servlet/key/KeyRecordParser.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/key/KeyRecordParser.java
@@ -47,6 +47,7 @@ public class KeyRecordParser {
     public final static String OUT_RECOVERED_ON = "recoveredOn";
 
     /* parameters to populate WrappingParams */
+    public final static String OUT_STORAGE_KEY_ALGORITHM = "storageKeyAlgorithm";
     public final static String OUT_SK_TYPE = "sessionKeyType";
     public final static String OUT_SK_KEYGEN_ALGORITHM = "sessionKeyKeyGenAlgorithm";
     public final static String OUT_SK_LENGTH = "sessionKeyLength";

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/KeyRecord.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/KeyRecord.java
@@ -33,6 +33,7 @@ import com.netscape.certsrv.base.EBaseException;
 import com.netscape.certsrv.base.MetaInfo;
 import com.netscape.certsrv.dbs.keydb.KeyState;
 import com.netscape.cms.servlet.key.KeyRecordParser;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
  * A class represents a Key record. It maintains the key
@@ -457,26 +458,67 @@ public class KeyRecord extends DBRecord {
         return realm;
     }
 
+    /**
+     * Sets wrapping parameters for key record metadata.
+     * Backwards compatibility method - calls overloaded version with storageKeyAlg=null.
+     */
     public void setWrappingParams(WrappingParams params, boolean doEncrypt) throws Exception {
+        setWrappingParams(params, doEncrypt, null);
+    }
+
+    /**
+     * Sets wrapping parameters for key record metadata.
+     *
+     * There are two archival paths:
+     * 1. Normal wrapping path (doEncrypt=false):
+     *    - Uses StorageKeyUnit.wrap() → wrapUsingSymmetricKey()
+     *    - Records: sessionKey*, payloadWrapAlgorithm, payloadWrappingIV
+     *    - For ML-KEM: skips sessionKeyWrapAlgorithm, sessionKeyKeyGenAlgorithm
+     *
+     * 2. Encryption path (doEncrypt=true, allowEncDecrypt_archival=true):
+     *    - Uses StorageKeyUnit.encryptInternalPrivate() → encryptUsingSymmetricKey()
+     *    - Records: sessionKey*, payloadEncryptionOID, payloadEncryptionIV
+     *    - Note: ML-KEM does NOT support this path (blocked in EnrollmentService)
+     *
+     * @param params Wrapping parameters from storage unit
+     * @param doEncrypt Whether encryption was used (vs wrapping)
+     * @param storageKeyAlg Storage cert public key algorithm (e.g., "RSA", "EC", "ML-KEM-1024")
+     */
+    public void setWrappingParams(WrappingParams params, boolean doEncrypt, String storageKeyAlg) throws Exception {
         if (mMetaInfo == null) {
             mMetaInfo = new MetaInfo();
         }
+
+        // Detect if ML-KEM is used
+        boolean isMLKEM = CryptoUtil.isAlgorithmMLKEM(storageKeyAlg);
+
+        // Record the storage key algorithm for clarity
+        if (storageKeyAlg != null) {
+            mMetaInfo.set(KeyRecordParser.OUT_STORAGE_KEY_ALGORITHM, storageKeyAlg);
+        }
+
         // set session key parameters
         mMetaInfo.set(KeyRecordParser.OUT_SK_LENGTH, String.valueOf(params.getSkLength()));
         if (params.getSkType() != null) {
             mMetaInfo.set(KeyRecordParser.OUT_SK_TYPE, params.getSkType().toString());
         }
-        if (params.getSkKeyGenAlgorithm() != null) {
+
+        // For ML-KEM, skip sessionKeyKeyGenAlgorithm (key is derived via KEM, not generated)
+        if (!isMLKEM && params.getSkKeyGenAlgorithm() != null) {
             // JSS doesn't have a name map or a functional OID map
             // for now, save the "name"
             mMetaInfo.set(KeyRecordParser.OUT_SK_KEYGEN_ALGORITHM, params.getSkKeyGenAlgorithm().toString());
         }
-        if (params.getSkWrapAlgorithm() != null) {
+
+        // For ML-KEM, skip sessionKeyWrapAlgorithm (uses encapsulation, not wrapping)
+        if (!isMLKEM && params.getSkWrapAlgorithm() != null) {
             mMetaInfo.set(KeyRecordParser.OUT_SK_WRAP_ALGORITHM, params.getSkWrapAlgorithm().toString());
         }
 
         // set payload parameters
-        if (params.getPayloadEncryptionAlgorithm() != null) {
+        // Only set encryption parameters if doEncrypt=true (allowEncDecrypt_archival path)
+        // Normal wrapping path uses payloadWrapAlgorithm instead
+        if (doEncrypt && params.getPayloadEncryptionAlgorithm() != null) {
             EncryptionAlgorithm encrypt = params.getPayloadEncryptionAlgorithm();
             try {
                 OBJECT_IDENTIFIER oid = encrypt.toOID();
@@ -488,17 +530,19 @@ public class KeyRecord extends DBRecord {
                 mMetaInfo.set(KeyRecordParser.OUT_PL_ENCRYPTION_PADDING, encrypt.getPadding().toString());
             }
         }
-        if (params.getPayloadWrapAlgorithm() != null) {
+        // Wrapping parameters are used in normal path (doEncrypt=false)
+        if (!doEncrypt && params.getPayloadWrapAlgorithm() != null) {
             mMetaInfo.set(KeyRecordParser.OUT_PL_WRAP_ALGORITHM, params.getPayloadWrapAlgorithm().toString());
         }
-        if (params.getPayloadWrappingIV() != null) {
+        if (!doEncrypt && params.getPayloadWrappingIV() != null) {
             // store as base64 encoded string
             mMetaInfo.set(
                 KeyRecordParser.OUT_PL_WRAP_IV,
                 Base64.encodeBase64String(params.getPayloadWrappingIV().getIV())
             );
         }
-        if (params.getPayloadEncryptionIV() != null) {
+        // Only set encryption IV if doEncrypt=true (allowEncDecrypt_archival path)
+        if (doEncrypt && params.getPayloadEncryptionIV() != null) {
             // store as base 64 encoded string
             mMetaInfo.set(
                 KeyRecordParser.OUT_PL_ENCRYPTION_IV,
@@ -529,10 +573,11 @@ public class KeyRecord extends DBRecord {
         data = mMetaInfo.get(KeyRecordParser.OUT_PL_WRAP_ALGORITHM);
         if (data != null) params.setPayloadWrapAlgorithm(data.toString());
 
+        // Only set encryption algorithm if present (only stored when doEncrypt=true)
         if (mMetaInfo.get(KeyRecordParser.OUT_PL_ENCRYPTION_OID) != null) {
             String oidString = mMetaInfo.get(KeyRecordParser.OUT_PL_ENCRYPTION_OID).toString();
             params.setPayloadEncryptionAlgorithm(EncryptionAlgorithm.fromOID(new OBJECT_IDENTIFIER(oidString)));
-        } else {
+        } else if (mMetaInfo.get(KeyRecordParser.OUT_PL_ENCRYPTION_ALGORITHM) != null) {
             params.setPayloadEncryptionAlgorithm(
                 mMetaInfo.get(KeyRecordParser.OUT_PL_ENCRYPTION_ALGORITHM).toString(),
                 mMetaInfo.get(KeyRecordParser.OUT_PL_ENCRYPTION_MODE).toString(),


### PR DESCRIPTION
  This PR adds ML-KEM support to KRA key archival, focusing on the storage
  certificate side (encapsulation and wrapping) and keyRecord metadata
  improvements.

  **Scope:** This PR handles the KRA storage operations after the user's
  private key has been received by the KRA. The client-side changes
  (CRMFPopClient) and ML-KEM transport certificate support are covered
  separately in PR #5364.

  ## Commit 1: Add ML-KEM support to KRA key archival

  Implements ML-KEM key archival when using an ML-KEM storage certificate:
  - ML-KEM storage certs use encapsulation to derive a shared secret
  (instead of RSA/EC session key wrapping)
  - User private keys are wrapped with the shared secret using AES-KWP
  - Backward-compatible privateKeyData structure: `SEQUENCE { kemCiphertext,
   wrappedPrivateKey }`
  - Runtime enforcement prevents ML-KEM storage certs from using
  `allowEncDecrypt_archival` mode

  Recovery support will be added in a separate PR.

  ## Commit 2: Improve ML-KEM keyRecord metadata and upgrade to AES-256

  Cleans up keyRecord metadata and upgrades security defaults:
  - Skips non-applicable metadata fields for ML-KEM
  (sessionKeyWrapAlgorithm, sessionKeyKeyGenAlgorithm,
  payloadEncryptionOID/IV)
  - Adds `storageKeyAlgorithm` field for clear visibility (shows "ML-KEM",
  "RSA", or "EC")
  - Upgrades sessionKeyLength from AES-128 to AES-256
  - Adds recommended security settings to CS.cfg (OAEP, modern PKCS#12)

  **Before (ML-KEM keyRecord):**
  metaInfo: sessionKeyWrapAlgorithm:RSA
  metaInfo: sessionKeyKeyGenAlgorithm:AES
  metaInfo: sessionKeyLength:128
  metaInfo: payloadEncryptionOID:2.16.840.1.101.3.4.1.2
  metaInfo: payloadEncryptionIV:N5Dpy30TAonmtwgnCdFpKg==
  metaInfo: payloadWrapAlgorithm:AES KeyWrap/Padding

  **After (ML-KEM keyRecord):**
  metaInfo: storageKeyAlgorithm:ML-KEM
  metaInfo: sessionKeyLength:256
  metaInfo: payloadWrapAlgorithm:AES KeyWrap/Padding

  ---
  IDM-5472, IDM-6363
  Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ML-KEM (quantum‑safe) support for key wrapping and storage; storage algorithm is now recorded with key metadata and used when creating/archiveing keys.
  * Archive flow now captures ML‑KEM key strength when available, with a safe fallback if not.

* **Bug Fixes / Behaviour**
  * Archival now rejects incompatible ML‑KEM storage modes to prevent unsupported archival.

* **Chores / Configuration**
  * Session key length increased to 256 bits; OAEP enabled; legacy PKCS#12 disabled; non‑legacy AES‑256‑KWP selected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->