### PR TITLE
Add test for sub CA with PQC

### DIFF
--- a/.github/workflows/subca-pqc-test.yml
+++ b/.github/workflows/subca-pqc-test.yml
@@ -1,0 +1,1025 @@
+name: SubCA with PQC
+# This test will perform the following operations:
+# - install root CA
+# - install sub CA
+# - remove sub CA
+# - remove root CA
+
+on: workflow_call
+
+env:
+  DS_IMAGE: ${{ vars.DS_IMAGE || 'quay.io/389ds/dirsrv' }}
+
+jobs:
+  # docs/installation/ca/installing-subordinate-ca.adoc
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      SHARED: /tmp/workdir/pki
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v7
+
+      - name: Retrieve PKI images
+        uses: actions/cache@v5
+        with:
+          key: pki-images-${{ github.sha }}
+          path: pki-images.tar
+
+      - name: Load PKI images
+        run: docker load --input pki-images.tar
+
+      - name: Create network
+        run: docker network create example
+
+      - name: Set up root CA DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=rootcads.example.com \
+              --network=example \
+              --network-alias=rootcads.example.com \
+              --password=Secret.123 \
+              rootcads
+
+      - name: Set up root CA container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=rootca.example.com \
+              --network=example \
+              --network-alias=rootca.example.com \
+              rootca
+
+          # get Fedora version
+          FEDORA_VERSION=$(docker exec rootca sed -n 's/^VERSION_ID=//p' /etc/os-release)
+          echo "FEDORA_VERSION=$FEDORA_VERSION" >> $GITHUB_ENV
+
+      - name: Set up root CA crypto-policies
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 44 }}
+        # ML-DSA is enabled by default since Fedora 44
+        run: |
+          docker exec rootca sed -i \
+              's/smime-key-exchange:ECDSA/smime-key-exchange:ML-DSA-65:ECDSA/' \
+              /etc/crypto-policies/back-ends/nss.config
+
+      - name: Install root CA
+        run: |
+          docker exec rootca pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca-pqc.cfg \
+              -s CA \
+              -D pki_ds_url=ldap://rootcads.example.com:3389 \
+              -D "pki_ca_signing_subject_dn=cn=Root CA Signing Certificate,o=EXAMPLE" \
+              -v
+
+          docker exec rootca dnf install -y xmlstarlet
+
+          # disable access log buffer
+          docker exec rootca xmlstarlet edit --inplace \
+              -u "//Valve[@className='org.apache.catalina.valves.AccessLogValve']/@buffered" \
+              -v "false" \
+              -i "//Valve[@className='org.apache.catalina.valves.AccessLogValve' and not(@buffered)]" \
+              -t attr \
+              -n "buffered" \
+              -v "false" \
+              /etc/pki/pki-tomcat/server.xml
+
+          docker exec rootca pki-server restart --wait
+
+      - name: Set up sub CA DS container
+        run: |
+          tests/bin/ds-create.sh \
+              --image=${{ env.DS_IMAGE }} \
+              --hostname=subcads.example.com \
+              --network=example \
+              --network-alias=subcads.example.com \
+              --password=Secret.123 \
+              subcads
+
+      - name: Set up sub CA container
+        run: |
+          tests/bin/runner-init.sh \
+              --hostname=subca.example.com \
+              --network=example \
+              --network-alias=subca.example.com \
+              subca
+
+      - name: Set up sub CA crypto-policies
+        if: ${{ fromJSON(env.FEDORA_VERSION) < 44 }}
+        # ML-DSA is enabled by default since Fedora 44
+        run: |
+          docker exec subca sed -i \
+              's/smime-key-exchange:ECDSA/smime-key-exchange:ML-DSA-65:ECDSA/' \
+              /etc/crypto-policies/back-ends/nss.config
+
+      - name: Install sub CA
+        run: |
+          docker exec rootca pki-server cert-export \
+              --cert-file $SHARED/root-ca_signing.crt \
+              ca_signing
+
+          docker exec subca pkispawn \
+              -f /usr/share/pki/server/examples/installation/ca-pqc.cfg \
+              -s CA \
+              -D pki_cert_chain_path=$SHARED/root-ca_signing.crt \
+              -D pki_ds_url=ldap://subcads.example.com:3389 \
+              -D pki_security_domain_hostname=rootca.example.com \
+              -D pki_security_domain_user=caadmin \
+              -D pki_security_domain_password=Secret.123 \
+              -D pki_subordinate=True \
+              -D pki_issuing_ca_hostname=rootca.example.com \
+              -D "pki_ca_signing_subject_dn=cn=Sub CA Signing Certificate,o=EXAMPLE" \
+              -v
+
+      - name: Configure sub CA
+        run: |
+          docker exec subca dnf install -y xmlstarlet
+
+          # disable access log buffer
+          docker exec subca xmlstarlet edit --inplace \
+              -u "//Valve[@className='org.apache.catalina.valves.AccessLogValve']/@buffered" \
+              -v "false" \
+              -i "//Valve[@className='org.apache.catalina.valves.AccessLogValve' and not(@buffered)]" \
+              -t attr \
+              -n "buffered" \
+              -v "false" \
+              /etc/pki/pki-tomcat/server.xml
+
+          docker exec subca pki-server restart --wait
+
+      - name: Check sub CA signing cert request
+        run: |
+          docker exec subca openssl req -text -noout \
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_signing.csr \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              output > actual
+
+          cat > expected << EOF
+          Certificate Request:
+              Data:
+                  Version: 1 (0x0)
+                  Subject: O=EXAMPLE, CN=Sub CA Signing Certificate
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  Attributes:
+                      Requested Extensions:
+                          X509v3 Basic Constraints: critical
+                              CA:TRUE
+                          X509v3 Key Usage: critical
+                              Digital Signature, Non Repudiation, Certificate Sign, CRL Sign
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA OCSP signing cert request
+        run: |
+          docker exec subca openssl req -text -noout \
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_ocsp_signing.csr \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              output > actual
+
+          cat > expected << EOF
+          Certificate Request:
+              Data:
+                  Version: 1 (0x0)
+                  Subject: O=EXAMPLE, OU=pki-tomcat, CN=CA OCSP Signing Certificate
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  Attributes:
+                      (none)
+                      Requested Extensions:
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA audit signing cert request
+        run: |
+          docker exec subca openssl req -text -noout \
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_audit_signing.csr \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              output > actual
+
+          cat > expected << EOF
+          Certificate Request:
+              Data:
+                  Version: 1 (0x0)
+                  Subject: O=EXAMPLE, OU=pki-tomcat, CN=CA Audit Signing Certificate
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  Attributes:
+                      (none)
+                      Requested Extensions:
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA subsystem cert request
+        run: |
+          docker exec subca openssl req -text -noout \
+              -in /var/lib/pki/pki-tomcat/conf/certs/subsystem.csr \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              output > actual
+
+          cat > expected << EOF
+          Certificate Request:
+              Data:
+                  Version: 1 (0x0)
+                  Subject: O=EXAMPLE, OU=pki-tomcat, CN=Subsystem Certificate
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  Attributes:
+                      (none)
+                      Requested Extensions:
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA SSL server cert request
+        run: |
+          docker exec subca openssl req -text -noout \
+              -in /var/lib/pki/pki-tomcat/conf/certs/sslserver.csr \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              output > actual
+
+          cat > expected << EOF
+          Certificate Request:
+              Data:
+                  Version: 1 (0x0)
+                  Subject: O=EXAMPLE, OU=pki-tomcat, CN=subca.example.com
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  Attributes:
+                      (none)
+                      Requested Extensions:
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA admin cert request
+        run: |
+          docker exec subca openssl req -text -noout \
+              -in /var/lib/pki/pki-tomcat/conf/certs/ca_admin.csr \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              output > actual
+
+          cat > expected << EOF
+          Certificate Request:
+              Data:
+                  Version: 1 (0x0)
+                  Subject: O=EXAMPLE, OU=pki-tomcat, emailAddress=caadmin@example.com, CN=PKI Administrator
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  Attributes:
+                      (none)
+                      Requested Extensions:
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA signing cert
+        run: |
+          docker exec subca pki-server cert-export \
+              --cert-file ca_signing.crt \
+              ca_signing
+
+          docker exec subca openssl x509 -text -noout \
+              -in ca_signing.crt \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          # - remove date and time
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *Serial Number:$/d' \
+              -e '/^ *Validity$/d' \
+              -e '/^ *Not Before:/d' \
+              -e '/^ *Not After :/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              -e '/^$/d' \
+              -e 's/ *$//' \
+              output > actual
+
+          # cert should be issued by root CA
+          cat > expected << EOF
+          Certificate:
+              Data:
+                  Version: 3 (0x2)
+                  Signature Algorithm: ML-DSA-65
+                  Issuer: O=EXAMPLE, CN=Root CA Signing Certificate
+                  Subject: O=EXAMPLE, CN=Sub CA Signing Certificate
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  X509v3 extensions:
+                      X509v3 Subject Key Identifier:
+                      X509v3 Authority Key Identifier:
+                      X509v3 Basic Constraints: critical
+                          CA:TRUE
+                      X509v3 Key Usage: critical
+                          Digital Signature, Non Repudiation, Certificate Sign, CRL Sign
+                      Authority Information Access:
+                          OCSP - URI:http://rootca.example.com:8080/ca/ocsp
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA OCSP signing cert
+        run: |
+          docker exec subca pki-server cert-export \
+              --cert-file ca_ocsp_signing.crt \
+              ca_ocsp_signing
+
+          docker exec subca openssl x509 -text -noout \
+              -in ca_ocsp_signing.crt \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          # - remove date and time
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *Serial Number:$/d' \
+              -e '/^ *Validity$/d' \
+              -e '/^ *Not Before:/d' \
+              -e '/^ *Not After :/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              -e '/^$/d' \
+              -e 's/ *$//' \
+              output > actual
+
+          # cert should be issued by sub CA
+          cat > expected << EOF
+          Certificate:
+              Data:
+                  Version: 3 (0x2)
+                  Signature Algorithm: ML-DSA-65
+                  Issuer: O=EXAMPLE, CN=Sub CA Signing Certificate
+                  Subject: O=EXAMPLE, OU=pki-tomcat, CN=CA OCSP Signing Certificate
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  X509v3 extensions:
+                      X509v3 Authority Key Identifier:
+                      Authority Information Access:
+                          OCSP - URI:http://subca.example.com:8080/ca/ocsp
+                      X509v3 Extended Key Usage:
+                          OCSP Signing
+                      OCSP No Check:
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA audit signing cert
+        run: |
+          docker exec subca pki-server cert-export \
+              --cert-file ca_audit_signing.crt \
+              ca_audit_signing
+
+          docker exec subca openssl x509 -text -noout \
+              -in ca_audit_signing.crt \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          # - remove date and time
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *Serial Number:$/d' \
+              -e '/^ *Validity$/d' \
+              -e '/^ *Not Before:/d' \
+              -e '/^ *Not After :/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              -e '/^$/d' \
+              -e 's/ *$//' \
+              output > actual
+
+          # cert should be issued by sub CA
+          cat > expected << EOF
+          Certificate:
+              Data:
+                  Version: 3 (0x2)
+                  Signature Algorithm: ML-DSA-65
+                  Issuer: O=EXAMPLE, CN=Sub CA Signing Certificate
+                  Subject: O=EXAMPLE, OU=pki-tomcat, CN=CA Audit Signing Certificate
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  X509v3 extensions:
+                      X509v3 Authority Key Identifier:
+                      X509v3 Key Usage: critical
+                          Digital Signature, Non Repudiation
+                      Authority Information Access:
+                          OCSP - URI:http://subca.example.com:8080/ca/ocsp
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA subsystem cert
+        run: |
+          docker exec subca pki-server cert-export \
+              --cert-file subsystem.crt \
+              subsystem
+
+          docker exec subca openssl x509 -text -noout \
+              -in subsystem.crt \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          # - remove date and time
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *Serial Number:$/d' \
+              -e '/^ *Validity$/d' \
+              -e '/^ *Not Before:/d' \
+              -e '/^ *Not After :/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              -e '/^$/d' \
+              -e 's/ *$//' \
+              output > actual
+
+          # cert should be issued by root CA
+          cat > expected << EOF
+          Certificate:
+              Data:
+                  Version: 3 (0x2)
+                  Signature Algorithm: ML-DSA-65
+                  Issuer: O=EXAMPLE, CN=Root CA Signing Certificate
+                  Subject: O=EXAMPLE, OU=pki-tomcat, CN=Subsystem Certificate
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  X509v3 extensions:
+                      X509v3 Authority Key Identifier:
+                      Authority Information Access:
+                          OCSP - URI:http://rootca.example.com:8080/ca/ocsp
+                      X509v3 Key Usage: critical
+                          Digital Signature, Key Agreement
+                      X509v3 Extended Key Usage:
+                          TLS Web Client Authentication
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA SSL server cert
+        run: |
+          docker exec subca pki-server cert-export \
+              --cert-file sslserver.crt \
+              sslserver
+
+          docker exec subca openssl x509 -text -noout \
+              -in sslserver.crt \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          # - remove date and time
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *Serial Number:$/d' \
+              -e '/^ *Validity$/d' \
+              -e '/^ *Not Before:/d' \
+              -e '/^ *Not After :/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              -e '/^$/d' \
+              -e 's/ *$//' \
+              output > actual
+
+          # cert should be issued by sub CA
+          cat > expected << EOF
+          Certificate:
+              Data:
+                  Version: 3 (0x2)
+                  Signature Algorithm: ML-DSA-65
+                  Issuer: O=EXAMPLE, CN=Sub CA Signing Certificate
+                  Subject: O=EXAMPLE, OU=pki-tomcat, CN=subca.example.com
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  X509v3 extensions:
+                      X509v3 Authority Key Identifier:
+                      Authority Information Access:
+                          OCSP - URI:http://subca.example.com:8080/ca/ocsp
+                      X509v3 Key Usage: critical
+                          Digital Signature, Data Encipherment, Key Agreement
+                      X509v3 Extended Key Usage:
+                          TLS Web Server Authentication
+                      X509v3 Subject Alternative Name:
+                          DNS:subca.example.com
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Check sub CA admin cert
+        run: |
+          docker exec subca openssl x509 -text -noout \
+              -in /root/.dogtag/pki-tomcat/ca_admin.cert \
+              | tee output
+
+          # normalize output
+          # - remove hex string
+          # - remove date and time
+          sed -E \
+              -e '/^ *[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2})+:?$/d' \
+              -e '/^ *Serial Number:$/d' \
+              -e '/^ *Validity$/d' \
+              -e '/^ *Not Before:/d' \
+              -e '/^ *Not After :/d' \
+              -e '/^ *pub:$/d' \
+              -e '/^ *Signature Value:$/d' \
+              -e '/^$/d' \
+              -e 's/ *$//' \
+              output > actual
+
+          # cert should be issued by sub CA
+          cat > expected << EOF
+          Certificate:
+              Data:
+                  Version: 3 (0x2)
+                  Signature Algorithm: ML-DSA-65
+                  Issuer: O=EXAMPLE, CN=Sub CA Signing Certificate
+                  Subject: O=EXAMPLE, OU=pki-tomcat, emailAddress=caadmin@example.com, CN=PKI Administrator
+                  Subject Public Key Info:
+                      Public Key Algorithm: ML-DSA-65
+                          ML-DSA-65 Public-Key:
+                  X509v3 extensions:
+                      X509v3 Authority Key Identifier:
+                      Authority Information Access:
+                          OCSP - URI:http://subca.example.com:8080/ca/ocsp
+                      X509v3 Key Usage: critical
+                          Digital Signature, Non Repudiation, Key Agreement
+                      X509v3 Extended Key Usage:
+                          TLS Web Client Authentication, E-mail Protection
+              Signature Algorithm: ML-DSA-65
+          EOF
+
+          diff expected actual
+
+      - name: Run sub CA healthcheck
+        run: |
+          docker exec subca pki-healthcheck \
+              --failures-only \
+              --debug \
+              > >(tee stdout) 2> >(tee stderr >&2)
+
+      - name: Check external commands
+        if: always()
+        run: |
+          sed -n '/^Command:/p' stderr | tee output
+          wc -l output
+
+      - name: Check sub CA admin user
+        run: |
+          docker exec subca pki nss-cert-import \
+              --cert $SHARED/root-ca_signing.crt \
+              --trust CT,C,C \
+              root-ca_signing
+
+          docker exec subca pki nss-cert-import \
+              --cert ca_signing.crt \
+              ca_signing
+
+          docker exec subca pki pkcs12-import \
+              --pkcs12 /root/.dogtag/pki-tomcat/ca_admin_cert.p12 \
+              --password Secret.123
+
+          docker exec subca pki -n caadmin ca-user-show caadmin
+
+      - name: Check sub CA signing cert chain
+        run: |
+          docker exec subca openssl verify \
+              -CAfile $SHARED/root-ca_signing.crt \
+              ca_signing.crt
+
+      - name: Check sub CA OCSP signing cert chain
+        run: |
+          docker exec subca openssl verify \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -untrusted ca_signing.crt \
+              ca_ocsp_signing.crt
+
+      - name: Check sub CA audit signing cert chain
+        run: |
+          docker exec subca openssl verify \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -untrusted ca_signing.crt \
+              ca_audit_signing.crt
+
+      - name: Check sub CA subsystem cert chain
+        run: |
+          docker exec subca openssl verify \
+              -CAfile $SHARED/root-ca_signing.crt \
+              subsystem.crt
+
+      - name: Check sub CA SSL server cert chain
+        run: |
+          docker exec subca openssl verify \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -untrusted ca_signing.crt \
+              sslserver.crt
+
+      - name: Check sub CA admin cert chain
+        run: |
+          docker exec subca openssl verify \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -untrusted ca_signing.crt \
+              /root/.dogtag/pki-tomcat/ca_admin.cert
+
+      - name: Check sub CA signing cert status
+        run: |
+          docker exec subca pki-server cert-show ca_signing | tee output
+          SERIAL=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          docker exec subca openssl ocsp \
+              -url http://rootca.example.com:8080/ca/ocsp \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -issuer $SHARED/root-ca_signing.crt \
+              -serial $SERIAL \
+              | tee output
+
+          sed -n "/^$SERIAL:/p" output > actual
+          echo "$SERIAL: good" > expected
+
+          diff expected actual
+
+      - name: Check sub CA OCSP signing cert status
+        run: |
+          docker exec subca pki-server cert-show ca_ocsp_signing | tee output
+          SERIAL=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          docker exec subca openssl ocsp \
+              -url http://subca.example.com:8080/ca/ocsp \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -issuer ca_signing.crt \
+              -serial $SERIAL \
+              | tee output
+
+          sed -n "/^$SERIAL:/p" output > actual
+          echo "$SERIAL: good" > expected
+
+          diff expected actual
+
+      - name: Check sub CA audit signing cert status
+        run: |
+          docker exec subca pki-server cert-show ca_audit_signing | tee output
+          SERIAL=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          docker exec subca openssl ocsp \
+              -url http://subca.example.com:8080/ca/ocsp \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -issuer ca_signing.crt \
+              -serial $SERIAL \
+              | tee output
+
+          sed -n "/^$SERIAL:/p" output > actual
+          echo "$SERIAL: good" > expected
+
+          diff expected actual
+
+      - name: Check sub CA subsystem cert status
+        run: |
+          docker exec subca pki-server cert-show subsystem | tee output
+          SERIAL=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          docker exec subca openssl ocsp \
+              -url http://rootca.example.com:8080/ca/ocsp \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -issuer $SHARED/root-ca_signing.crt \
+              -serial $SERIAL \
+              | tee output
+
+          sed -n "/^$SERIAL:/p" output > actual
+          echo "$SERIAL: good" > expected
+
+          diff expected actual
+
+      - name: Check sub CA SSL server cert status
+        run: |
+          docker exec subca pki-server cert-show sslserver | tee output
+          SERIAL=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          docker exec subca openssl ocsp \
+              -url http://subca.example.com:8080/ca/ocsp \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -issuer ca_signing.crt \
+              -serial $SERIAL \
+              | tee output
+
+          sed -n "/^$SERIAL:/p" output > actual
+          echo "$SERIAL: good" > expected
+
+          diff expected actual
+
+      - name: Check sub CA admin cert status
+        run: |
+          docker exec subca pki nss-cert-show caadmin | tee output
+          SERIAL=$(sed -n "s/^\s*Serial Number:\s*\(\S*\)$/\1/p" output)
+
+          docker exec subca openssl ocsp \
+              -url http://subca.example.com:8080/ca/ocsp \
+              -CAfile $SHARED/root-ca_signing.crt \
+              -issuer ca_signing.crt \
+              -serial $SERIAL \
+              | tee output
+
+          sed -n "/^$SERIAL:/p" output > actual
+          echo "$SERIAL: good" > expected
+
+          diff expected actual
+
+      - name: Check sub CA signing cert usage
+        run: |
+          # cert should be usable as SSL CA (3)
+          docker exec subca /usr/lib64/nss/unsupported-tools/vfychain \
+              -v \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -u 3 \
+              -pp \
+              -g leaf \
+              -h requireFreshInfo \
+              -m ocsp \
+              -s failIfNoInfo \
+              -a \
+              ca_signing.crt \
+              > >(tee stdout) 2> >(tee stderr >&2)
+
+          cat > expected << EOF
+          Root Certificate Subject:: "CN=Root CA Signing Certificate,O=EXAMPLE"
+          Certificate 1 Subject: "CN=Sub CA Signing Certificate,O=EXAMPLE"
+          EOF
+
+          diff expected stdout
+
+          cat > expected << EOF
+          Chain is good!
+          EOF
+
+          diff expected stderr
+
+      - name: Check sub CA OCSP signing cert usage
+        run: |
+          # cert should be usable as OCSP responder (10)
+          # TODO: investigate vfychain failure
+          docker exec subca /usr/lib64/nss/unsupported-tools/vfychain \
+              -v \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -u 10 \
+              -pp \
+              -g leaf \
+              -h requireFreshInfo \
+              -m ocsp \
+              -s failIfNoInfo \
+              -a \
+              ca_ocsp_signing.crt \
+              > >(tee stdout) 2> >(tee stderr >&2) \
+              || true
+
+          diff /dev/null stdout
+
+          cat > expected << EOF
+          Chain is bad!
+          PROBLEM WITH THE CERT CHAIN:
+          CERT 1. ca_signing [Certificate Authority]:
+            ERROR -8180: Peer's Certificate has been revoked.
+          EOF
+
+          diff expected stderr
+
+      - name: Check sub CA audit signing cert usage
+        run: |
+          # cert should be usable as Object signer (6)
+          docker exec subca /usr/lib64/nss/unsupported-tools/vfychain \
+              -v \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -u 6 \
+              -pp \
+              -g leaf \
+              -h requireFreshInfo \
+              -m ocsp \
+              -s failIfNoInfo \
+              -a \
+              ca_audit_signing.crt \
+              > >(tee stdout) 2> >(tee stderr >&2)
+
+          cat > expected << EOF
+          Certificate 1 Subject: "CN=CA Audit Signing Certificate,OU=pki-tomcat,O=EXAMP
+              LE"
+          EOF
+
+          diff expected stdout
+
+          cat > expected << EOF
+          Chain is good!
+          EOF
+
+          diff expected stderr
+
+      - name: Check sub CA subsystem cert usage
+        run: |
+          # cert should be usable as SSL client (0)
+          docker exec subca /usr/lib64/nss/unsupported-tools/vfychain \
+              -v \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -u 0 \
+              -pp \
+              -g leaf \
+              -h requireFreshInfo \
+              -m ocsp \
+              -s failIfNoInfo \
+              -a \
+              subsystem.crt \
+              > >(tee stdout) 2> >(tee stderr >&2)
+
+          cat > expected << EOF
+          Root Certificate Subject:: "CN=Root CA Signing Certificate,O=EXAMPLE"
+          Certificate 1 Subject: "CN=Subsystem Certificate,OU=pki-tomcat,O=EXAMPLE"
+          EOF
+
+          diff expected stdout
+
+          cat > expected << EOF
+          Chain is good!
+          EOF
+
+          diff expected stderr
+
+      - name: Check sub CA SSL server cert usage
+        run: |
+          # cert should be usable as SSL server (1)
+          docker exec subca /usr/lib64/nss/unsupported-tools/vfychain \
+              -v \
+              -d /var/lib/pki/pki-tomcat/conf/alias \
+              -u 1 \
+              -pp \
+              -g leaf \
+              -h requireFreshInfo \
+              -m ocsp \
+              -s failIfNoInfo \
+              -a \
+              sslserver.crt \
+              > >(tee stdout) 2> >(tee stderr >&2)
+
+          cat > expected << EOF
+          Root Certificate Subject:: "CN=Sub CA Signing Certificate,O=EXAMPLE"
+          Certificate 1 Subject: "CN=subca.example.com,OU=pki-tomcat,O=EXAMPLE"
+          EOF
+
+          diff expected stdout
+
+          cat > expected << EOF
+          Chain is good!
+          EOF
+
+          diff expected stderr
+
+      - name: Check sub CA admin cert usage
+        run: |
+          # cert should be usable as SSL client (0)
+          docker exec subca /usr/lib64/nss/unsupported-tools/vfychain \
+              -v \
+              -d /root/.dogtag/nssdb \
+              -u 0 \
+              -pp \
+              -g leaf \
+              -h requireFreshInfo \
+              -m ocsp \
+              -s failIfNoInfo \
+              -a \
+              /root/.dogtag/pki-tomcat/ca_admin.cert \
+              > >(tee stdout) 2> >(tee stderr >&2)
+
+          cat > expected << EOF
+          Root Certificate Subject:: "CN=Root CA Signing Certificate,O=EXAMPLE"
+          Certificate 1 Subject: "CN=PKI Administrator,E=caadmin@example.com,OU=pki-tom
+              cat,O=EXAMPLE"
+          Certificate 2 Subject: "CN=Sub CA Signing Certificate,O=EXAMPLE"
+          EOF
+
+          diff expected stdout
+
+          cat > expected << EOF
+          Chain is good!
+          EOF
+
+          diff expected stderr
+
+      - name: Remove sub CA
+        run: docker exec subca pkidestroy -s CA -v
+
+      - name: Remove root CA
+        run: docker exec rootca pkidestroy -s CA -v
+
+      - name: Check root CA DS server systemd journal
+        if: always()
+        run: |
+          docker exec rootcads journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check root CA DS container logs
+        if: always()
+        run: |
+          docker logs rootcads
+
+      - name: Check root CA systemd journal
+        if: always()
+        run: |
+          docker exec rootca journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check root CA access log
+        if: always()
+        run: |
+          docker exec rootca find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check root CA debug log
+        if: always()
+        run: |
+          docker exec rootca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;
+
+      - name: Check sub CA DS server systemd journal
+        if: always()
+        run: |
+          docker exec subcads journalctl -x --no-pager -u dirsrv@localhost.service
+
+      - name: Check sub CA DS container logs
+        if: always()
+        run: |
+          docker logs subcads
+
+      - name: Check sub CA systemd journal
+        if: always()
+        run: |
+          docker exec subca journalctl -x --no-pager -u pki-tomcatd@pki-tomcat.service
+
+      - name: Check sub CA access log
+        if: always()
+        run: |
+          docker exec subca find /var/log/pki/pki-tomcat -name "localhost_access_log.*" -exec cat {} \;
+
+      - name: Check sub CA debug log
+        if: always()
+        run: |
+          docker exec subca find /var/lib/pki/pki-tomcat/logs/ca -name "debug.*" -exec cat {} \;

--- a/.github/workflows/subca-tests.yml
+++ b/.github/workflows/subca-tests.yml
@@ -13,6 +13,11 @@ jobs:
     needs: build
     uses: ./.github/workflows/subca-basic-test.yml
 
+  subca-pqc-test:
+    name: SubCA with PQC
+    needs: build
+    uses: ./.github/workflows/subca-pqc-test.yml
+
   subca-cmc-test:
     name: SubCA with CMC
     needs: build


### PR DESCRIPTION
A new test has been added to install root CA and sub CA with PQC, then validate the cert requests, issued certs, cert chains, cert statuses, and cert usages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CI test flow for Sub CA setups using PQC-enabled certificate profiles.
  * Expanded automated validation for certificate issuance, OCSP checks, chain verification, and CA health.

* **Bug Fixes**
  * Improved compatibility checks for older Fedora environments by adjusting crypto settings when needed.

* **Chores**
  * Added a new build job to run the PQC Sub CA test as part of the existing test pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->