### PR TITLE
Auto-configure ML-KEM archival in pkispawn and enhance KRA PQC test

### DIFF
--- a/.github/workflows/kra-pqc-test.yml
+++ b/.github/workflows/kra-pqc-test.yml
@@ -280,18 +280,23 @@ jobs:
           echo pki.example.com > expected
           diff expected actual
 
-      - name: Configure KRA for ML-KEM archival
+      - name: Verify KRA ML-KEM archival auto-configuration
         run: |
-          # Configure CS.cfg for ML-KEM archival
-          docker exec pki pki-server kra-config-set kra.storageUnit.wrapping.1.sessionKeyLength 256
-          docker exec pki pki-server kra-config-set kra.storageUnit.wrapping.1.payloadWrapAlgorithm "AES KeyWrap/Padding"
-          docker exec pki pki-server kra-config-set kra.storageUnit.wrapping.1.sessionKeyType AES
-          docker exec pki pki-server kra-config-set kra.storageUnit.wrapping.choice 1
-          docker exec pki pki-server kra-config-set kra.legacyPKCS12 false
-          docker exec pki pki-server kra-config-set kra.nonLegacyAlg "AES/None/PKCS5Padding/Kwp/256"
+          # ML-KEM archival should be configured automatically by pkispawn for PQC installations
+          docker exec pki pki-server kra-config-find | tee output
 
-          # Restart KRA
-          docker exec pki pki-server kra-redeploy --wait
+          # Verify the ML-KEM wrapping settings (wrapping.2) were configured
+          grep "kra.storageUnit.wrapping.2.sessionKeyLength=256" output
+          grep "kra.storageUnit.wrapping.2.sessionKeyType=AES" output
+          # Note: sessionKeyWrapAlgorithm and sessionKeyKeyGenAlgorithm are not set for ML-KEM
+          grep "kra.storageUnit.wrapping.2.payloadEncryptionAlgorithm=AES" output
+          grep "kra.storageUnit.wrapping.2.payloadEncryptionMode=CBC" output
+          grep "kra.storageUnit.wrapping.2.payloadEncryptionPadding=PKCS5Padding" output
+          grep "kra.storageUnit.wrapping.2.payloadEncryptionIVLen=16" output
+          grep 'kra.storageUnit.wrapping.2.payloadWrapAlgorithm=AES KeyWrap/Padding' output
+          grep "kra.storageUnit.wrapping.choice=2" output
+          grep "kra.legacyPKCS12=false" output
+          grep 'kra.nonLegacyAlg=AES/None/PKCS5Padding/Kwp/256' output
 
       - name: Import transport cert
         run: |
@@ -356,7 +361,6 @@ jobs:
               -a mlkem \
               -l 768 \
               -w "AES KeyWrap/Wrapped" \
-              -t false \
               -v \
               -o $SHARED/testuser.csr
 
@@ -467,14 +471,43 @@ jobs:
               -o ldif_wrap=no \
               -LLL | tee output
 
-          # encryption mode should be "false" by default
-          echo "false" > expected
-          sed -n 's/^metaInfo:\s*payloadEncrypted:\(.*\)$/\1/p' output > actual
-          diff expected actual
+          # Normalize LDAP output for validation
+          sed \
+              -e '/^$/d' \
+              -e 's/^\(serialno\): .*$/\1: XXXXX/' \
+              -e 's/^\(privateKeyData\):: .*$/\1:: XXXXX/' \
+              -e 's/^\(publicKeyData\):: .*$/\1:: XXXXX/' \
+              -e 's/^\(metaInfo: payloadEncryptionIV\):.*/\1:XXXXX/' \
+              -e 's/^\(dateOfCreate\): .*$/\1: XXXXX/' \
+              -e 's/^\(dateOfModify\): .*$/\1: XXXXX/' \
+              output > actual
 
-          # key wrap algorithm should be "AES KeyWrap/Padding" for ML-KEM
-          echo "AES KeyWrap/Padding" > expected
-          sed -n 's/^metaInfo:\s*payloadWrapAlgorithm:\(.*\)$/\1/p' output > actual
+          cat > expected << EOF
+          dn: cn=$DEC_KEY_ID,ou=keyRepository,ou=kra,dc=kra,dc=pki,dc=example,dc=com
+          objectClass: top
+          objectClass: keyRecord
+          keyState: VALID
+          serialno: XXXXX
+          ownerName: UID=testuser,CN=Test User,OU=noPOP
+          keySize: 768
+          algorithm: 2.16.840.1.101.3.4.4.2
+          privateKeyData:: XXXXX
+          publicKeyData:: XXXXX
+          metaInfo: storageKeyAlgorithm:ML-KEM
+          metaInfo: payloadEncrypted:false
+          metaInfo: sessionKeyLength:256
+          metaInfo: payloadEncryptionPadding:PKCS5Padding
+          metaInfo: payloadEncryptionAlgorithm:AES
+          metaInfo: payloadEncryptionIV:XXXXX
+          metaInfo: payloadEncryptionMode:CBC
+          metaInfo: payloadWrapAlgorithm:AES KeyWrap/Padding
+          metaInfo: sessionKeyType:AES
+          dateOfCreate: XXXXX
+          dateOfModify: XXXXX
+          archivedBy: CA-pki.example.com-8443
+          cn: $DEC_KEY_ID
+          EOF
+
           diff expected actual
 
       - name: Retrieve ML-KEM key

--- a/base/kra/shared/conf/CS.cfg
+++ b/base/kra/shared/conf/CS.cfg
@@ -144,12 +144,10 @@ kra.storageUnit.wrapping.0.payloadWrapAlgorithm=DES3/CBC/Pad
 kra.storageUnit.wrapping.0.payloadWrapIV=AQEBAQEBAQE=
 kra.storageUnit.wrapping.0.sessionKeyType=DESede
 kra.storageUnit.wrapping._000=##
-kra.storageUnit.wrapping._001=## wrapping.1 settings apply to RSA, EC, and ML-KEM storage certs
-kra.storageUnit.wrapping._002=## For ML-KEM: sessionKeyWrapAlgorithm and sessionKeyKeyGenAlgorithm
-kra.storageUnit.wrapping._003=## are not used (ML-KEM uses encapsulation, not wrapping/generation)
-kra.storageUnit.wrapping._004=## payloadEncryption* fields only used when kra.allowEncDecrypt.archival=true
-kra.storageUnit.wrapping._005=## (ML-KEM does not support allowEncDecrypt.archival)
-kra.storageUnit.wrapping._006=##
+kra.storageUnit.wrapping._001=## wrapping.0 settings apply to legacy DES3 storage certs
+kra.storageUnit.wrapping._002=## wrapping.1 settings apply to RSA and EC storage certs
+kra.storageUnit.wrapping._003=## wrapping.2 settings apply to ML-KEM storage certs
+kra.storageUnit.wrapping._004=##
 kra.storageUnit.wrapping.1.sessionKeyLength=128
 kra.storageUnit.wrapping.1.sessionKeyWrapAlgorithm=RSA
 kra.storageUnit.wrapping.1.payloadEncryptionPadding=PKCS5Padding
@@ -159,6 +157,20 @@ kra.storageUnit.wrapping.1.payloadEncryptionMode=CBC
 kra.storageUnit.wrapping.1.payloadEncryptionIVLen=16
 kra.storageUnit.wrapping.1.payloadWrapAlgorithm=AES KeyWrap/Padding
 kra.storageUnit.wrapping.1.sessionKeyType=AES
+kra.storageUnit.wrapping._005=##
+kra.storageUnit.wrapping._006=## wrapping.2 for ML-KEM:
+kra.storageUnit.wrapping._007=##   - sessionKeyWrapAlgorithm and sessionKeyKeyGenAlgorithm are NOT set
+kra.storageUnit.wrapping._008=##     (ML-KEM uses encapsulation instead of key wrapping)
+kra.storageUnit.wrapping._009=##   - payloadEncryption* fields only used when kra.allowEncDecrypt.archival=true
+kra.storageUnit.wrapping._010=##     (ML-KEM does not support allowEncDecrypt.archival)
+kra.storageUnit.wrapping._011=##
+kra.storageUnit.wrapping.2.sessionKeyLength=256
+kra.storageUnit.wrapping.2.sessionKeyType=AES
+kra.storageUnit.wrapping.2.payloadEncryptionAlgorithm=AES
+kra.storageUnit.wrapping.2.payloadEncryptionMode=CBC
+kra.storageUnit.wrapping.2.payloadEncryptionPadding=PKCS5Padding
+kra.storageUnit.wrapping.2.payloadEncryptionIVLen=16
+kra.storageUnit.wrapping.2.payloadWrapAlgorithm=AES KeyWrap/Padding
 kra.storageUnit.wrapping.choice=1
 kra.storageUnit.nickName=
 kra.transportUnit.nickName=

--- a/base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java
+++ b/base/kra/src/main/java/com/netscape/kra/StorageKeyUnit.java
@@ -153,12 +153,22 @@ public class StorageKeyUnit extends EncryptionUnit implements IStorageKeyUnit {
         WrappingParams params = new WrappingParams();
         params.setSkType(config.getString(KeyRecordParser.OUT_SK_TYPE));
         params.setSkLength(config.getInteger(KeyRecordParser.OUT_SK_LENGTH, 0));
-        String keyWrapAlg = config.getString(KeyRecordParser.OUT_SK_WRAP_ALGORITHM);
-        if("RSA".equals(keyWrapAlg) && useOAEPKeyWrap == true) {
-            keyWrapAlg = "RSAES-OAEP";
+
+        // sessionKeyWrapAlgorithm is optional (not used for ML-KEM)
+        String keyWrapAlg = config.getString(KeyRecordParser.OUT_SK_WRAP_ALGORITHM, null);
+        if (keyWrapAlg != null) {
+            if("RSA".equals(keyWrapAlg) && useOAEPKeyWrap == true) {
+                keyWrapAlg = "RSAES-OAEP";
+            }
+            params.setSkWrapAlgorithm(keyWrapAlg);
         }
-        params.setSkWrapAlgorithm(keyWrapAlg);
-        params.setSkKeyGenAlgorithm(config.getString(KeyRecordParser.OUT_SK_KEYGEN_ALGORITHM));
+
+        // sessionKeyKeyGenAlgorithm is optional (not used for ML-KEM)
+        String keyGenAlg = config.getString(KeyRecordParser.OUT_SK_KEYGEN_ALGORITHM, null);
+        if (keyGenAlg != null) {
+            params.setSkKeyGenAlgorithm(keyGenAlg);
+        }
+
         params.setPayloadWrapAlgorithm(config.getString(KeyRecordParser.OUT_PL_WRAP_ALGORITHM));
 
         if (config.getString(KeyRecordParser.OUT_PL_ENCRYPTION_OID, null) != null) {

--- a/base/server/etc/default.cfg
+++ b/base/server/etc/default.cfg
@@ -408,6 +408,15 @@ pki_import_admin_cert=True
 pki_standalone=False
 pki_kra_ephemeral_requests=False
 
+# ML-KEM archival configuration (optional overrides for PQC installations)
+# If empty, sensible defaults are used automatically when ML-KEM certs are detected
+pki_kra_wrapping_session_key_length=
+pki_kra_wrapping_payload_wrap_algorithm=
+pki_kra_wrapping_session_key_type=
+pki_kra_wrapping_choice=
+pki_kra_legacy_pkcs12=
+pki_kra_non_legacy_algorithm=
+
 # DEPRECATED
 # Use 'pki_*_csr_path' instead.
 pki_external_admin_csr_path=

--- a/base/server/python/pki/server/deployment/__init__.py
+++ b/base/server/python/pki/server/deployment/__init__.py
@@ -1507,6 +1507,50 @@ class PKIDeployer:
             logger.debug('Setting ephemeral requests to true')
             subsystem.set_config('kra.ephemeralRequests', 'true')
 
+        # Auto-configure key wrapping based on storage cert type
+        # Defaults for wrapping.0, wrapping.1, and wrapping.2 are in CS.cfg
+        storage_key_type = self.get_key_type(subsystem, 'storage')
+
+        # Auto-select wrapping profile based on storage key type
+        if storage_key_type == 'MLKEM':
+            wrapping_choice = '2'
+            logger.info('ML-KEM storage cert detected, using wrapping.2')
+        else:
+            # RSA, ECC, or other traditional algorithms use wrapping.1
+            wrapping_choice = '1'
+            logger.info('Traditional storage cert detected, using wrapping.1')
+
+        # Set the wrapping choice
+        subsystem.set_config('kra.storageUnit.wrapping.choice', wrapping_choice)
+
+        # Allow user overrides of individual wrapping parameters for the selected profile
+        wrapping_prefix = 'kra.storageUnit.wrapping.%s' % wrapping_choice
+
+        if self.mdict.get('pki_kra_wrapping_session_key_length'):
+            subsystem.set_config(
+                '%s.sessionKeyLength' % wrapping_prefix,
+                self.mdict['pki_kra_wrapping_session_key_length'])
+
+        if self.mdict.get('pki_kra_wrapping_session_key_type'):
+            subsystem.set_config(
+                '%s.sessionKeyType' % wrapping_prefix,
+                self.mdict['pki_kra_wrapping_session_key_type'])
+
+        if self.mdict.get('pki_kra_wrapping_payload_wrap_algorithm'):
+            subsystem.set_config(
+                '%s.payloadWrapAlgorithm' % wrapping_prefix,
+                self.mdict['pki_kra_wrapping_payload_wrap_algorithm'])
+
+        # ML-KEM specific: configure secure PKCS#12 settings by default
+        if storage_key_type.upper() == 'MLKEM':
+            subsystem.set_config(
+                'kra.legacyPKCS12',
+                self.mdict.get('pki_kra_legacy_pkcs12') or 'false')
+
+            subsystem.set_config(
+                'kra.nonLegacyAlg',
+                self.mdict.get('pki_kra_non_legacy_algorithm') or 'AES/None/PKCS5Padding/Kwp/256')
+
     def configure_tps(self, subsystem):
 
         baseDN = subsystem.config['internaldb.basedn']


### PR DESCRIPTION
    This change automatically selects the appropriate key wrapping profile
    based on the storage certificate type during KRA installation.
    
    Changes:
    - Add wrapping.2 defaults to CS.cfg for ML-KEM storage certs
    - Auto-select wrapping profile in configure_kra() based on storage_key_type:
      - wrapping.1 for RSA/ECC storage certs (existing default)
      - wrapping.2 for ML-KEM storage certs
    - Users can override individual wrapping parameters via pkispawn config
    - ML-KEM installations get secure PKCS#12 settings by default
    - Update kra-pqc-test.yml to verify auto-configuration
    - Add comprehensive LDAP validation for ML-KEM archived keys
    
    This makes the code more maintainable and easier to extend for future
    key types without requiring ML-KEM-specific logic.

    Assisted-by: Claude
    DOGTAG-4328 part 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically configures ML-KEM archival/wrapping settings for detected ML-KEM storage keys, including legacy vs non-legacy options.
* **Improvements**
  * Adds ML-KEM-specific wrapping/session configuration and clarifies applicability for RSA/EC vs ML-KEM.
  * Makes session-key wrap/key-generation algorithm settings optional, applying them only when provided.
* **Tests**
  * Updates ML-KEM archival end-to-end validation to verify auto-configuration parameters.
  * Improves archived-key LDAP verification by redacting dynamic fields before comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->