### PR TITLE
Minimize impact on non-PQC deployments for KRA archival

### DIFF
--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -150,7 +150,7 @@ kra.storageUnit.wrapping._003=## are not used (ML-KEM uses encapsulation, not wr
 kra.storageUnit.wrapping._004=## payloadEncryption* fields only used when kra.allowEncDecrypt.archival=true
 kra.storageUnit.wrapping._005=## (ML-KEM does not support allowEncDecrypt.archival)
 kra.storageUnit.wrapping._006=##
-kra.storageUnit.wrapping.1.sessionKeyLength=256
+kra.storageUnit.wrapping.1.sessionKeyLength=128
 kra.storageUnit.wrapping.1.sessionKeyWrapAlgorithm=RSA
 kra.storageUnit.wrapping.1.payloadEncryptionPadding=PKCS5Padding
 kra.storageUnit.wrapping.1.sessionKeyKeyGenAlgorithm=AES
@@ -169,13 +169,14 @@ kra._003=## For improved security, the following settings are recommended:
 kra._004=##
 kra._005=## 1. Use OAEP for RSA session key wrapping (applies to RSA storage certs only)
 kra._006=##    ML-KEM storage certs use encapsulation, not RSA wrapping
-keyWrap.useOAEP=true
-kra._007=##
-kra._008=## 2. Use AES-256-KWP for PKCS#12 encryption (applies to all storage certs)
-kra._009=##    Legacy mode uses DES3, which is less secure
-kra.legacyPKCS12=false
-kra.nonLegacyAlg=AES/None/PKCS5Padding/Kwp/256
-kra._010=##
+kra._007=##    Uncomment to enable: keyWrap.useOAEP=true
+kra._008=##
+kra._009=## 2. Use AES-256-KWP for PKCS#12 encryption (applies to all storage certs)
+kra._010=##    Legacy mode uses DES3, which is less secure
+kra._011=##    Uncomment to enable:
+kra._012=##    kra.legacyPKCS12=false
+kra._013=##    kra.nonLegacyAlg=AES/None/PKCS5Padding/Kwp/256
+kra._014=##
 log._000=##
 log._001=## Logging
 log._002=##

--- a/base/server/src/main/java/com/netscape/cmscore/dbs/KeyRecord.java
+++ b/base/server/src/main/java/com/netscape/cmscore/dbs/KeyRecord.java
@@ -469,19 +469,17 @@ public class KeyRecord extends DBRecord {
     /**
      * Sets wrapping parameters for key record metadata.
      *
-     * There are two archival paths:
-     * 1. Normal wrapping path (doEncrypt=false):
-     *    - Uses StorageKeyUnit.wrap() → wrapUsingSymmetricKey()
-     *    - Records: sessionKey*, payloadWrapAlgorithm, payloadWrappingIV
-     *    - For ML-KEM: skips sessionKeyWrapAlgorithm, sessionKeyKeyGenAlgorithm
+     * Stores all wrapping/encryption parameters that are present in the params object.
+     * For RSA/EC storage certs, the config typically populates both encryption and wrapping
+     * parameters. For ML-KEM storage certs, only wrapping parameters are relevant (ML-KEM
+     * does not support the allowEncDecrypt_archival encryption path).
      *
-     * 2. Encryption path (doEncrypt=true, allowEncDecrypt_archival=true):
-     *    - Uses StorageKeyUnit.encryptInternalPrivate() → encryptUsingSymmetricKey()
-     *    - Records: sessionKey*, payloadEncryptionOID, payloadEncryptionIV
-     *    - Note: ML-KEM does NOT support this path (blocked in EnrollmentService)
+     * ML-KEM-specific handling:
+     * - Skips sessionKeyWrapAlgorithm (ML-KEM uses encapsulation, not RSA wrapping)
+     * - Skips sessionKeyKeyGenAlgorithm (shared secret is derived via KEM, not generated)
      *
      * @param params Wrapping parameters from storage unit
-     * @param doEncrypt Whether encryption was used (vs wrapping)
+     * @param doEncrypt Whether encryption was used (vs wrapping) - stored in payloadEncrypted field
      * @param storageKeyAlg Storage cert public key algorithm (e.g., "RSA", "EC", "ML-KEM-1024")
      */
     public void setWrappingParams(WrappingParams params, boolean doEncrypt, String storageKeyAlg) throws Exception {
@@ -492,8 +490,8 @@ public class KeyRecord extends DBRecord {
         // Detect if ML-KEM is used
         boolean isMLKEM = CryptoUtil.isAlgorithmMLKEM(storageKeyAlg);
 
-        // Record the storage key algorithm for clarity
-        if (storageKeyAlg != null) {
+        // Record the storage key algorithm for ML-KEM only (to distinguish from RSA/EC)
+        if (isMLKEM && storageKeyAlg != null) {
             mMetaInfo.set(KeyRecordParser.OUT_STORAGE_KEY_ALGORITHM, storageKeyAlg);
         }
 
@@ -516,9 +514,10 @@ public class KeyRecord extends DBRecord {
         }
 
         // set payload parameters
-        // Only set encryption parameters if doEncrypt=true (allowEncDecrypt_archival path)
-        // Normal wrapping path uses payloadWrapAlgorithm instead
-        if (doEncrypt && params.getPayloadEncryptionAlgorithm() != null) {
+        // Store all payload parameters that are present in params.
+        // For RSA/EC: both encryption and wrapping params are set from config
+        // For ML-KEM: only wrapping params are relevant (no encryption path supported)
+        if (params.getPayloadEncryptionAlgorithm() != null) {
             EncryptionAlgorithm encrypt = params.getPayloadEncryptionAlgorithm();
             try {
                 OBJECT_IDENTIFIER oid = encrypt.toOID();
@@ -530,19 +529,17 @@ public class KeyRecord extends DBRecord {
                 mMetaInfo.set(KeyRecordParser.OUT_PL_ENCRYPTION_PADDING, encrypt.getPadding().toString());
             }
         }
-        // Wrapping parameters are used in normal path (doEncrypt=false)
-        if (!doEncrypt && params.getPayloadWrapAlgorithm() != null) {
+        if (params.getPayloadWrapAlgorithm() != null) {
             mMetaInfo.set(KeyRecordParser.OUT_PL_WRAP_ALGORITHM, params.getPayloadWrapAlgorithm().toString());
         }
-        if (!doEncrypt && params.getPayloadWrappingIV() != null) {
+        if (params.getPayloadWrappingIV() != null) {
             // store as base64 encoded string
             mMetaInfo.set(
                 KeyRecordParser.OUT_PL_WRAP_IV,
                 Base64.encodeBase64String(params.getPayloadWrappingIV().getIV())
             );
         }
-        // Only set encryption IV if doEncrypt=true (allowEncDecrypt_archival path)
-        if (doEncrypt && params.getPayloadEncryptionIV() != null) {
+        if (params.getPayloadEncryptionIV() != null) {
             // store as base 64 encoded string
             mMetaInfo.set(
                 KeyRecordParser.OUT_PL_ENCRYPTION_IV,


### PR DESCRIPTION
    When unwrapping session keys sent by clients via PKIArchiveOptions,
    TransportKeyUnit.unwrap() was incorrectly using the server's
    keyWrap.useOAEP config setting instead of respecting the algorithm
    specified by the client.
    
    This caused a client/server mismatch when keyWrap.useOAEP=true was
    set in CS.cfg:
    - Client wraps session key with RSA PKCS#1 v1.5 (default)
    - Server tries to unwrap with RSA-OAEP (from config)
    - Result: "Failed to unwrap key: (-8190) security library: received bad data"
    
    The keyWrap.useOAEP setting is intended for server-controlled operations
    (StorageKeyUnit wrapping with storage cert, TransportKeyUnit.wrap() for
    key generation). For client-controlled operations (unwrapping keys from
    PKIArchiveOptions), the server must use whatever algorithm the client
    specified.
    
    Fix: Remove the RSA special case in TransportKeyUnit.unwrap() that was
    overriding the client's choice. Always use params.getSkWrapAlgorithm()
    which comes from the client's PKIArchiveOptions, with fallback to RSA
    PKCS#1 v1.5 when the client omits the optional keyAlg field (RFC 4211).
    
    This preserves backward compatibility with clients using RSA v1.5 while
    still allowing keyWrap.useOAEP=true for server-side operations.
    
    Fixes regression introduced in commit 60dc2ac8e0 (ML-KEM storage support).
    
    Assisted-by: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Session key wrapping configuration parameters updated
  * Cryptographic configuration guidance restructured with improved documentation for legacy and modern modes

* **Documentation**
  * Key metadata handling and persistence documentation enhanced for improved clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->