### PR TITLE
Add HTTPS connector test with ML-DSA certs and Kryoptic HSM

### DIFF
--- a/.github/workflows/server-https-kryoptic-pqc-test.yml
+++ b/.github/workflows/server-https-kryoptic-pqc-test.yml
@@ -1,0 +1,495 @@
+name: HTTPS connector with Kryoptic HSM (PQC)
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install xmlstarlet
+
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v4
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up server container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=pki.example.com \
+              --network=example \
+              --network-alias=pki.example.com \
+              --network-alias=server.example.com \
+              pki
+
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec pki sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
+      - name: Enable ML-DSA in default crypto-policies
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 44 }}
+        run: |
+          docker exec pki sed -i \
+              's/smime-key-exchange:ECDSA/smime-key-exchange:ML-DSA-65:ECDSA/' \
+              /etc/crypto-policies/back-ends/nss.config
+
+      - name: Install Kryoptic
+        run: |
+          # install OpenDNSSEC to ensure no conflicts
+          # https://github.com/dogtagpki/pki/issues/5045
+          docker exec pki dnf install -y kryoptic opensc opendnssec
+
+          docker exec pki rpm -ql kryoptic
+          docker exec pki cat /usr/share/p11-kit/modules/kryoptic.module
+
+          # check with OpenSC
+          # NOTE: the command fails if there's no token
+          docker exec pki pkcs11-tool \
+              --module /usr/lib64/pkcs11/libkryoptic_pkcs11.so \
+              --show-info || true
+
+          # check with OpenSC
+          # NOTE: the command fails if there's no token
+          docker exec pki pkcs11-tool \
+              --module /usr/lib64/pkcs11/libkryoptic_pkcs11.so \
+              --list-slots || true
+
+          # check with NSS
+          docker exec pki modutil -nocertdb -list
+
+      # https://github.com/dogtagpki/pki/wiki/Kryoptic
+      - name: Create Kryoptic token
+        run: |
+          # create password file for HSM
+          echo "Secret.HSM" > password.hsm
+
+          # configure token for root (for cert generation)
+          docker exec pki mkdir -p /root/.config/kryoptic
+          docker exec -i pki tee /root/.config/kryoptic/token.conf << EOF
+          [[slots]]
+          slot = 1
+          dbtype = "sqlite"
+          dbargs = "/root/.config/kryoptic/token.sql"
+          EOF
+
+          # check with OpenSC
+          docker exec pki pkcs11-tool \
+              --module /usr/lib64/pkcs11/libkryoptic_pkcs11.so \
+              --list-slots
+
+          # initialize token and SO PIN
+          docker exec pki pkcs11-tool \
+              --module /usr/lib64/pkcs11/libkryoptic_pkcs11.so \
+              --label HSM \
+              --so-pin $(cat password.hsm) \
+              --init-token
+
+          # initialize user PIN
+          docker exec pki pkcs11-tool \
+              --module /usr/lib64/pkcs11/libkryoptic_pkcs11.so \
+              --login \
+              --login-type so \
+              --so-pin $(cat password.hsm) \
+              --pin $(cat password.hsm) \
+              --init-pin
+
+          # check with OpenSC
+          docker exec pki pkcs11-tool \
+              --module /usr/lib64/pkcs11/libkryoptic_pkcs11.so \
+              --list-slots
+
+          # check with NSS
+          docker exec pki modutil -nocertdb -list
+
+          # configure token for pkiuser (for server runtime)
+          docker exec pki runuser -u pkiuser -- \
+              mkdir -p /home/pkiuser/.config/kryoptic
+          docker exec pki cp \
+              /root/.config/kryoptic/token.conf \
+              /home/pkiuser/.config/kryoptic/token.conf
+          docker exec pki cp \
+              /root/.config/kryoptic/token.sql \
+              /home/pkiuser/.config/kryoptic/token.sql
+          docker exec pki chown -R pkiuser:pkiuser \
+              /home/pkiuser/.config/kryoptic
+
+      - name: Create PKI server
+        run: |
+          docker exec pki pki-server create -v
+
+      - name: Create NSS database in PKI server
+        run: |
+          # create password file for internal token
+          echo "Secret.123" > password.txt
+
+          # create password config
+          echo "internal=$(cat password.txt)" > password.conf
+          echo "hardware-HSM=$(cat password.hsm)" >> password.conf
+
+          docker exec pki pki-server nss-create \
+              --password-file $SHARED/password.txt
+
+          docker exec pki cp $SHARED/password.conf \
+              /var/lib/pki/pki-tomcat/conf/password.conf
+
+      - name: Create CA signing cert
+        run: |
+          # generate CA signing CSR in HSM
+          cat password.hsm | docker exec -i pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-cert-request \
+              --key-type MLDSA \
+              --key-size 65 \
+              --subject "CN=CA Signing Certificate" \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --csr $SHARED/ca_signing.csr
+
+          # create CA signing cert
+          cat password.hsm | docker exec -i pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-cert-issue \
+              --csr $SHARED/ca_signing.csr \
+              --ext /usr/share/pki/server/certs/ca_signing.conf \
+              --validity-length 1 \
+              --validity-unit year \
+              --cert $SHARED/ca_signing.crt
+
+          # check CA signing cert
+          openssl x509 -text -noout -in ca_signing.crt
+
+          # import CA signing cert
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              -f $SHARED/password.conf \
+              nss-cert-import \
+              --cert $SHARED/ca_signing.crt \
+              --trust CT,C,C \
+              HSM:ca_signing
+
+          # check CA signing cert
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              -f $SHARED/password.conf \
+              nss-cert-show \
+              HSM:ca_signing
+
+      - name: Create SSL server cert
+        run: |
+          # generate SSL server CSR in HSM
+          cat password.hsm | docker exec -i pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-cert-request \
+              --key-type MLDSA \
+              --key-size 65 \
+              --subject "CN=pki.example.com" \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --csr $SHARED/sslserver.csr
+
+          # issue SSL server cert that expires in 2 minutes
+          cat password.hsm | docker exec -i pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              -f $SHARED/password.conf \
+              --token HSM \
+              nss-cert-issue \
+              --issuer HSM:ca_signing \
+              --csr $SHARED/sslserver.csr \
+              --ext /usr/share/pki/server/certs/sslserver.conf \
+              --validity-length 2 \
+              --validity-unit minute \
+              --cert $SHARED/sslserver.crt
+
+          # check SSL server cert
+          openssl x509 -text -noout -in sslserver.crt
+
+          # import SSL server cert
+          docker exec pki pki \
+              -d /var/lib/pki/pki-tomcat/alias \
+              -f $SHARED/password.conf \
+              nss-cert-import \
+              --cert $SHARED/sslserver.crt \
+              HSM:sslserver
+
+      - name: Create HTTPS connector with Kryoptic HSM
+        run: |
+          docker exec pki pki-server jss-enable
+          docker exec pki pki-server http-connector-add \
+              --port 8443 \
+              --scheme https \
+              --secure true \
+              --sslEnabled true \
+              --sslProtocol SSL \
+              --sslImpl org.dogtagpki.jss.tomcat.JSSImplementation \
+              Secure
+          docker exec pki pki-server http-connector-cert-add \
+              --keyAlias HSM:sslserver \
+              --keystoreType pkcs11 \
+              --keystoreProvider Mozilla-JSS
+
+      - name: Deploy webapps
+        run: |
+          docker exec pki pki-server webapp-deploy \
+              --descriptor /usr/share/pki/server/conf/Catalina/localhost/ROOT.xml \
+              ROOT
+
+          docker exec pki pki-server webapp-deploy \
+              --descriptor /usr/share/pki/server/conf/Catalina/localhost/pki.xml \
+              pki
+
+      - name: Start PKI server
+        run: |
+          docker exec pki pki-server start
+
+      - name: Set up client container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=client.example.com \
+              --network=example \
+              --network-alias=client.example.com \
+              client
+
+      - name: Wait for PKI server to start
+        run: |
+          docker exec client curl \
+              --retry 60 \
+              --retry-delay 0 \
+              --retry-connrefused \
+              -s \
+              -k \
+              -o /dev/null \
+              https://pki.example.com:8443
+
+      - name: Check PKI CLI with unknown issuer
+        run: |
+          # run PKI CLI but don't trust the cert
+          echo n | docker exec -i client pki \
+              -U https://pki.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://pki.example.com:8443
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
+          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: UNKNOWN_CA
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Unknown issuer: CN=CA Signing Certificate
+          EOF
+
+          diff expected stderr
+
+          # the cert should not be stored
+          docker exec client pki nss-cert-find --subject CN=pki.example.com | tee output
+
+          diff /dev/null output
+
+      - name: Check PKI CLI with unknown issuer with wrong hostname
+        run: |
+          # run PKI CLI with wrong hostname
+          echo n | docker exec -i client pki \
+              -U https://server.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://server.example.com:8443
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          WARNING: BAD_CERT_DOMAIN encountered on 'CN=pki.example.com' indicates a common-name mismatch
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
+          Trust this certificate (y/N)? SEVERE: FATAL: SSL alert sent: ACCESS_DENIED
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Bad certificate domain: CN=pki.example.com
+          EOF
+
+          diff expected stderr
+
+          # the cert should not be stored
+          docker exec client pki nss-cert-find --subject CN=pki.example.com | tee output
+
+          diff /dev/null output
+
+      - name: Check PKI CLI with newly trusted server cert
+        run: |
+          VERSION=$(
+              xmlstarlet sel -t -v '/_:project/_:version' pom.xml \
+              | sed 's/^\(.*\)-SNAPSHOT/\1/'
+          )
+
+          # run PKI CLI and trust the cert
+          echo y | docker exec -i client pki \
+              -U https://pki.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://pki.example.com:8443
+            Server Name: Dogtag Certificate System
+            Server Version: $VERSION
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          WARNING: UNKNOWN_ISSUER encountered on 'CN=pki.example.com' indicates an unknown CA cert 'CN=CA Signing Certificate'
+          Trust this certificate (y/N)?
+          EOF
+
+          # remove trailing whitespace
+          sed -i 's/ *$//' stderr
+
+          # append end of line
+          echo >> stderr
+
+          diff expected stderr
+
+          # the cert should be stored and trusted
+          docker exec client pki nss-cert-find --subject CN=pki.example.com | tee output
+
+          sed -i \
+              -e '/^ *Serial Number:/d' \
+              -e '/^ *Not Valid Before:/d' \
+              -e '/^ *Not Valid After:/d' \
+              output
+
+          cat > expected << EOF
+            Nickname: CN=pki.example.com
+            Subject DN: CN=pki.example.com
+            Issuer DN: CN=CA Signing Certificate
+            Trust Flags: P,,
+          EOF
+
+          diff expected output
+
+      - name: Check PKI CLI with trusted server cert with wrong hostname
+        run: |
+          VERSION=$(
+              xmlstarlet sel -t -v '/_:project/_:version' pom.xml \
+              | sed 's/^\(.*\)-SNAPSHOT/\1/'
+          )
+
+          # run PKI CLI with wrong hostname
+          docker exec client pki \
+              -U https://server.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://server.example.com:8443
+            Server Name: Dogtag Certificate System
+            Server Version: $VERSION
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          WARNING: BAD_CERT_DOMAIN encountered on 'CN=pki.example.com' indicates a common-name mismatch
+          EOF
+
+          diff expected stderr
+
+      - name: Check PKI CLI with already trusted server cert
+        run: |
+          VERSION=$(
+              xmlstarlet sel -t -v '/_:project/_:version' pom.xml \
+              | sed 's/^\(.*\)-SNAPSHOT/\1/'
+          )
+
+          # run PKI CLI with correct hostname
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://pki.example.com:8443
+            Server Name: Dogtag Certificate System
+            Server Version: $VERSION
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          diff /dev/null stderr
+
+      - name: Check PKI CLI with expired server cert
+        run: |
+          sleep 120
+
+          docker exec client pki \
+              -U https://pki.example.com:8443 \
+              info \
+              > >(tee stdout) 2> >(tee stderr >&2) || true
+
+          # check stdout
+          cat > expected << EOF
+            Server URL: https://pki.example.com:8443
+          EOF
+
+          diff expected stdout
+
+          # check stderr
+          cat > expected << EOF
+          ERROR: EXPIRED_CERTIFICATE encountered on 'CN=pki.example.com' results in a denied SSL server cert!
+          SEVERE: FATAL: SSL alert sent: CERTIFICATE_EXPIRED
+          IOException: Unable to write to socket: Unable to validate CN=pki.example.com: Expired certificate: CN=pki.example.com
+          EOF
+
+          diff expected stderr
+
+      - name: Stop PKI server
+        run: |
+          docker exec pki pki-server stop --wait -v
+
+      - name: Remove PKI server
+        run: |
+          docker exec pki pki-server remove -v
+
+      - name: Remove Kryoptic token
+        run: |
+          docker exec pki rm -rf /root/.config/kryoptic
+          docker exec pki runuser -u pkiuser -- \
+              rm -rf /home/pkiuser/.config/kryoptic
+
+      - name: Check PKI server systemd journal
+        if: always()
+        run: |
+          docker exec pki journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -49,6 +49,12 @@ jobs:
     needs: build
     uses: ./.github/workflows/server-https-nss-pqc-test.yml
 
+  server-https-kryoptic-pqc-test:
+    if: ${{ vars.BASE_IMAGE != 'registry.fedoraproject.org/fedora:42' }}
+    name: HTTPS connector with Kryoptic HSM (PQC)
+    needs: build
+    uses: ./.github/workflows/server-https-kryoptic-pqc-test.yml
+
   server-backup-test:
     name: Server backup
     needs: build


### PR DESCRIPTION
Tests PKI server HTTPS connectivity using ML-DSA-65 certificates with private keys stored in a Kryoptic HSM. This is the first server-https-*.yml test to use an HSM backend.

Combines the HTTPS connector pattern from server-https-nss-pqc-test.yml with the Kryoptic HSM setup from ca-kryoptic-test.yml. Keys are generated and stored in the HSM via --token HSM, and the HTTPS connector uses --keyAlias HSM:sslserver.

Verifies PKI CLI client behavior across five scenarios: unknown issuer, wrong hostname, newly trusted cert, trusted cert with wrong hostname, and expired cert.

Follow-up to DOGTAG-4372, PR #5369.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end HTTPS testing for post-quantum cryptography support: validates certificate trust chains, issuer/hostname mismatch handling, expired certificate rejection, and trusted-certificate persistence across restarts to improve protocol resilience and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->