### PR TITLE
Add ML-KEM support for KRA key recovery

### DIFF
--- a/base/common/src/main/java/com/netscape/certsrv/key/KeyClient.java
+++ b/base/common/src/main/java/com/netscape/certsrv/key/KeyClient.java
@@ -565,16 +565,31 @@ public class KeyClient extends Client {
         if (passphrase == null) {
             throw new IllegalArgumentException("Passphrase must be specified.");
         }
-        KeyWrapAlgorithm alg = KeyWrapAlgorithm.RSA;
 
-        if(this.useOAEP == true) {
-            alg = KeyWrapAlgorithm.RSA_OAEP;
+        SymmetricKey sessionKey;
+        byte[] transWrappedSessionKey;
+
+        // Check if transport key is ML-KEM
+        if (CryptoUtil.isAlgorithmMLKEM(transportCert.getPublicKey().getAlgorithm())) {
+            // ML-KEM: Encapsulate to get shared secret + ciphertext
+            CryptoUtil.KEMEncapsulation kemResult = crypto.encapsulateMLKEM(
+                transportCert.getPublicKey(),
+                encryptAlgorithm
+            );
+            sessionKey = kemResult.sharedSecret;
+            transWrappedSessionKey = kemResult.ciphertext;
+        } else {
+            // RSA/EC: Generate session key and wrap it
+            KeyWrapAlgorithm alg = KeyWrapAlgorithm.RSA;
+            if (this.useOAEP == true) {
+                alg = KeyWrapAlgorithm.RSA_OAEP;
+            }
+            sessionKey = generateSessionKey();
+            transWrappedSessionKey = crypto.wrapSymmetricKey(sessionKey, transportCert.getPublicKey(), alg);
         }
 
-        SymmetricKey sessionKey = generateSessionKey();
-        byte[] transWrappedSessionKey = crypto.wrapSymmetricKey(sessionKey, transportCert.getPublicKey(),alg);
+        // Encrypt passphrase with session key (works for both ML-KEM and RSA/EC)
         byte[] nonceData = CryptoUtil.getNonceData(encryptAlgorithm.getIVLength());
-
         byte[] secret = passphrase.getBytes("UTF-8");
         byte[] sessionWrappedPassphrase = crypto.encryptSecret(secret, nonceData, sessionKey,
                 encryptAlgorithm);
@@ -589,16 +604,31 @@ public class KeyClient extends Client {
         if (passphrase == null) {
             throw new IllegalArgumentException("Passphrase must be specified.");
         }
-        KeyWrapAlgorithm alg = KeyWrapAlgorithm.RSA;
 
-        if(this.useOAEP == true) {
-            alg = KeyWrapAlgorithm.RSA_OAEP;
+        SymmetricKey sessionKey;
+        byte[] transWrappedSessionKey;
+
+        // Check if transport key is ML-KEM
+        if (CryptoUtil.isAlgorithmMLKEM(transportCert.getPublicKey().getAlgorithm())) {
+            // ML-KEM: Encapsulate to get shared secret + ciphertext
+            CryptoUtil.KEMEncapsulation kemResult = crypto.encapsulateMLKEM(
+                transportCert.getPublicKey(),
+                encryptAlgorithm
+            );
+            sessionKey = kemResult.sharedSecret;
+            transWrappedSessionKey = kemResult.ciphertext;
+        } else {
+            // RSA/EC: Generate session key and wrap it
+            KeyWrapAlgorithm alg = KeyWrapAlgorithm.RSA;
+            if (this.useOAEP == true) {
+                alg = KeyWrapAlgorithm.RSA_OAEP;
+            }
+            sessionKey = generateSessionKey();
+            transWrappedSessionKey = crypto.wrapSymmetricKey(sessionKey, transportCert.getPublicKey(), alg);
         }
 
-        SymmetricKey sessionKey = generateSessionKey();
-        byte[] transWrappedSessionKey = crypto.wrapSymmetricKey(sessionKey, transportCert.getPublicKey(),alg);
+        // Encrypt passphrase with session key (works for both ML-KEM and RSA/EC)
         byte[] nonceData = CryptoUtil.getNonceData(encryptAlgorithm.getIVLength());
-
         byte[] secret = passphrase.getBytes("UTF-8");
         byte[] sessionWrappedPassphrase = crypto.encryptSecret(secret, nonceData, sessionKey,
                 encryptAlgorithm);

--- a/base/common/src/main/java/com/netscape/certsrv/util/CryptoProvider.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/CryptoProvider.java
@@ -6,6 +6,8 @@ import org.mozilla.jss.crypto.EncryptionAlgorithm;
 import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.SymmetricKey;
 
+import com.netscape.cmsutil.crypto.CryptoUtil;
+
 /**
  * An abstract class defining the functionality to be provided by
  * sub classes to perform cryptographic operations.
@@ -54,6 +56,18 @@ public abstract class CryptoProvider {
 
     public abstract byte[] unwrapAsymmetricKeyWithSessionKey(byte[] wrappedRecoveredKey, SymmetricKey recoveryKey,
             KeyWrapAlgorithm wrapAlgorithm, byte[] nonceData, PublicKey pubKey)
+            throws Exception;
+
+    /**
+     * Performs ML-KEM encapsulation to generate a shared secret.
+     * Imports the public key to the token before performing encapsulation.
+     *
+     * @param publicKey ML-KEM public key
+     * @param encAlg Encryption algorithm (determines derived key size)
+     * @return KEMEncapsulation containing shared secret and ciphertext
+     * @throws Exception if encapsulation fails
+     */
+    public abstract CryptoUtil.KEMEncapsulation encapsulateMLKEM(PublicKey publicKey, EncryptionAlgorithm encAlg)
             throws Exception;
 
 }

--- a/base/common/src/main/java/com/netscape/certsrv/util/NSSCryptoProvider.java
+++ b/base/common/src/main/java/com/netscape/certsrv/util/NSSCryptoProvider.java
@@ -81,9 +81,41 @@ public class NSSCryptoProvider extends CryptoProvider {
             Password password = new Password(certDBPassword.toCharArray());
             try {
                 token.login(password);
+
+                // Check if login actually succeeded - token.login() can return without error
+                // even when the token has no password set
+                if (!token.isLoggedIn()) {
+                    System.err.println("WARNING: NSS token login succeeded but token is not logged in.");
+                    System.err.println("         The NSS database may not have a password set.");
+                    System.err.println("         Attempting to initialize password automatically.");
+                    System.err.println("         To avoid this warning, set a password manually using:");
+                    System.err.println("           certutil -W -d <path-to-nssdb>");
+                    try {
+                        token.initPassword(password, password);
+                        token.login(password);
+                    } catch (AlreadyInitializedException e2) {
+                        // Password already initialized but login still failed - this shouldn't happen
+                        System.err.println("ERROR: Token password already initialized but login failed.");
+                        System.err.println("       Check that the NSS database is not corrupted.");
+                        throw new TokenException("Token password already initialized but login failed - NSS database may be corrupted");
+                    }
+                }
             } catch (IncorrectPasswordException | TokenException e) {
                 if (!token.isLoggedIn()) {
-                    token.initPassword(password, password);
+                    // Login failed - check if database was never initialized with a password
+                    // If so, initialize it now and retry login
+                    try {
+                        System.err.println("WARNING: NSS token login failed. Database may be uninitialized.");
+                        System.err.println("         Attempting to initialize password automatically.");
+                        System.err.println("         To avoid this, initialize the database password manually using:");
+                        System.err.println("           certutil -W -d <path-to-nssdb>");
+                        token.initPassword(password, password);
+                        token.login(password);
+                    } catch (AlreadyInitializedException e2) {
+                        // Password was already set, so original exception was due to wrong password
+                        // or other issue - rethrow original exception
+                        throw e;
+                    }
                 }
             } finally {
                 password.clear();
@@ -293,5 +325,22 @@ public class NSSCryptoProvider extends CryptoProvider {
                 secret,
                 ivps,
                 wrapAlg);
+    }
+
+    @Override
+    public CryptoUtil.KEMEncapsulation encapsulateMLKEM(PublicKey publicKey, EncryptionAlgorithm encAlg)
+            throws Exception {
+        if (token == null) {
+            throw new NotInitializedException();
+        }
+        if (publicKey == null) {
+            throw new IllegalArgumentException("publicKey cannot be null");
+        }
+        if (encAlg == null) {
+            throw new IllegalArgumentException("encAlg cannot be null");
+        }
+        // ML-KEM requires the public key to be imported to the token
+        token.importPublicKey(publicKey, false);
+        return CryptoUtil.encapsulateMLKEM(publicKey, encAlg.getKeyStrength());
     }
 }

--- a/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -2273,6 +2273,19 @@ public class CryptoUtil {
             CryptoToken token,
             PublicKey wrappingKey,
             SymmetricKey sk) throws Exception {
+
+        String wrappingAlg = wrappingKey.getAlgorithm();
+
+        if (wrappingAlg == null) {
+            throw new Exception("Unable to determine transport key algorithm");
+        }
+
+        if (isAlgorithmMLKEM(wrappingAlg)) {
+            throw new Exception("ML-KEM cannot wrap existing symmetric keys. " +
+                    "Use encapsulateMLKEM() instead - ML-KEM encapsulation generates a new shared secret.");
+        }
+
+        // RSA/EC: Use traditional key wrapping
         return wrapUsingPublicKey(token, wrappingKey, sk, KeyWrapAlgorithm.RSA);
     }
 
@@ -2945,6 +2958,19 @@ public class CryptoUtil {
     public static byte[] wrapUsingPublicKey(CryptoToken token, PublicKey wrappingKey, SymmetricKey data,
             KeyWrapAlgorithm alg) throws Exception {
         String method = "CryptoUtil.wrapUsingPublicKey ";
+
+        String wrappingAlg = wrappingKey.getAlgorithm();
+
+        if (wrappingAlg == null) {
+            throw new Exception("Unable to determine wrapping key algorithm");
+        }
+
+        if (isAlgorithmMLKEM(wrappingAlg)) {
+            throw new Exception("ML-KEM cannot wrap existing symmetric keys. " +
+                    "Use encapsulateMLKEM() instead - ML-KEM encapsulation generates a new shared secret.");
+        }
+
+        // RSA/EC: Use traditional key wrapping
         KeyWrapper rsaWrap = token.getKeyWrapper(alg);
         logger.debug(method + " KeyWrapAlg: " + alg);
         if (alg.equals(KeyWrapAlgorithm.RSA_OAEP)) {

--- a/base/kra/src/main/java/com/netscape/kra/EncryptionUnit.java
+++ b/base/kra/src/main/java/com/netscape/kra/EncryptionUnit.java
@@ -81,6 +81,16 @@ public abstract class EncryptionUnit implements IEncryptionUnit {
             WrappingParams params) throws Exception {
         PrivateKey wrappingKey = getPrivateKey();
         String priKeyAlgo = wrappingKey.getAlgorithm();
+
+        // For ML-KEM transport keys, use decapsulation instead of traditional key unwrapping
+        // The encSymmKey contains the KEM ciphertext, not a wrapped key
+        if (CryptoUtil.isAlgorithmMLKEM(priKeyAlgo)) {
+            logger.debug("EncryptionUnit.unwrap_session_key: Using ML-KEM decapsulation");
+            return CryptoUtil.decapsulateMLKEM(wrappingKey,
+                     encSymmKey,
+                     params.getPayloadEncryptionAlgorithm());
+        }
+
         if (priKeyAlgo.equals("EC"))
             params.setSkWrapAlgorithm(KeyWrapAlgorithm.AES_ECB);
 

--- a/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
+++ b/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
@@ -331,6 +331,18 @@ public class RecoveryService implements IService {
                 encrypted = allowEncDecrypt_recovery;
             }
 
+            // Check if allowEncDecrypt_recovery is configured with ML-KEM storage
+            // ML-KEM uses KEM decapsulation, not traditional private key decryption
+            if (allowEncDecrypt_recovery && keyRecord.getMetaInfo() != null) {
+                String storageKeyAlg = (String) keyRecord.getMetaInfo().get(
+                    com.netscape.cms.servlet.key.KeyRecordParser.OUT_STORAGE_KEY_ALGORITHM);
+                if (storageKeyAlg != null && CryptoUtil.isAlgorithmMLKEM(storageKeyAlg)) {
+                    throw new EBaseException(
+                        "allowEncDecrypt_recovery is not supported with ML-KEM storage certificates. " +
+                        "ML-KEM uses KEM decapsulation and cannot decrypt private keys directly.");
+                }
+            }
+
             PrivateKey privKey = null;
             if (encrypted) {
                 privateKeyData = recoverKey(params, keyRecord);

--- a/base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java
+++ b/base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java
@@ -1327,6 +1327,13 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
     @Override
     public SymmetricKey unwrap(byte wrappedKeyData[], SymmetricKey.Type algorithm, int keySize,
             WrappingParams params) throws Exception {
+        // SEQUENCE structure (same for RSA/EC and ML-KEM):
+        // SEQUENCE {
+        //     encryptedSession OCTET STRING,  // RSA/EC: wrapped session key
+        //                                     // ML-KEM: KEM ciphertext
+        //     encryptedPrivate OCTET STRING   // User symmetric key wrapped with session key/shared secret
+        // }
+
         DerValue val = new DerValue(wrappedKeyData);
         // val.tag == DerValue.tag_Sequence
         DerInputStream in = val.data;
@@ -1336,10 +1343,32 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
         byte pri[] = dPri.getOctetString();
 
         CryptoToken token = getToken();
-        // (1) unwrap the session key
-        SymmetricKey sk = unwrap_session_key(token, session, SymmetricKey.Usage.UNWRAP, params);
+        PublicKey storagePubKey = getPublicKey();
+        String storageAlg = storagePubKey.getAlgorithm();
 
-        // (2) unwrap the session-wrapped-symmetric key
+        SymmetricKey sk;
+
+        // Check if storage cert is ML-KEM (PQC)
+        if (CryptoUtil.isAlgorithmMLKEM(storageAlg)) {
+            logger.debug("StorageKeyUnit:unwrap() Using ML-KEM storage cert for symmetric key");
+
+            // (1) ML-KEM decapsulation to recover shared secret
+            PrivateKey storagePrivKey = getPrivateKey();
+            sk = CryptoUtil.decapsulateMLKEM(
+                    storagePrivKey,
+                    session,
+                    params.getSkLength());
+
+            logger.debug("StorageKeyUnit:unwrap() ML-KEM decapsulation complete - recovered shared secret");
+
+        } else {
+            // (1) RSA/EC: unwrap the session key
+            logger.debug("StorageKeyUnit:unwrap() Using RSA/EC storage cert for symmetric key");
+            sk = unwrap_session_key(token, session, SymmetricKey.Usage.UNWRAP, params);
+            logger.debug("StorageKeyUnit:unwrap() session key unwrapped");
+        }
+
+        // (2) unwrap the session-wrapped-symmetric key (same for both RSA/EC and ML-KEM)
         return CryptoUtil.unwrap(
                 token,
                 algorithm,
@@ -1354,6 +1383,13 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
     @Override
     public PrivateKey unwrap(byte wrappedKeyData[], PublicKey pubKey, boolean temporary, WrappingParams params)
             throws Exception {
+        // SEQUENCE structure (same for RSA/EC and ML-KEM):
+        // SEQUENCE {
+        //     encryptedSession OCTET STRING,  // RSA/EC: wrapped session key
+        //                                     // ML-KEM: KEM ciphertext
+        //     encryptedPrivate OCTET STRING   // User private key wrapped with session key/shared secret
+        // }
+
         DerValue val = new DerValue(wrappedKeyData);
         // val.tag == DerValue.tag_Sequence
         DerInputStream in = val.data;
@@ -1363,10 +1399,32 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
         byte pri[] = dPri.getOctetString();
 
         CryptoToken token = getToken();
-        // (1) unwrap the session key
-        SymmetricKey sk = unwrap_session_key(token, session, SymmetricKey.Usage.UNWRAP, params);
+        PublicKey storagePubKey = getPublicKey();
+        String storageAlg = storagePubKey.getAlgorithm();
 
-        // (2) unwrap the private key
+        SymmetricKey sk;
+
+        // Check if storage cert is ML-KEM (PQC)
+        if (CryptoUtil.isAlgorithmMLKEM(storageAlg)) {
+            logger.debug("StorageKeyUnit:unwrap() Using ML-KEM storage cert");
+
+            // (1) ML-KEM decapsulation to recover shared secret
+            PrivateKey storagePrivKey = getPrivateKey();
+            sk = CryptoUtil.decapsulateMLKEM(
+                    storagePrivKey,
+                    session,
+                    params.getSkLength());
+
+            logger.debug("StorageKeyUnit:unwrap() ML-KEM decapsulation complete - recovered shared secret");
+
+        } else {
+            // (1) RSA/EC: unwrap the session key
+            logger.debug("StorageKeyUnit:unwrap() Using RSA/EC storage cert");
+            sk = unwrap_session_key(token, session, SymmetricKey.Usage.UNWRAP, params);
+            logger.debug("StorageKeyUnit:unwrap() session key unwrapped");
+        }
+
+        // (2) unwrap the user private key (same for both RSA/EC and ML-KEM)
         return CryptoUtil.unwrap(
                 token,
                 pubKey,


### PR DESCRIPTION
    This commit implements complete ML-KEM support for KRA key recovery
    workflow, enabling recovery of keys that were archived using ML-KEM
    storage certificates or retrieval using ML-KEM transport certificates.
    
    Server-side recovery changes (storage key):
    
    - StorageKeyUnit.java:
      * Updated unwrap() methods for both PrivateKey and SymmetricKey
        recovery to detect ML-KEM storage certificate
      * Added ML-KEM decapsulation to recover shared secret from KEM
        ciphertext instead of traditional session key unwrapping
      * Maintains backward compatibility with RSA/EC storage certificates
      * Added comments documenting SEQUENCE structure semantics for
        RSA/EC (wrapped session key) vs ML-KEM (KEM ciphertext)
    
    - RecoveryService.java:
      * Added note that allowEncDecrypt_recovery is not supported for
        ML-KEM storage at this time
    
    Server-side recovery changes (transport key):
    
    - EncryptionUnit.java:
      * Updated unwrap_session_key() to detect ML-KEM transport
        certificate and use decapsulation instead of unwrapping
      * Added clarifying comments explaining KEM ciphertext vs wrapped key
    
    Client-side recovery changes (transport key handling):

    - CryptoUtil.java:
      * Added defensive checks in wrapSymmetricKey() and wrapUsingPublicKey()
      * Throws clear exception if ML-KEM transport key is detected
    
    Client-side recovery changes (passphrase-based recovery):
    - CryptoProvider.java:
      * Added abstract encapsulateMLKEM() method for ML-KEM encapsulation
    
    - NSSCryptoProvider.java:
      * Implemented encapsulateMLKEM() with token.importPublicKey() to
        fix SIGSEGV crash during ML-KEM public key operations
      * Added defensive NSS token login logic with helpful error messages
        for uninitialized NSS databases
    
    - KeyClient.java:
      * Updated retrieveKeyByPassphrase() and retrieveKeyByRequestWithPassphrase()
        to detect ML-KEM transport certificate and use encapsulateMLKEM()
      * For ML-KEM: generates shared secret directly via encapsulation
      * For RSA/EC: generates session key and wraps it (existing behavior)
      * Encrypts passphrase with session key/shared secret in both cases
    
    Key insight: ML-KEM encapsulation produces both the shared secret and
    ciphertext together, unlike RSA/EC where the session key is generated
    separately and then wrapped.
    
    Recovery workflow:
    1. Read privateKeyData SEQUENCE from KeyRecord
    2. Extract ciphertext (first OCTET STRING) and wrapped key (second)
    3. If storage/transport cert is ML-KEM: decapsulate to get shared secret
    4. If storage/transport cert is RSA/EC: unwrap session key (existing path)
    5. Unwrap user's private key with shared secret/session key
    6. Create PKCS#12 with recovered key (works for PQC keys)
    
    The PKCS#12 creation code requires no changes as it already works
    with PQC keys (verified by hsmCompatVerifyServ tool).
    
    Assisted-by: Claude
    IDM-5473 IDM-6363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for ML‑KEM transport when encrypting passphrases for key retrieval.
  * Support for ML‑KEM–based storage for encrypting and decrypting stored keys.

* **Bug Fixes**
  * Improved token login verification and safer auto‑password initialization/retry behavior.

* **Documentation**
  * Clarified ML‑KEM limitations in key recovery workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->