### PR TITLE
Fix Tomcat paths for RHEL compatibility (DOGTAG-4399)

### DIFF
--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -104,7 +104,7 @@ class Tomcat(object):
     CONF_DIR = '/etc/tomcat'
     LIB_DIR = '/usr/share/java/tomcat'
     SHARE_DIR = '/usr/share/tomcat'
-    OLD_EXECUTABLE = '/usr/bin/tomcat'
+    OLD_EXECUTABLE = '/usr/sbin/tomcat'
     EXECUTABLE = '/usr/share/tomcat/bin/catalina.sh'
     UNIT_FILE = '/lib/systemd/system/tomcat@.service'
     SERVER_XML = CONF_DIR + '/server.xml'

--- a/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd-nuxwdog@.service
@@ -24,8 +24,8 @@ ExecStartPre=/usr/sbin/pki-server migrate %i
 ExecStartPre=/usr/bin/pkidaemon start %i
 
 # Use abstraction wrappers - work for both old and new Tomcat
-ExecStart=/usr/bin/pki-tomcat-start
-ExecStop=/usr/bin/pki-tomcat-stop
+ExecStart=/usr/sbin/pki-tomcat-start
+ExecStop=/usr/sbin/pki-tomcat-stop
 
 ExecStopPost=+/usr/bin/pki-server-nuxwdog --clear
 

--- a/base/server/share/lib/systemd/system/pki-tomcatd@.service
+++ b/base/server/share/lib/systemd/system/pki-tomcatd@.service
@@ -21,11 +21,11 @@ ExecStartPre=/usr/sbin/pki-server migrate %i
 ExecStartPre=/usr/bin/pkidaemon start %i
 
 # Use abstraction wrappers - work for both old and new Tomcat
-ExecStart=/usr/bin/pki-tomcat-start
-ExecStop=/usr/bin/pki-tomcat-stop
+ExecStart=/usr/sbin/pki-tomcat-start
+ExecStop=/usr/sbin/pki-tomcat-stop
 
 SuccessExitStatus=143
-Restart=on-failure    # Works well for both old and new
+Restart=on-failure
 User=pkiuser
 Group=pkiuser
 


### PR DESCRIPTION
Update Tomcat executable and systemd wrapper script paths for pki-tomcat-start/stop from /usr/bin to /usr/sbin for compatibility in RHEL. Additionally removed an in-line systemd service file comment causing a systemd parsing warning, which also resulted in pkispawn failure. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Tomcat and related service executables to use the system sbin directory instead of bin, ensuring service start/stop use the correct system-level binaries and improving runtime reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dogtagpki/pki/pull/5370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->