### PR TITLE
Add HTTPS connector test with ML-DSA certs (DOGTAG-4372)

### DIFF
--- a/.github/workflows/server-https-nss-pqc-test.yml
+++ b/.github/workflows/server-https-nss-pqc-test.yml
@@ -1,0 +1,400 @@
+name: HTTPS connector with NSS database (PQC)
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install xmlstarlet
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up server container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              --network-alias=server.example.com \
+              pki
+
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
+      - name: Enable ML-DSA in default crypto-policies
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 44 }}
+        run: |
+          docker exec pki sed -i \
+              's/smime-key-exchange:ECDSA/smime-key-exchange:ML-DSA-65:ECDSA/' \
+              /etc/crypto-policies/back-ends/nss.config
+
+      - name: Create PKI server
+        run: |
+          docker exec pki pki-server create -v
+
+      - name: Check pki-server nss CLI help message
+        run: |
+          docker exec pki pki-server nss
+          docker exec pki pki-server nss --help
+
+          # TODO: validate output
+
+      - name: Check pki-server nss-create CLI help message
+        run: |
+          docker exec pki pki-server nss-create --help
+
+          # TODO: validate output
+
+      - name: Create NSS database in PKI server
+        run: |
+          docker exec pki pki-server nss-create --no-password
+
+      - name: Create CA signing cert
+        run: |
+          # generate CA signing CSR
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-request \
+              --key-type MLDSA \
+              --key-size 65 \
+              --subject "CN=CA Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr $SHARED/ca_signing.csr
+
+          # create CA signing cert
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-issue \
+              --csr $SHARED/ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --validity-length 1 \
+              --validity-unit year \
+              --cert $SHARED/ca_signing.crt
+
+          # check CA signing cert
+          openssl x509 -text -noout -in ca_signing.crt
+
+          # import CA signing cert
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-import \
+              --cert $SHARED/ca_signing.crt \
+              --trust CT,C,C \
+              ca_signing
+
+          # check CA signing cert
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-show \
+              ca_signing
+
+      - name: Create SSL server cert
+        run: |
+          # generate SSL server CSR
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-request \
+              --key-type MLDSA \
+              --key-size 65 \
+              --subject "CN=pki.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr $SHARED/sslserver.csr
+
+          # issue SSL server cert that expires in 2 minutes
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-issue \
+              --issuer ca_signing \
+              --csr $SHARED/sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --validity-length 2 \
+              --validity-unit minute \
+              --cert $SHARED/sslserver.crt
+
+          # check SSL server cert
+          openssl x509 -text -noout -in sslserver.crt
+
+          # import SSL server cert
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              nss-cert-import \
+              --cert $SHARED/sslserver.crt \
+              sslserver
+
+      - name: Create HTTPS connector with NSS database
+        run: |
+          docker exec pki pki-server jss-enable
+          docker exec pki pki-server http-connector-add \
+              --port 8443 \
+              --scheme https \
+              --secure true \
+              --sslEnabled true \
+              --sslProtocol SSL \
+              --sslImpl org.dogtagpki.jss.tomcat.JSSImplementation \
+              Secure
+          docker exec pki pki-server http-connector-cert-add \
+              --keyAlias sslserver \
+              --keystoreType pkcs11 \
+              --keystoreProvider Mozilla-JSS
+
+      - name: Deploy webapps
+        run: |
+          docker exec pki pki-server webapp-deploy \
+              --descriptor /usr/share/pki/server/conf/Catalina/localhost/ROOT.xml \
+              ROOT
+
+          docker exec pki pki-server webapp-deploy \
+              --descriptor /usr/share/pki/server/conf/Catalina/localhost/pki.xml \
+              pki
+
+      - name: Start PKI server
+        run: |
+          docker exec pki pki-server start
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              --network-alias=client.example.com \
+              client
+
+      - name: Wait for PKI server to start
+        run: |
+          docker exec client curl \
+              --retry 60 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://pki.example.com:8443
+
+      - name: Check PKI CLI with unknown issuer
+        run: |
+          # run PKI CLI but don't trust the cert
+          echo n | docker exec -i client pki \
+              -U https://pki.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://pki.example.com:8443
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
+          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: UNKNOWN_CA
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Unknown issuer: CN=CA Signing Certificate
+          EOF
+
+          diff expected stderr
+
+          # the cert should not be stored
+          docker exec client pki nss-cert-find --subject CN=pki.example.com | tee output
+
+          diff /dev/null output
+
+      - name: Check PKI CLI with unknown issuer with wrong hostname
+        run: |
+          # run PKI CLI with wrong hostname
+          echo n | docker exec -i client pki \
+              -U https://server.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://server.example.com:8443
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          WARNING: BAD_CERT_DOMAIN encountered on 'CN=pki.example.com' indicates a common-name mismatch
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
+          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: ACCESS_DENIED
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Bad certificate domain: CN=pki.example.com
+          EOF
+
+          diff expected stderr
+
+          # the cert should not be stored
+          docker exec client pki nss-cert-find --subject CN=pki.example.com | tee output
+
+          diff /dev/null output
+
+      - name: Check PKI CLI with newly trusted server cert
+        run: |
+          VERSION=$(
+              xmlstarlet sel -t -v '/_:project/_:version' pom.xml \
+              | sed 's/^\(.*\)-SNAPSHOT/\1/'
+          )
+
+          # run PKI CLI and trust the cert
+          echo y | docker exec -i client pki \
+              -U https://pki.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://pki.example.com:8443
+            Server Name: Dogtag Certificate System
+            Server Version: $VERSION
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
+          Trust this certificate (y/N)?
+          EOF
+
+          # remove trailing whitespace
+          sed -i 's/ *$//' stderr
+
+          # append end of line
+          echo >> stderr
+
+          diff expected stderr
+
+          # the cert should be stored and trusted
+          docker exec client pki nss-cert-find --subject CN=pki.example.com | tee output
+
+          sed -i \
+              -e '/^ *Serial Number:/d' \
+              -e '/^ *Not Valid Before:/d' \
+              -e '/^ *Not Valid After:/d' \
+              output
+
+          cat > expected << EOF
+            Nickname: CN=pki.example.com
+            Subject DN: CN=pki.example.com
+            Issuer DN: CN=CA Signing Certificate
+            Trust Flags: P,,
+          EOF
+
+          diff expected output
+
+      - name: Check PKI CLI with trusted server cert with wrong hostname
+        run: |
+          VERSION=$(
+              xmlstarlet sel -t -v '/_:project/_:version' pom.xml \
+              | sed 's/^\(.*\)-SNAPSHOT/\1/'
+          )
+
+          # run PKI CLI with wrong hostname
+          docker exec client pki \
+              -U https://server.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://server.example.com:8443
+            Server Name: Dogtag Certificate System
+            Server Version: $VERSION
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          WARNING: BAD_CERT_DOMAIN encountered on 'CN=pki.example.com' indicates a common-name mismatch
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI CLI with already trusted server cert
+        run: |
+          VERSION=$(
+              xmlstarlet sel -t -v '/_:project/_:version' pom.xml \
+              | sed 's/^\(.*\)-SNAPSHOT/\1/'
+          )
+
+          # run PKI CLI with correct hostname
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://pki.example.com:8443
+            Server Name: Dogtag Certificate System
+            Server Version: $VERSION
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          diff /dev/null stderr
+
+      - name: Check PKI CLI with expired server cert
+        run: |
+          sleep 120
+
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://pki.example.com:8443
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          ERROR: EXPIRED_CERTIFICATE encountered on 'CN=pki.example.com' results in a denied SSL server cert!
+          SEVERE: FATAL: SSL alert sent: CERTIFICATE_EXPIRED
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Expired certificate: CN=pki.example.com
+          EOF
+
+          diff expected stderr
+
+      - name: Stop PKI server
+        run: |
+          docker exec pki pki-server stop --wait -v
+
+      - name: Remove PKI server
+        run: |
+          docker exec pki pki-server remove -v
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -43,6 +43,12 @@ jobs:
     needs: build
     uses: ./.github/workflows/server-https-nss-test.yml
 
+  server-https-nss-pqc-test:
+    if: ${{ vars.BASE_IMAGE != 'registry.fedoraproject.org/fedora:42' }}
+    name: HTTPS connector with NSS database (PQC)
+    needs: build
+    uses: ./.github/workflows/server-https-nss-pqc-test.yml
+
   server-backup-test:
     name: Server backup
     needs: build


### PR DESCRIPTION
Tests PKI server HTTPS with ML-DSA-65 certificates using an NSS database. Clones server-https-nss-test.yml with post-quantum cert generation and crypto-policy enablement for Fedora < 44. Verifies PKI CLI client behavior for unknown issuer, wrong hostname, trusted cert, and expired cert scenarios. Disabled on Fedora 42.

Added file:
- .github/workflows/server-https-nss-pqc-test.yml

Updated file: 
- .github/workflows/server-tests.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD testing infrastructure with new HTTPS integration tests using NSS database and post-quantum cryptography certificates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->