### PR TITLE
Fix duplicate error messages in LDAPExceptionConverter

### DIFF
--- a/.github/workflows/ca-ssnv2-test.yml
+++ b/.github/workflows/ca-ssnv2-test.yml
@@ -1411,7 +1411,7 @@ jobs:
 
           # the CLI should complete successfully, but currently it's failing
           cat > expected << EOF
-          PKIException: Server Internal Error: Unable to add certificate record: Record already exists: Already exists
+          PKIException: Server Internal Error: Unable to add certificate record: Record already exists
           EOF
 
           diff expected stderr

--- a/base/common/src/main/java/com/netscape/certsrv/ldap/LDAPExceptionConverter.java
+++ b/base/common/src/main/java/com/netscape/certsrv/ldap/LDAPExceptionConverter.java
@@ -34,36 +34,38 @@ import netscape.ldap.LDAPException;
 public class LDAPExceptionConverter {
 
     public static DBException toDBException(LDAPException e) {
+        String ldapErrorMessage = e.getLDAPErrorMessage() != null ? ": " + e.getLDAPErrorMessage() : "";
         switch (e.getLDAPResultCode()) {
         case LDAPException.ATTRIBUTE_OR_VALUE_EXISTS:
-            return new DBRecordAlreadyExistsException("Record already exists: " + e.getMessage(), e);
+            return new DBRecordAlreadyExistsException("Record already exists" + ldapErrorMessage, e);
         case LDAPException.NO_SUCH_OBJECT:
-            return new DBRecordNotFoundException("Record not found: " + e.getMessage(), e);
+            return new DBRecordNotFoundException("Record not found" + ldapErrorMessage, e);
         case LDAPException.UNAVAILABLE:
-            return new DBNotAvailableException("Database not available: " + e.getMessage(), e);
+            return new DBNotAvailableException("Database not available" + ldapErrorMessage, e);
         case LDAPException.ENTRY_ALREADY_EXISTS:
-            return new DBRecordAlreadyExistsException("Record already exists: " + e.getMessage(), e);
+            return new DBRecordAlreadyExistsException("Record already exists" + ldapErrorMessage, e);
         default:
-            return new DBException("Database error: " + e.getMessage(), e);
+            return new DBException("Database error" + ldapErrorMessage, e);
         }
     }
 
     public static PKIException toPKIException(LDAPException e) {
+        String ldapErrorMessage = e.getLDAPErrorMessage() != null ? ": " + e.getLDAPErrorMessage() : "";
         switch (e.getLDAPResultCode()) {
         case LDAPException.ATTRIBUTE_OR_VALUE_EXISTS:
-            return new ConflictingOperationException("Attribute or value exists: " + e.getMessage(), e);
+            return new ConflictingOperationException("Attribute or value exists" + ldapErrorMessage, e);
         case LDAPException.NO_SUCH_OBJECT:
-            return new ResourceNotFoundException("No such object: " + e.getMessage(), e);
+            return new ResourceNotFoundException("No such object" + ldapErrorMessage, e);
         case LDAPException.NO_SUCH_ATTRIBUTE:
-            return new ResourceNotFoundException("No such attribute: " + e.getMessage(), e);
+            return new ResourceNotFoundException("No such attribute" + ldapErrorMessage, e);
         case LDAPException.INVALID_DN_SYNTAX:
-            return new BadRequestException("Invalid DN syntax: " + e.getMessage(), e);
+            return new BadRequestException("Invalid DN syntax" + ldapErrorMessage, e);
         case LDAPException.INVALID_ATTRIBUTE_SYNTAX:
-            return new BadRequestException("Invalid attribute syntax: " + e.getMessage(), e);
+            return new BadRequestException("Invalid attribute syntax" + ldapErrorMessage, e);
         case LDAPException.ENTRY_ALREADY_EXISTS:
-            return new ConflictingOperationException("Entry already exists: " + e.getMessage(), e);
+            return new ConflictingOperationException("Entry already exists" + ldapErrorMessage, e);
         default:
-            return new PKIException("LDAP error ("+e.getLDAPResultCode()+"): "+e.getMessage(), e);
+            return new PKIException("LDAP error ("+e.getLDAPResultCode()+")"+ ldapErrorMessage, e);
         }
     }
 }


### PR DESCRIPTION
Description:

LDAPExceptionConverter was using e.getMessage() to append detail to error messages. getMessage() returns the LDAP SDK's generic error code string (e.g. "No such object", "Already exists"), which restates the prefix already in the message, producing output like:
`ResourceNotFoundException: No such object: No such object`
`ConflictingOperationException: Entry already exists: Already exists`

Replace e.getMessage() with e.getLDAPErrorMessage(), which returns the server-side diagnostic detail. When present, this provides useful context (e.g. a DN). When null, the message falls back to just the prefix with no duplication.

Update ca-ssnv2-test.yml expected error message to match the corrected output.

Fixes issue: https://github.com/dogtagpki/pki/issues/4859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved system error formatting so LDAP-related errors include the LDAP-specific message suffix when present, yielding clearer, more informative error text.

* **Bug Fix**
  * Enrollment conflict error message standardized to "Record already exists" for clearer, consistent user-facing feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->