### PR TITLE
Add variable to enable/disable test suites

### DIFF
--- a/.github/workflows/acme-tests.yml
+++ b/.github/workflows/acme-tests.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialization
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          TESTS: ${{ vars.TESTS }}
         run: tests/bin/test-init.sh
 
       - name: Update Dockerfile

--- a/.github/workflows/ipa-tests.yml
+++ b/.github/workflows/ipa-tests.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialization
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          TESTS: ${{ vars.TESTS }}
         run: tests/bin/test-init.sh
 
       - name: Update Dockerfile

--- a/.github/workflows/wait-for-build.yml
+++ b/.github/workflows/wait-for-build.yml
@@ -5,9 +5,19 @@ on:
 
 jobs:
   waiting-for-build:
-    name: Waiting For Build
+    name: Waiting for build
     runs-on: ubuntu-latest
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v7
+
+      - name: Initialization
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          TESTS: ${{ vars.TESTS }}
+        run: tests/bin/test-init.sh
+
       - name: Wait for build
         uses: lewagon/wait-on-check-action@v1.8.0
         with:

--- a/tests/bin/test-init.sh
+++ b/tests/bin/test-init.sh
@@ -35,3 +35,34 @@ if [ "$COPR_REPO" = "" ]; then
         echo "COPR_REPO=$COPR_REPO" | tee -a $GITHUB_ENV
     fi
 fi
+
+# <owner>/<project>/.github/workflows/<name>-tests.yml@refs/heads/<branch>
+echo "WORKFLOW_REF=$WORKFLOW_REF"
+
+# get test suite name from workflow reference path
+if [[ "$WORKFLOW_REF" =~ /([^/]+)-tests\.yml@ ]]; then
+    TEST_SUITE="${BASH_REMATCH[1]}"
+else
+    TEST_SUITE=""
+fi
+echo "TEST_SUITE=$TEST_SUITE"
+
+# check list of test suites
+echo "TESTS=$TESTS"
+
+if [ "$TESTS" != "" ]; then
+
+    # check whether test suite is enabled
+    ENABLED=false
+    for item in $TESTS; do
+        if [ "$item" = "$TEST_SUITE" ]; then
+            ENABLED=true
+            break
+        fi
+    done
+
+    # if not enabled, cancel test suite
+    if [ "$ENABLED" = "false" ]; then
+        gh run cancel $GITHUB_RUN_ID
+    fi
+fi


### PR DESCRIPTION
A new GH Action variable has been added to configure the list of test suites that will run in the CI.

https://github.com/dogtagpki/pki/wiki/Configuring-Test-Suites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow initialization so test runs now receive the needed context automatically (including workflow reference and test configuration).
  * Added a safeguard that stops a run when the derived test suite isn’t included in the configured test list.
  * Updated build and wait steps so initialization is performed consistently before tests proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->