### PR TITLE
Update kryoptic configuration for trust attributes

### DIFF
--- a/.github/workflows/ca-kryoptic-test.yml
+++ b/.github/workflows/ca-kryoptic-test.yml
@@ -103,6 +103,7 @@ jobs:
           slot = 1
           dbtype = "sqlite"
           dbargs = "/home/pkiuser/.config/kryoptic/token.sql"
+          objects_dedup = "TrustOnly"
           EOF
 
           # check with OpenSC
@@ -209,9 +210,7 @@ jobs:
               HSM:ca_signing \
               | tee output
 
-          # trust attributes should be CTu,Cu,Cu but some are missing
-          # TODO: investigate missing trust attributes
-          echo "CTu,u,u" > expected
+          echo "CTu,Cu,Cu" > expected
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
 
           diff expected actual

--- a/.github/workflows/kra-kryoptic-test.yml
+++ b/.github/workflows/kra-kryoptic-test.yml
@@ -105,6 +105,7 @@ jobs:
           slot = 1
           dbtype = "sqlite"
           dbargs = "/home/pkiuser/.config/kryoptic/token.sql"
+          objects_dedup = "TrustOnly"
           EOF
 
           # check with OpenSC

--- a/.github/workflows/pki-nss-kryoptic-test.yml
+++ b/.github/workflows/pki-nss-kryoptic-test.yml
@@ -85,6 +85,7 @@ jobs:
           slot = 1
           dbtype = "sqlite"
           dbargs = "/root/.config/kryoptic/token.sql"
+          objects_dedup = "TrustOnly"
           EOF
 
           # check with OpenSC
@@ -270,19 +271,12 @@ jobs:
           # this command doesn't prompt for a password but it requires
           # the HSM password in order to import the cert
           #
-          # currently Kryoptic can't modify trust attributes after
-          # import (https://github.com/latchset/kryoptic/issues/450)
-          # so the attributes must be specified during import
-          #
-          # for consistency with the audit signing cert import below
-          # this command specifies the u attributes, but they don't
-          # seem to affect the outcome of the test
           docker exec pki pki \
               -C $SHARED/password.hsm \
               --token HSM \
               nss-cert-import \
               --cert ca_signing.crt \
-              --trust "CTu,Cu,Cu" \
+              --trust "CT,C,C" \
               HSM:ca_signing
 
       - name: Check CA signing cert in internal token
@@ -316,10 +310,7 @@ jobs:
               -h HSM \
               | tee output
 
-          # trust attributes should be CTu,Cu,Cu
-          # but currently Kryoptic returns incomplete trust attributes
-          # https://github.com/latchset/kryoptic/issues/450
-          echo "CTu,u,u" > expected
+          echo "CTu,Cu,Cu" > expected
           sed -n 's/^HSM:ca_signing\s*\(\S\+\)\s*$/\1/p' output > actual
 
           diff expected actual
@@ -330,10 +321,7 @@ jobs:
               HSM:ca_signing \
               | tee output
 
-          # trust attributes should be CTu,Cu,Cu
-          # but currently Kryoptic returns incomplete trust attributes
-          # https://github.com/latchset/kryoptic/issues/450
-          echo "CTu,u,u" > expected
+          echo "CTu,Cu,Cu" > expected
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
 
           diff expected actual
@@ -492,7 +480,7 @@ jobs:
               | tee output
 
           # cert should be removed
-          echo "HSM:ca_signing CTu,u,u" > expected
+          echo "HSM:ca_signing CTu,Cu,Cu" > expected
           sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
 
           diff expected actual
@@ -561,19 +549,12 @@ jobs:
         run: |
           # this command doesn't prompt for a password but it requires
           # the HSM password in order to import the cert
-          #
-          # currently Kryoptic can't modify trust attributes after
-          # import (https://github.com/latchset/kryoptic/issues/450)
-          # so the attributes must be specified during import
-          #
-          # in this command the u attributes must be specified in order
-          # to set the trust attributes properly
           docker exec pki pki \
               -C $SHARED/password.hsm \
               --token HSM \
               nss-cert-import \
               --cert audit_signing.crt \
-              --trust "u,u,Pu" \
+              --trust ",,P" \
               HSM:audit_signing
 
       - name: Check audit signing key
@@ -609,7 +590,6 @@ jobs:
               -h HSM \
               | tee output
 
-          # trust attributes should be u,u,Pu
           echo "u,u,Pu" > expected
           sed -n 's/^HSM:audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
 
@@ -620,7 +600,6 @@ jobs:
               nss-cert-show \
               HSM:audit_signing | tee output
 
-          # trust attributes should be u,u,Pu
           echo "u,u,Pu" > expected
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
 
@@ -628,12 +607,9 @@ jobs:
 
       - name: Modify audit signing cert trust attributes
         run: |
-          # this command tries to modify the trust attributes but
-          # currently Kryoptic can't modify trust attributes
-          # https://github.com/latchset/kryoptic/issues/450
           cat password.hsm | docker exec -i pki pki \
               nss-cert-mod \
-              --trust-flags "u,u,u" \
+              --trust-flags ",," \
               HSM:audit_signing
 
       - name: Check audit signing cert trust attributes in internal token
@@ -667,10 +643,7 @@ jobs:
               -h HSM \
               | tee output
 
-          # trust attributes should be u,u,u
-          # but currently Kryoptic can't modify trust attributes
-          # https://github.com/latchset/kryoptic/issues/450
-          echo "u,u,Pu" > expected
+          echo "u,u,u" > expected
           sed -n 's/^HSM:audit_signing\s*\(\S\+\)\s*$/\1/p' output > actual
 
           diff expected actual
@@ -681,10 +654,7 @@ jobs:
               HSM:audit_signing \
               | tee output
 
-          # trust attributes should be u,u,u
-          # but currently Kryoptic can't modify trust attributes
-          # https://github.com/latchset/kryoptic/issues/450
-          echo "u,u,Pu" > expected
+          echo "u,u,u" > expected
           sed -n 's/\s*Trust Flags:\s*\(\S\+\)\s*$/\1/p' output > actual
 
           diff expected actual
@@ -727,7 +697,7 @@ jobs:
               | tee output
 
           # cert should be removed
-          echo "HSM:ca_signing CTu,u,u" > expected
+          echo "HSM:ca_signing CTu,Cu,Cu" > expected
           sed -n -e '1,4d' -e 's/^\(.*\S\)\s\+\(\S\+\)\s*$/\1 \2/p' output > actual
 
           diff expected actual


### PR DESCRIPTION
To be compatible with NSS, Kryoptic has introduced the new configuration option `objects_dedup = "TrustOnly"` which prevent the creation of multiple overlapping trust objects.

The Kryoptic workflow has been updated to use the new configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test workflows updated to set Kryoptic token object deduplication to "TrustOnly".

* **Tests**
  * CI expectations adjusted for revised certificate trust attributes/flags for CA and audit keys.
  * Audit-signing import/modify flows and assertions simplified; obsolete explanatory comments removed to match new expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->