### PR TITLE
Fix EST upgrade script, and add profile.configuration.managed switch to be able to disable adding profiles under CM

### DIFF
--- a/base/server/upgrade/11.9.0/01-EnableEST.py
+++ b/base/server/upgrade/11.9.0/01-EnableEST.py
@@ -28,8 +28,14 @@ class EnableEST(pki.server.upgrade.PKIServerUpgradeScriptlet):
             logger.debug("Impossible to access CA DB. Update aborted")
             return
 
-        logger.info('Make est profile available')
-        self.enable_est_profile(instance, subsystem)
+        manageprofiles = (
+            str(subsystem.config.get('profile.configuration.managed', 'false')).lower() == 'true'
+        )
+        if not manageprofiles:
+            logger.info('Make est profile available')
+            self.enable_est_profile(instance, subsystem)
+        else:
+            logger.info('Skipped est profile install')
         logger.info('Update internal profile to accept EST administrator')
         self.update_internal_profiles(subsystem)
         logger.info('Update registry to accept est profile')
@@ -97,19 +103,21 @@ class EnableEST(pki.server.upgrade.PKIServerUpgradeScriptlet):
             file_name = '{}.cfg'.format(profile)
             path = os.path.join(subsystem.base_dir, 'profiles', 'ca', file_name)
 
-            config = {}
-            logger.info('Loading %s', path)
-            pki.util.load_properties(path, config)
+            if os.path.isfile(path):
+                config = {}
+                logger.info('Loading %s', path)
+                pki.util.load_properties(path, config)
 
-            if 'group="Enterprise EST Administrators"' in config['authz.acl']:
-                logger.info('Internal profile ACLs already updated.')
-                return
+                if 'group="Enterprise EST Administrators"' in config['authz.acl']:
+                    logger.info('Internal profile ACLs already updated.')
+                    continue
 
-            self.backup(path)
-            config['authz.acl'] = config['authz.acl'] + ' || group="Enterprise EST Administrators"'
+                self.backup(path)
+                config['authz.acl'] = config['authz.acl'] + \
+                    ' || group="Enterprise EST Administrators"'
 
-            logger.info('Storing %s', path)
-            pki.util.store_properties(path, config)
+                logger.info('Storing %s', path)
+                pki.util.store_properties(path, config)
 
     def update_registry(self, subsystem):
         self.backup(subsystem.registry_conf)

--- a/base/server/upgrade/11.9.0/04-UpdateMLDSAProfiles.py
+++ b/base/server/upgrade/11.9.0/04-UpdateMLDSAProfiles.py
@@ -25,18 +25,20 @@ class UpdateMLDSAProfiles(pki.server.upgrade.PKIServerUpgradeScriptlet):
         if subsystem.name != 'ca':
             return
 
-        # New ML-DSA profiles to add
-        new_profiles = [
-            'caMLDSAUserCert',
-            'caMLDSAServerCert',
-            'caMLDSASubsystemCert',
-            'caMLDSAAdminCert',
-            'caMLDSAInternalAuthServerCert',
-            'caMLDSAInternalAuthSubsystemCert'
-        ]
+        manageprofiles = (
+            str(subsystem.config.get('profile.configuration.managed', 'false')).lower() == 'true'
+        )
+        if not manageprofiles:
+            logger.info('Update existing profiles for ML-DSA Support')
+            self.update_existing_profiles(instance, subsystem)
+            logger.info('Adding new ML-DSA Profiles')
+            self.add_mldsa_profiles(instance, subsystem)
+        else:
+            logger.info('Skipping update of existing profiles for MLD-SA')
+            logger.info('Skipping adding new ML-DSA Profiles')
+        self.config_updates(instance, subsystem)
 
-        # Read the available profile list
-        profile_list = subsystem.config.get('profile.list').split(',')
+    def update_existing_profiles(self, instance, subsystem):
 
         # Update all profiles
         # If the signature algorithms have been modified in the instance
@@ -75,6 +77,19 @@ class UpdateMLDSAProfiles(pki.server.upgrade.PKIServerUpgradeScriptlet):
             logger.info('Storing %s', path)
             pki.util.store_properties(path, instance_profile)
 
+    def add_mldsa_profiles(self, instance, subsystem):
+        # New ML-DSA profiles to add
+        new_profiles = [
+            'caMLDSAUserCert',
+            'caMLDSAServerCert',
+            'caMLDSASubsystemCert',
+            'caMLDSAAdminCert',
+            'caMLDSAInternalAuthServerCert',
+            'caMLDSAInternalAuthSubsystemCert'
+        ]
+        # Read the available profile list
+        profile_list = subsystem.config.get('profile.list').split(',')
+
         # Add new profiles
         for profile in new_profiles:
             file_name = '{}.cfg'.format(profile)
@@ -100,6 +115,7 @@ class UpdateMLDSAProfiles(pki.server.upgrade.PKIServerUpgradeScriptlet):
 
         subsystem.set_config('profile.list', ','.join(profile_list))
 
+    def config_updates(self, instance, subsystem):
         subsystem.set_config('keys.mldsa.keysize.default', '65')
 
         # Make a backup of existing CS.cfg before writing modified values


### PR DESCRIPTION
Add ability to turn off adding profiles to a CA with CM Managed Profiles

Check the CS.cfg for a new item profile.configuration.managed and default to false.  If Profiles are under CM Management "true" skip adding files to the ca/profiles/ca for the instances but perform all other actions such as updating the registry for new entries, and new defaults for CS.cfg etc. 
manageprofiles = subsystem.config.get('profile.configuration.managed', False)

01 EST Script does not check if a profile exists before attempting to update resulting in CA start failure if a profile does not exist.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer profile upgrades with existence checks, file backups, and selective ACL updates (avoids redundant changes when already applied).
  * Profile installation and updates now respect centrally managed configuration flags to skip unnecessary work.

* **Refactor**
  * Upgrade flow reorganized so ML-DSA profile creation/updates run only when not centrally managed, while key configuration updates are applied consistently.
  * Split and restructure upgrade logic for clearer, more reliable handling of profile lists and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->