### PR TITLE
Address sporadic CI crashes by having the CLI cmds clean up the conne…

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/cli/MainCLI.java
@@ -839,16 +839,29 @@ public class MainCLI extends CLI {
 
     public static void main(String args[]) throws Exception {
         MainCLI cli = new MainCLI();
+        int exitCode = 0;
         try {
             cli.execute(args);
 
         } catch (CLIException e) {
             cli.handleException(e);
-            System.exit(e.getCode());
-
+            exitCode = e.getCode();
         } catch (Throwable t) {
             cli.handleException(t);
-            System.exit(-1);
+            exitCode = -1;
+        } finally {
+            if (cli.client != null) {
+                try {
+                    logger.debug("MainCLI: closing PKI client connection");
+                    cli.client.close();
+                } catch (Exception e) {
+                    logger.warn("MainCLI: failed to close PKI client connection:" + e);
+                }
+            }
+        }
+
+        if (exitCode != 0) {
+            System.exit(exitCode);
         }
     }
 }


### PR DESCRIPTION
Address sporadic CI crashes by having the CLI cmds clean up the connection at the end.
Let's see how the CI test go with this potential fix.

Assisted by Claude Sonnet 4.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal resource cleanup and process termination handling to ensure proper shutdown sequencing and centralized exit code management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->