### PR TITLE
Update OCSPServlet response on internal error

### DIFF
--- a/.github/workflows/ocsp-basic-test.yml
+++ b/.github/workflows/ocsp-basic-test.yml
@@ -591,7 +591,7 @@ jobs:
 
           # responder should fail since there's no CRLs
           cat > expected << EOF
-          ERROR: Unable to submit OCSP request: Incorrect tag: expected [UNIVERSAL 16], found [UNIVERSAL 28]
+          ERROR: OCSPResponseStatus: INTERNAL_ERROR
           EOF
 
           diff expected stderr
@@ -613,7 +613,7 @@ jobs:
 
           # responder should fail since there's no CRLs
           cat > expected << EOF
-          SEVERE: InvalidBERException: Incorrect tag: expected [UNIVERSAL 16], found [UNIVERSAL 28]
+          SEVERE: CLIException: OCSPResponseStatus: INTERNAL_ERROR
           EOF
 
           diff expected actual
@@ -627,22 +627,14 @@ jobs:
               -CAfile ca_signing.crt \
               -issuer ca_signing.crt \
               -serial $CERT_ID \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
-
-          # remove the random parts of stderr so it can be compared
-          sed -i "s/^[^:]*:error:/error:/g" stderr
-
-          # remove file names and line numbers so it can be compared
-          sed -i "s/^\([^:]*:[^:]*:[^:]*:[^:]*:[^:]*:\)[^:]*:[^:]*:/\1/" stderr
+              | tee output
 
           # responder should fail since there's no CRLs
           cat > expected << EOF
-          Error querying OCSP responder
-          error:1E800076:HTTP routines:OSSL_HTTP_REQ_CTX_nbio:unexpected content type:expected=application/ocsp-response, actual=text/html
-          error:1E800067:HTTP routines:OSSL_HTTP_REQ_CTX_exchange:error receiving:server=http://pki.example.com:8080
+          Responder Error: internalerror (2)
           EOF
 
-          diff expected stderr
+          diff expected output
 
       - name: Prepare revoked cert
         run: |

--- a/.github/workflows/ocsp-crl-direct-test.yml
+++ b/.github/workflows/ocsp-crl-direct-test.yml
@@ -269,9 +269,13 @@ jobs:
               --serial $CERT_ID \
               > >(tee stdout) 2> >(tee stderr >&2) || true
 
-          # the responder should fail
-          sed -n "s/^SEVERE:\s*\(\S*\)/\1/p" stderr > actual
-          echo "InvalidBERException: Incorrect tag: expected [UNIVERSAL 16], found [UNIVERSAL 28]" > expected
+          sed -n "/^SEVERE:/p" stderr > actual
+
+          # responder should fail since there's no CRLs
+          cat > expected << EOF
+          SEVERE: CLIException: OCSPResponseStatus: INTERNAL_ERROR
+          EOF
+
           diff expected actual
 
           # check cert status using OpenSSL
@@ -280,20 +284,14 @@ jobs:
               -CAfile ${SHARED}/ca_signing.crt \
               -issuer ${SHARED}/ca_signing.crt \
               -serial $CERT_ID \
-              > >(tee stdout) 2> >(tee stderr >&2) || true
+              | tee output
 
-          # remove the random parts of stderr so it can be compared
-          sed -i "s/^[^:]*:error:/error:/g" stderr
+          # responder should fail since there's no CRLs
+          cat > expected << EOF
+          Responder Error: internalerror (2)
+          EOF
 
-          # remove file names and line numbers so it can be compared
-          sed -i "s/^\([^:]*:[^:]*:[^:]*:[^:]*:[^:]*:\)[^:]*:[^:]*:/\1/" stderr
-
-          # the responder should fail
-          echo "Error querying OCSP responder" > expected
-          echo "error:1E800076:HTTP routines:OSSL_HTTP_REQ_CTX_nbio:unexpected content type:expected=application/ocsp-response, actual=text/html" >> expected
-          echo "error:1E800067:HTTP routines:OSSL_HTTP_REQ_CTX_exchange:error receiving:server=http://ocsp.example.com:8080" >> expected
-
-          diff expected stderr
+          diff expected output
 
       - name: Check OCSP responder with initial CRL
         run: |

--- a/base/common/src/main/java/com/netscape/cmsutil/ocsp/OCSPResponseStatus.java
+++ b/base/common/src/main/java/com/netscape/cmsutil/ocsp/OCSPResponseStatus.java
@@ -63,12 +63,34 @@ public class OCSPResponseStatus implements ASN1Value {
 
     private ENUMERATED responseStatus;
 
+    public OCSPResponseStatus(long val) {
+        responseStatus = new ENUMERATED(val);
+    }
+
     public long getValue() {
         return responseStatus.getValue();
     }
 
-    public OCSPResponseStatus(long val) {
-        responseStatus = new ENUMERATED(val);
+    public String getName() throws IllegalArgumentException, IllegalAccessException {
+
+        int value = (int) getValue();
+
+        switch (value) {
+        case 0:
+            return "SUCCESSFUL";
+        case 1:
+            return "MALFORMED_REQUEST";
+        case 2:
+            return "INTERNAL_ERROR";
+        case 3:
+            return "TRY_LATER";
+        case 5:
+            return "SIG_REQUIRED";
+        case 6:
+            return "UNAUTHORIZED";
+        default:
+            return "UNKNOWN (" + value + ")";
+        }
     }
 
     ///////////////////////////////////////////////////////////////////////

--- a/base/server/src/main/java/com/netscape/cms/servlet/ocsp/OCSPServlet.java
+++ b/base/server/src/main/java/com/netscape/cms/servlet/ocsp/OCSPServlet.java
@@ -45,6 +45,7 @@ import com.netscape.cmscore.util.StatsSubsystem;
 import com.netscape.cmsutil.ocsp.BasicOCSPResponse;
 import com.netscape.cmsutil.ocsp.OCSPRequest;
 import com.netscape.cmsutil.ocsp.OCSPResponse;
+import com.netscape.cmsutil.ocsp.OCSPResponseStatus;
 import com.netscape.cmsutil.ocsp.ResponseBytes;
 import com.netscape.cmsutil.ocsp.ResponseData;
 import com.netscape.cmsutil.ocsp.SingleResponse;
@@ -250,8 +251,9 @@ public class OCSPServlet extends CMSServlet {
                 }
 
             } catch (Exception e) {
-                logger.warn("OCSPServlet: " + e.getMessage(), e);
+                logger.error("OCSPServlet: " + e.getMessage(), e);
                 auditor.log(OCSPGenerationEvent.createFailureEvent(auditSubjectID(), e.getMessage()));
+                response = new OCSPResponse(OCSPResponseStatus.INTERNAL_ERROR, null);
             }
 
             if (response != null) {

--- a/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/OCSPClient.java
@@ -30,6 +30,7 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.dogtagpki.cli.CLIException;
 import org.dogtagpki.util.logging.PKILogger;
 import org.mozilla.jss.CryptoManager;
 
@@ -39,6 +40,7 @@ import com.netscape.cmsutil.ocsp.CertStatus;
 import com.netscape.cmsutil.ocsp.OCSPProcessor;
 import com.netscape.cmsutil.ocsp.OCSPRequest;
 import com.netscape.cmsutil.ocsp.OCSPResponse;
+import com.netscape.cmsutil.ocsp.OCSPResponseStatus;
 import com.netscape.cmsutil.ocsp.ResponseBytes;
 import com.netscape.cmsutil.ocsp.ResponseData;
 import com.netscape.cmsutil.ocsp.SingleResponse;
@@ -196,6 +198,11 @@ public class OCSPClient {
 
                 logger.info("Submitting OCSP request");
                 response = processor.submitRequest(url, request);
+
+                OCSPResponseStatus status = response.getResponseStatus();
+                if (status.getValue() != 0) {
+                    throw new CLIException("OCSPResponseStatus: " + status.getName());
+                }
 
                 ResponseBytes bytes = response.getResponseBytes();
                 BasicOCSPResponse basic = (BasicOCSPResponse)BasicOCSPResponse.getTemplate().decode(

--- a/base/tools/src/main/java/com/netscape/cmstools/ocsp/OCSPCertVerifyCLI.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/ocsp/OCSPCertVerifyCLI.java
@@ -26,6 +26,7 @@ import com.netscape.cmsutil.ocsp.CertStatus;
 import com.netscape.cmsutil.ocsp.OCSPProcessor;
 import com.netscape.cmsutil.ocsp.OCSPRequest;
 import com.netscape.cmsutil.ocsp.OCSPResponse;
+import com.netscape.cmsutil.ocsp.OCSPResponseStatus;
 import com.netscape.cmsutil.ocsp.ResponseData;
 import com.netscape.cmsutil.ocsp.RevokedInfo;
 import com.netscape.cmsutil.ocsp.SingleResponse;
@@ -136,6 +137,11 @@ public class OCSPCertVerifyCLI extends SubsystemCommandCLI {
             response = processor.submitRequest(request);
         } catch (Exception e) {
             throw new CLIException("Unable to submit OCSP request: " + e.getMessage());
+        }
+
+        OCSPResponseStatus status = response.getResponseStatus();
+        if (status.getValue() != 0) {
+            throw new CLIException("OCSPResponseStatus: " + status.getName());
         }
 
         logger.info("Parsing OCSP response");


### PR DESCRIPTION
The `OCSPServlet` has been updated to return a proper response status if there is an internal error (e.g. missing CRL data) as defined in RFC 6960:

https://datatracker.ietf.org/doc/html/rfc6960#section-2.3

> The response "internalError" indicates that the OCSP responder reached an inconsistent internal state. The query should be retried, potentially with another responder.

The OCSP clients have been updated to check for error status before processing the response bytes and generate a more intelligible error message.

The OCSP tests have been updated to expect the new error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OCSP response statuses can now be shown using clearer, human-readable names (with fallback for unknown values).

* **Bug Fixes**
  * OCSP request failures now generate explicit `INTERNAL_ERROR` responses for more consistent behavior.
  * OCSP CLI output and error handling now report internal error statuses with clearer messaging.

* **Tests**
  * Updated OCSP workflow expectations to match the improved internal-error messages and output sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->