### PR TITLE
Fix ML-DSA signing algorithm name extraction

### DIFF
--- a/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
+++ b/base/common/src/main/java/org/dogtagpki/nss/NSSDatabase.java
@@ -39,9 +39,12 @@ import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
+import java.security.SignatureException;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECParameterSpec;
+import java.security.spec.NamedParameterSpec;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -61,6 +64,7 @@ import org.mozilla.jss.asn1.SEQUENCE;
 import org.mozilla.jss.crypto.CryptoStore;
 import org.mozilla.jss.crypto.CryptoToken;
 import org.mozilla.jss.crypto.KeyGenAlgorithm;
+import org.mozilla.jss.crypto.KeyPairAlgorithm;
 import org.mozilla.jss.crypto.KeyPairGeneratorSpi.Usage;
 import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.ObjectNotFoundException;
@@ -1504,6 +1508,14 @@ public class NSSDatabase {
         logger.debug("NSSDatabase: Private key algorithm: " + privateKeyAlgorithm);
 
         String signingAlgorithm = privateKeyAlgorithm;
+        if (signingAlgorithm.equals(KeyPairAlgorithm.MLKEM.toString())) {
+            throw new SignatureException("Impossible to create a signature with an ML-KEM key.");
+        }
+        if (signingAlgorithm.equals(KeyPairAlgorithm.MLDSA.toString()) &&
+            privateKey.getParams() instanceof NamedParameterSpec name) {
+            signingAlgorithm = name.getName();
+            hash = null;
+        }
         if (hash != null) {
             signingAlgorithm = hash + "with" + privateKeyAlgorithm;
         }


### PR DESCRIPTION
Extract the specific ML-DSA variant name from NamedParameterSpec when determining the signing algorithm. This ensures ML-DSA keys use the correct variant identifier (e.g., ML-DSA-44, ML-DSA-65, ML-DSA-87) rather than the generic KeyPairAlgorithm name when signing certificates.

This fix is necessary because ML-DSA has multiple variants defined by NIST FIPS 204, and the signing operation requires the specific variant name to select the correct algorithm parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Certificates issued for ML-DSA-style keys now use the algorithm name derived from the key parameters, ensuring the declared signing algorithm matches the key.
  * The hash component is no longer incorrectly appended for parameter-based ML-DSA algorithms, reducing signature identifier mismatches during issuance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->