### PR TITLE
For Server Side KeyGen, both CA and TPS, allow the key usages to be c…

### DIFF
--- a/base/ca/shared/profiles/ca/caServerKeygen_DirUserCert.cfg
+++ b/base/ca/shared/profiles/ca/caServerKeygen_DirUserCert.cfg
@@ -41,6 +41,7 @@ policyset.userCertSet.3.default.name=Server-Side Keygen Default
 policyset.userCertSet.3.default.params.keyType=RSA
 policyset.userCertSet.3.default.params.keySize=2048
 policyset.userCertSet.3.default.params.enableArchival=true
+policyset.userCertSet.3.default.params.keyGenUsages=sign,verify,sign_recover,verify_recover,encrypt,decrypt,wrap,unwrap
 policyset.userCertSet.4.constraint.class_id=noConstraintImpl
 policyset.userCertSet.4.constraint.name=No Constraint
 policyset.userCertSet.4.default.class_id=authorityKeyIdentifierExtDefaultImpl

--- a/base/ca/shared/profiles/ca/caServerKeygen_UserCert.cfg
+++ b/base/ca/shared/profiles/ca/caServerKeygen_UserCert.cfg
@@ -43,6 +43,7 @@ policyset.userCertSet.3.default.name=Server-Side Keygen Default
 policyset.userCertSet.3.default.params.keyType=RSA
 policyset.userCertSet.3.default.params.keySize=2048
 policyset.userCertSet.3.default.params.enableArchival=true
+policyset.userCertSet.3.default.params.keyGenUsages=sign,verify,sign_recover,verify_recover,encrypt,decrypt,wrap,unwrap
 policyset.userCertSet.4.constraint.class_id=noConstraintImpl
 policyset.userCertSet.4.constraint.name=No Constraint
 policyset.userCertSet.4.default.class_id=authorityKeyIdentifierExtDefaultImpl

--- a/base/ca/src/main/java/com/netscape/cms/profile/def/ServerKeygenUserKeyDefault.java
+++ b/base/ca/src/main/java/com/netscape/cms/profile/def/ServerKeygenUserKeyDefault.java
@@ -56,6 +56,7 @@ public class ServerKeygenUserKeyDefault extends EnrollDefault {
     public static final String CONFIG_TYPE = "keyType";
     public static final String VAL_LEN = "LEN";
     public static final String VAL_TYPE = "TYPE";
+    public static final String CONFIG_KEY_GEN_USAGES = "keyGenUsages";
 
     //  DO NOT REMOVE
     private static final String TEMP_PUBKEY_RSA_1024 = "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDBz6H2rT2r1RpHdr3JyYr7thSjfwWPbIJ6U09NziHSekLsNZQKsjdLS/LPCfe/aXkhpzPztlx++tkPucpt/xT0exp08feAPIE+Y6gVoyXzEw+Ztz+Zez9Y1cQWxAyp7z11flytjL+4zBGDXmEoe3ZlQvij9DGypPjBC9PhWm0lBwIDAQAB";
@@ -295,6 +296,7 @@ public class ServerKeygenUserKeyDefault extends EnrollDefault {
                 } else {
                     logger.debug("ServerKeygenUserKeyDefault: populate: keySize in request null;  default to" + keySize);
                 }
+
                 // Do things when RSA is selected
             } else if (keyType.contentEquals("EC")) {
                 isEC = true;
@@ -310,6 +312,14 @@ public class ServerKeygenUserKeyDefault extends EnrollDefault {
             } else {
                 throw new Exception("Unsupported keyType: " + keyType);
             }
+
+            // Set PKCS#11 key usages if configured
+            String keyGenUsages = getConfig(CONFIG_KEY_GEN_USAGES);
+            if (keyGenUsages != null && !keyGenUsages.isEmpty()) {
+                logger.debug(method + "keyGenUsages: " + keyGenUsages);
+                request.setExtData(Request.KEY_GEN_USAGES, keyGenUsages);
+            }
+
             request.setExtData(Request.KEY_GEN_ALGORITHM, keyType);
             if(keyType.contentEquals("RSA")) {
                 request.setExtData(Request.KEY_GEN_SIZE, keySize);

--- a/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/crypto/CryptoUtil.java
@@ -3432,6 +3432,40 @@ public class CryptoUtil {
                 .map(SymmetricKey.Usage::valueOf).toArray(SymmetricKey.Usage[]::new);
 
     }
+
+    /**
+       * Enforces PKCS#11 attribute pairing in the usage list.
+       * Some HSMs require that paired attributes
+       * (e.g. CKA_SIGN/CKA_VERIFY, CKA_SIGN_RECOVER/CKA_VERIFY_RECOVER)
+       * are both present in the key generation template. Per PKCS#11 spec,
+       * these are paired operations across public and private keys.
+       *
+       * @param usages The usage list to enforce pairing on
+       */
+    public static void enforcePairedUsages(List<String> usages) {
+        ensureUsagePair(usages, "sign", "verify");
+        ensureUsagePair(usages, "sign_recover", "verify_recover");
+        ensureUsagePair(usages, "encrypt", "decrypt");
+        ensureUsagePair(usages, "wrap", "unwrap");
+    }
+
+    /**
+     * Ensures both members of a PKCS#11 attribute pair are present.
+     * If one is present without the other, adds the missing one.
+     *
+     * @param usages The usage list to check
+     * @param a First member of the pair
+     * @param b Second member of the pair
+     */
+    private static void ensureUsagePair(List<String> usages, String a, String b) {
+        if (usages.contains(a) && !usages.contains(b)) {
+            logger.debug("CryptoUtil: Adding missing paired usage: " + b);
+            usages.add(b);
+        } else if  (usages.contains(b) && !usages.contains(a)) {
+            logger.debug("CryptoUtil: Adding missing paired usage: " + a);
+            usages.add(a);
+        }
+    }
 }
 
 // START ENABLE_ECC

--- a/base/kra/src/main/java/com/netscape/cms/servlet/connector/GenerateKeyPairServlet.java
+++ b/base/kra/src/main/java/com/netscape/cms/servlet/connector/GenerateKeyPairServlet.java
@@ -250,6 +250,12 @@ public class GenerateKeyPairServlet extends CMSServlet {
                 thisreq.setExtData(Request.NETKEY_ATTR_SSKEYGEN_AES_KEY_WRAP_ALG,rAesWrapAlg);
             }
 
+            String rKeyGenUsages = req.getParameter(IRemoteRequest.KRA_KEYGEN_Usages);
+            if (rKeyGenUsages != null && !rKeyGenUsages.isEmpty()) {
+                logger.debug("GenerateKeyPairServlet: processServerSideKeygen(): keyGenUsages: " + rKeyGenUsages);
+                thisreq.setExtData(Request.KEY_GEN_USAGES, rKeyGenUsages);
+            }
+
             queue.processRequest(thisreq);
             Integer result = thisreq.getExtDataInInteger(Request.RESULT);
             if (result != null) {

--- a/base/kra/src/main/java/com/netscape/kra/AsymKeyGenService.java
+++ b/base/kra/src/main/java/com/netscape/kra/AsymKeyGenService.java
@@ -133,6 +133,8 @@ public class AsymKeyGenService implements IService {
 
         KeyPairGeneratorSpi.Usage[] usageList = null;
         String usageStr = request.getExtDataInString(Request.KEY_GEN_USAGES);
+        logger.debug("AsymKeyGenService: KEY_GEN_USAGES from request: " + usageStr);
+
         if (usageStr != null) {
             String[] usages = usageStr.split(",");
 

--- a/base/kra/src/main/java/com/netscape/kra/KeyRecoveryAuthority.java
+++ b/base/kra/src/main/java/com/netscape/kra/KeyRecoveryAuthority.java
@@ -32,6 +32,8 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.StringTokenizer;
 import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.dogtagpki.legacy.kra.KRAPolicy;
 import org.dogtagpki.legacy.kra.KRAPolicyConfig;
@@ -1855,6 +1857,42 @@ public class KeyRecoveryAuthority extends Subsystem implements IAuthority {
             kpAlg = KeyPairAlgorithm.EC;
         else
             kpAlg = KeyPairAlgorithm.DSA;
+
+        // Enforce PKCS#11 attribute pairing for HSM compatibility.
+        // (e.g. CKA_SIGN with CKA_VERIFY, CKA_SIGN_RECOVER with
+        // CKA_VERIFY_RECOVER) to both be present.
+        if (usageList != null) {
+            if (logger.isDebugEnabled()) {
+                for (KeyPairGeneratorSpi.Usage u : usageList) {
+                    if (u != null) {
+                        logger.debug("KeyRecoveryAuthority: incoming usage: "
+                            + u.name());
+                    }
+                }
+            }
+
+            List<String> usageCheck = new ArrayList<>();
+            for (KeyPairGeneratorSpi.Usage u : usageList) {
+                if ( u != null) {
+                    usageCheck.add(u.name().toLowerCase());
+                }
+            }
+            int originalSize = usageCheck.size();
+            CryptoUtil.enforcePairedUsages(usageCheck);
+            if (usageCheck.size() != originalSize) {
+                logger.debug("KeyRecoveryAuthority: Rebuilt usage"
+                    + " list after pairing enforcement");
+                usageList = CryptoUtil.generateUsage(
+                    String.join(",", usageCheck));
+                if (logger.isDebugEnabled()) {
+                    for (KeyPairGeneratorSpi.Usage u : usageList) {
+                        if (u != null) {
+                            logger.debug("KeyRecoveryAuthority: enforced usage: " + u.name());
+                        }
+                    }
+                }
+            }
+        }
 
         try {
             KeyPair kp = generateKeyPair(kpAlg, keySize, keyCurve, pqg, usageList, temp);

--- a/base/kra/src/main/java/com/netscape/kra/NetkeyKeygenService.java
+++ b/base/kra/src/main/java/com/netscape/kra/NetkeyKeygenService.java
@@ -37,6 +37,7 @@ import org.mozilla.jss.crypto.KeyWrapAlgorithm;
 import org.mozilla.jss.crypto.PrivateKey;
 import org.mozilla.jss.crypto.SymmetricKey;
 import org.mozilla.jss.crypto.KeyPairAlgorithm;
+import org.mozilla.jss.crypto.KeyPairGeneratorSpi;
 import org.mozilla.jss.pkcs11.PK11SymKey;
 import org.mozilla.jss.pkix.crmf.PKIArchiveOptions;
 import org.mozilla.jss.util.Base64OutputStream;
@@ -332,11 +333,21 @@ public class NetkeyKeygenService implements IService {
 
             logger.debug("NetkeyKeygenService: about to generate key pair");
 
+            String keyGenUsages = request.getExtDataInString(Request.KEY_GEN_USAGES);
+            KeyPairGeneratorSpi.Usage[] usageList = null;
+
+            if (keyGenUsages != null && !keyGenUsages.isEmpty()) {
+                logger.debug("NetkeyKeygenService: keyGenUsages received: " + keyGenUsages);
+                usageList = CryptoUtil.generateUsage(keyGenUsages);
+            } else {
+                logger.debug("NetkeyKeygenService: no keyGenUsages, using NSS defaults");
+            }
+
             keypair = mKRA.generateKeyPair(rKeytype /* rKeytype: "RSA" or "EC" */,
                 keysize /*Integer.parseInt(len)*/,
                 rKeycurve /* for "EC" only */,
                 null /*pqgParams*/,
-                null /* usageList*/);
+                usageList /* usageList*/);
 
             if (keypair == null) {
                 logger.debug("NetkeyKeygenService: failed generating key pair for " + rCUID + ":" + rUserid);

--- a/base/server/src/main/java/org/dogtagpki/server/connector/IRemoteRequest.java
+++ b/base/server/src/main/java/org/dogtagpki/server/connector/IRemoteRequest.java
@@ -117,6 +117,7 @@ public interface IRemoteRequest {
     public static final String KRA_KEYGEN_KeyType = "keytype";
     public static final String KRA_KEYGEN_EC_KeyCurve = "eckeycurve";
     public static final String KRA_KEYGEN_KeySize = "keysize";
+    public static final String KRA_KEYGEN_Usages = "keyGenUsages";
     public static final String KRA_RECOVERY_CERT = "cert";
     public static final String KRA_RECOVERY_KEYID = "keyid";
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/TPSEngine.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/TPSEngine.java
@@ -636,7 +636,7 @@ public class TPSEngine extends CMSEngine {
     public KRAServerSideKeyGenResponse serverSideKeyGen(int keySize, String cuid, String userid, String drmConnId,
             TPSBuffer wrappedDesKey, TPSBuffer drmWrappedAesKey,
             boolean archive,
-            boolean isECC,String aesKeyWrapAlg) throws TPSException {
+            boolean isECC,String aesKeyWrapAlg, String keyGenUsages) throws TPSException {
 
 /*
         logger.debug("TPSEngine.serverSideKeyGen entering... keySize: " + keySize + " cuid: " + cuid + " userid: "
@@ -658,7 +658,7 @@ public class TPSEngine extends CMSEngine {
             resp = kra.serverSideKeyGen(isECC, keySize, cuid, userid,
                     (wrappedDesKey != null) ? Util.specialURLEncode(wrappedDesKey) :  "",
                     (drmWrappedAesKey != null) ? Util.specialURLEncode(drmWrappedAesKey) : "",
-                    archive,aesKeyWrapAlg);
+                    archive,aesKeyWrapAlg, keyGenUsages);
 
         } catch (EBaseException e) {
             throw new TPSException("TPSEngine.serverSideKeyGen: Problem creating  or using KRARemoteRequestHandler! "

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/cms/KRARemoteRequestHandler.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/cms/KRARemoteRequestHandler.java
@@ -69,10 +69,12 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
             String sDesKey,
             String sAesKey,
             boolean archive,
-            String aesKeyWrapAlg)
+            String aesKeyWrapAlg,
+            String keyGenUsages)
             throws EBaseException {
 
         logger.debug("KRARemoteRequestHandler: serverSideKeyGen(): begins.");
+        logger.debug("KRARemoteRequestHandler: serverSideKeyGen(): keyGenUsages: " + keyGenUsages); 
         if (cuid == null || userid == null || sDesKey == null) {
             throw new EBaseException("KRARemoteRequestHandler: serverSideKeyGen(): input parameter null.");
         }
@@ -125,6 +127,10 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
 
             //logger.debug("KRARemoteRequestHandler: outgoing request for ECC: " + request);
 
+            if (keyGenUsages != null && !keyGenUsages.isEmpty()) {
+                request += "&" + IRemoteRequest.KRA_KEYGEN_Usages + "=" + keyGenUsages;
+            }
+
             resp =
                     conn.send("GenerateKeyPair",
                             request);
@@ -147,6 +153,9 @@ public class KRARemoteRequestHandler extends RemoteRequestHandler
                     "&" + IRemoteRequest.KRA_Aes_Wrap_Alg + "=" +
                     aesWrapAlg;
 
+            if (keyGenUsages != null && !keyGenUsages.isEmpty()) {
+                request += "&" + IRemoteRequest.KRA_KEYGEN_Usages + "=" + keyGenUsages;
+            }
 
             //logger.debug("KRARemoteRequestHandler: outgoing request for RSA: " + request);
 

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSEnrollProcessor.java
@@ -305,6 +305,18 @@ public class TPSEnrollProcessor extends TPSProcessor {
                         logger.debug(method + " OK not to have appletVer target in token range mapping");
                     }
                     // ** Applet and Alg Selection by Token Range Support end **
+
+                    // ** Get key gen Usages  **
+
+                     try {
+                         String keyGenUsages = resolverInst.getResolvedMapping(
+                                 mappingParams, "keyGenUsages", symKeySize);
+                         setSelectedKeyGenUsages(keyGenUsages);
+                         logger.debug(method + " resolved keyGenUsages: " + keyGenUsages);
+                     } catch (TPSException e) {
+                         logger.debug(method + " OK not to have keyGenUsages target in token range mapping");
+                     }
+
                 }
             } catch (TPSException e) {
                 logMsg = e.toString();
@@ -2549,6 +2561,8 @@ public class TPSEnrollProcessor extends TPSProcessor {
                     "TPSEnrollProcessor.enrollOneCertificate: either generate private key on the server, or preform recovery or perform renewal.");
             boolean archive = checkForServerKeyArchival(cEnrollInfo);
             String kraConnId = getDRMConnectorID(cEnrollInfo.getKeyType());
+            // Get any configured SSKG key generation usages..
+            String keyGenUsages = establishKeyGenUsagesSSKeyGen(cEnrollInfo);
 
             String publicKeyStr = null;
             //Do this for JUST server side keygen
@@ -2559,7 +2573,7 @@ public class TPSEnrollProcessor extends TPSProcessor {
                 ssKeyGenResponse = engine
                         .serverSideKeyGen(cEnrollInfo.getKeySize(),
                                 aInfo.getCUIDhexStringPlain(), userid, kraConnId, drmDesKey,drmAesKey,
-                                archive, isECC, aesKeyWrapAlg);
+                                archive, isECC, aesKeyWrapAlg, keyGenUsages);
 
                 publicKeyStr = ssKeyGenResponse.getPublicKey();
                 //logger.debug("TPSEnrollProcessor.enrollOneCertificate: public key string from server: " + publicKeyStr);
@@ -3572,6 +3586,47 @@ public class TPSEnrollProcessor extends TPSProcessor {
         logger.debug(method + " returning: " + aesKeyWrapAlg); 
         return aesKeyWrapAlg;
 
+    }
+
+    public String establishKeyGenUsagesSSKeyGen(CertEnrollInfo cInfo) throws TPSException {
+        String method = "TPSEnrollProcessor::establishKeyGenUsagesSSKeyGen: ";
+
+        // Check resolver result first
+        String selectedUsages = getSelectedKeyGenUsages();
+
+        if (selectedUsages != null) {
+            selectedUsages = selectedUsages.trim();
+        }
+
+        if (selectedUsages != null && !selectedUsages.isEmpty()) {
+            logger.debug(method + " using keyGenUsages from resolver: " + selectedUsages);
+            return selectedUsages;
+        }
+
+        // Fall back to static profile config
+        if (cInfo == null) {
+            logger.debug(method + " cInfo is null, cannot check static profile config");
+            return null;
+        }
+
+        TPSEngineConfig configStore = this.getConfigStore();
+        try {
+            String configValue = cInfo.getKeyTypePrefix() + ".serverKeygen.keyGenUsages";
+            logger.debug(method + " configValue: " + configValue);
+            selectedUsages = configStore.getString(configValue, null);
+            if (selectedUsages != null) {
+                selectedUsages = selectedUsages.trim();
+                if (selectedUsages.isEmpty()) {
+                    selectedUsages = null;
+                }
+            }
+        } catch (EBaseException e) {
+            throw new TPSException(method + " error reading config " + e.getMessage(),
+                   TPSStatus.STATUS_ERROR_MISCONFIGURATION);
+        }
+
+        logger.debug(method + " returning: " + selectedUsages);
+        return selectedUsages;
     }
 
     private boolean checkForServerSideKeyGen(CertEnrollInfo cInfo) throws TPSException {

--- a/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/processor/TPSProcessor.java
@@ -143,6 +143,10 @@ public class TPSProcessor {
     protected String selectedKeySet;
     protected String selectedKeyWrapAlg;   // ** Applet and Alg Selection by Token Range Support **
     protected String selectedAppletVer;    // ** Applet and Alg Selection by Token Range Support **
+
+    protected String selectedKeyGenUsages;
+
+
     AuthToken authToken;
     List<String> ldapStringAttrs;
 
@@ -5543,7 +5547,15 @@ logger.debug("defaultAID: " + defaultAID);
     public String getSelectedKeyWrapAlg() {
         return selectedKeyWrapAlg;
     }
-    
+
+    protected void setSelectedKeyGenUsages(String usages) {
+        selectedKeyGenUsages = usages;
+    }
+
+    public String getSelectedKeyGenUsages() {
+        return selectedKeyGenUsages;
+    }
+
     protected void setSelectedAppletVer(String theAppletVer) {
         selectedAppletVer = theAppletVer;
     }


### PR DESCRIPTION
 For Server Side KeyGen, both CA and TPS, allow the key usages to be configured.


For the CA, we can configure these in the SSKG CA cert enrollment profiles. For TPS we can confugire these both in the token profile for each key type or the keyset mapping resolver configuration.

Exs:

CA SSKG profile (e.g., caServerKeygen_UserCert):

  policyset.userCertSet.3.default.params.keyGenUsages=sign,verify,sign_recover,verify_recover,encrypt,decrypt,wrap,unwrap

TPS static profile config:

  op.enroll.externalRegISEtoken.keyGen.encryption.serverKeygen.enable=True
  op.enroll.externalRegISEtoken.keyGen.encryption.serverKeygen.archive=true
  op.enroll.externalRegISEtoken.keyGen.encryption.serverKeygen.drm.conn=kra1
  op.enroll.externalRegISEtoken.keyGen.encryption.serverKeygen.keyGenUsages=sign,verify,sign_recover,verify_recover,wrap,unwrap

  TPS keySetMappingResolver:

  tps.mapping.resolver.keySetMappingResolver.0.filter.tokenCUID.start=40906145B1960000
  tps.mapping.resolver.keySetMappingResolver.0.filter.tokenCUID.end=40906145B19600FF
  tps.mapping.resolver.keySetMappingResolver.0.target.keySet=defKeySet
  tps.mapping.resolver.keySetMappingResolver.0.target.keyWrapAlg=KWP
  tps.mapping.resolver.keySetMappingResolver.0.target.keyGenUsages=sign,verify,sign_recover,verify_recover,wrap,unwrap

Assisted-by : claude Sonnet 4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable key-generation usage settings for enrollment profiles and requests.
  * Per-token-range selection of server-side key-generation usages during external registration.

* **Enhancements**
  * Usage parameters are propagated through the enrollment pipeline and logged.
  * Automatic enforcement/completion of paired PKCS#11 usages (sign/verify, sign_recover/verify_recover, encrypt/decrypt, wrap/unwrap).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->