### PR TITLE
Add Fedora ELN support to get_tomcat_app_server

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -202,6 +202,10 @@ get_tomcat_app_server() {
              distro="rhel"
              ver=$VERSION_ID
              ;;
+         "eln")
+             distro="rhel"
+             ver=$VERSION_ID
+             ;;
          *)
              echo $app_server_9
              return


### PR DESCRIPTION
Fedora ELN, the basis for the next RHEL major version, now uses ID="eln" and VERSION_ID=11 in /etc/os-release to avoid confusion with Fedora Linux. This fixes the build script so that tomcat-10.1 is properly selected for ELN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for Enterprise Linux (ELN) OS identification to ensure compatible Tomcat version selection on ELN systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->