### PR TITLE
Upgrade scripts fail with highly modified profiles

### DIFF
--- a/base/server/upgrade/11.9.0/04-UpdateMLDSAProfiles.py
+++ b/base/server/upgrade/11.9.0/04-UpdateMLDSAProfiles.py
@@ -63,10 +63,14 @@ class UpdateMLDSAProfiles(pki.server.upgrade.PKIServerUpgradeScriptlet):
             keys = [key for key, val in instance_profile.items()
                     if '.constraint.params.signingAlgsAllowed' in key]
             for key in keys:
-                new_profile_signing = set(new_profile[key].split(','))
-                instance_profile_signing = set(instance_profile[key].split(','))
-                if new_signing_algs == new_profile_signing.difference(instance_profile_signing):
-                    instance_profile[key] = new_profile[key]
+                if key in new_profile:
+                    new_profile_signing = set(new_profile[key].split(','))
+                    instance_profile_signing = set(instance_profile[key].split(','))
+                    if (
+                        new_signing_algs == new_profile_signing.difference(
+                            instance_profile_signing)
+                    ):
+                        instance_profile[key] = new_profile[key]
             self.backup(path)
             logger.info('Storing %s', path)
             pki.util.store_properties(path, instance_profile)


### PR DESCRIPTION
highly modified profiles, or profiles that match by name but do not match on the first part of the keys being updated will result in errors, and failure to start. 


Would also be nice to have a CS.cfg switch, or other mechanism to disable profile updates, and or profile installs via upgrade scripts for environments that keep their profiles under Configuration Management.


Allow for highly modified profiles with the same name or custom profiles that do not match example/stock profiles.

From modified profile:
policyset.GenericCertificateSet.SigningAlgorithms.constraint.params.signingAlgsAllowed=SHA384withRSA

From stock Profile:
policyset.serverCertSet.8.constraint.params.signingAlgsAllowed=SHA256withRSA,SHA512withRSA,SHA256withEC,SHA384withRSA,SHA384withEC,SHA512withEC,SHA256withRSA/PSS,SHA384withRSA/PSS,SHA512withRSA/PSS,ML-DSA-44,ML-DSA-65,ML-DSA-87

Journal output:

May 29 18:36:19  pki-server[7069]: NullPointerException: Cannot invoke "String.startsWith(String)" because "<local3>" is null
May 29 18:36:19  pki-server[7062]: ERROR: 'policyset.GenericCertificateSet.SigningAlgorithms.constraint.params.signingAlgsAllowed'
May 29 18:36:19  pki-server[7062]: Traceback (most recent call last):
May 29 18:36:19  pki-server[7062]:   File "/usr/lib/python3.6/site-packages/pki/server/pkiserver.py", line 41, in <module>
May 29 18:36:19  pki-server[7062]:     cli.execute(sys.argv[1:])
May 29 18:36:19  pki-server[7062]:   File "/usr/lib/python3.6/site-packages/pki/server/cli/__init__.py", line 355, in execute
May 29 18:36:19  pki-server[7062]:     module.execute(module_args)
May 29 18:36:19  pki-server[7062]:   File "/usr/lib/python3.6/site-packages/pki/server/cli/upgrade.py", line 155, in execute
May 29 18:36:19  pki-server[7062]:     tracker_version)
May 29 18:36:19  pki-server[7062]:   File "/usr/lib/python3.6/site-packages/pki/server/cli/upgrade.py", line 182, in upgrade
May 29 18:36:19  pki-server[7062]:     upgrader.upgrade()
May 29 18:36:19  pki-server[7062]:   File "/usr/lib/python3.6/site-packages/pki/upgrade.py", line 485, in upgrade
May 29 18:36:19  pki-server[7062]:     self.upgrade_version(version)
May 29 18:36:19  pki-server[7062]:   File "/usr/lib/python3.6/site-packages/pki/upgrade.py", line 460, in upgrade_version
May 29 18:36:19  pki-server[7062]:     self.run_scriptlet(scriptlet)
May 29 18:36:19  pki-server[7062]:   File "/usr/lib/python3.6/site-packages/pki/server/upgrade.py", line 110, in run_scriptlet
May 29 18:36:19  pki-server[7062]:     scriptlet.upgrade_subsystem(self.instance, subsystem)
May 29 18:36:19  pki-server[7062]:   File "/usr/share/pki/server/upgrade/11.9.0/04-UpdateMLDSAProfiles.py", line 66, in upgrade_subsystem
May 29 18:36:19  pki-server[7062]:     new_profile_signing = set(new_profile[key].split(','))
May 29 18:36:19  pki-server[7062]: KeyError: 'policyset.GenericCertificateSet.SigningAlgorithms.constraint.params.signingAlgsAllowed'
May 29 18:36:19  systemd[1]: pki-tomcatd-nuxwdog@dev-ca-1.service: Control process exited, code=exited status=1
May 29 18:36:20  runuser[7110]: pam_unix(runuser:session): session opened for user pkiuser-dev-ca-1 by (uid=0)
May 29 18:36:20  runuser[7110]: pam_unix(runuser:session): session closed for user pkiuser-dev-ca-1
May 29 18:36:20  systemd[1]: pki-tomcatd-nuxwdog@dev-ca-1.service: Failed with result 'exit-code'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented upgrade failures by validating the presence of expected profile entries before using them.
  * Ensured profile constraints are only updated when corresponding new values are present and precisely match intended changes, avoiding unintended overwrites during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->