### PR TITLE
Fix bundled jackson version mismatch

### DIFF
--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -404,30 +404,15 @@ if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
         COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
         COMMAND sed -n "s/^jackson-annotations-\\(.*\\)\\.jar\$/\\1/p"
         OUTPUT_STRIP_TRAILING_WHITESPACE
-        OUTPUT_VARIABLE JACKSON_VERSION
+        OUTPUT_VARIABLE JACKSON_ANNOTATIONS_VERSION
     )
 endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
 
-if (JACKSON_VERSION)
+if (JACKSON_ANNOTATIONS_VERSION)
     # use imported JARs
 
-    set(JACKSON_ANNOTATIONS_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-annotations-${JACKSON_VERSION}.jar")
-    set(JACKSON_ANNOTATIONS_LINK "jackson-annotations-${JACKSON_VERSION}.jar")
-
-    set(JACKSON_CORE_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-core-${JACKSON_VERSION}.jar")
-    set(JACKSON_CORE_LINK "jackson-core-${JACKSON_VERSION}.jar")
-
-    set(JACKSON_DATABIND_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-databind-${JACKSON_VERSION}.jar")
-    set(JACKSON_DATABIND_LINK "jackson-databind-${JACKSON_VERSION}.jar")
-
-    set(JACKSON_JAXRS_BASE_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-jaxrs-base-${JACKSON_VERSION}.jar")
-    set(JACKSON_JAXRS_BASE_LINK "jackson-jaxrs-base-${JACKSON_VERSION}.jar")
-
-    set(JACKSON_JAXRS_JSON_PROVIDER_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-jaxrs-json-provider-${JACKSON_VERSION}.jar")
-    set(JACKSON_JAXRS_JSON_PROVIDER_LINK "jackson-jaxrs-json-provider-${JACKSON_VERSION}.jar")
-
-    set(JACKSON_MODULE_JAXB_ANNOTATIONS_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-module-jaxb-annotations-${JACKSON_VERSION}.jar")
-    set(JACKSON_MODULE_JAXB_ANNOTATIONS_LINK "jackson-module-jaxb-annotations-${JACKSON_VERSION}.jar")
+    set(JACKSON_ANNOTATIONS_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-annotations-${JACKSON_ANNOTATIONS_VERSION}.jar")
+    set(JACKSON_ANNOTATIONS_LINK "jackson-annotations-${JACKSON_ANNOTATIONS_VERSION}.jar")
 
 else()
     # use system JARs
@@ -439,6 +424,38 @@ else()
             /usr/share/java
     )
     set(JACKSON_ANNOTATIONS_LINK "../../../..${JACKSON_ANNOTATIONS_JAR}")
+
+endif (JACKSON_ANNOTATIONS_VERSION)
+
+if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+    execute_process(
+        COMMAND ls ${CMAKE_SOURCE_DIR}/base/common/lib
+        COMMAND sed -n "s/^jackson-core-\\(.*\\)\\.jar\$/\\1/p"
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        OUTPUT_VARIABLE JACKSON_CORE_VERSION
+    )
+endif (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
+
+if (JACKSON_CORE_VERSION)
+    # use imported JARs
+
+    set(JACKSON_CORE_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-core-${JACKSON_CORE_VERSION}.jar")
+    set(JACKSON_CORE_LINK "jackson-core-${JACKSON_CORE_VERSION}.jar")
+
+    set(JACKSON_DATABIND_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-databind-${JACKSON_CORE_VERSION}.jar")
+    set(JACKSON_DATABIND_LINK "jackson-databind-${JACKSON_CORE_VERSION}.jar")
+
+    set(JACKSON_JAXRS_BASE_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-jaxrs-base-${JACKSON_CORE_VERSION}.jar")
+    set(JACKSON_JAXRS_BASE_LINK "jackson-jaxrs-base-${JACKSON_CORE_VERSION}.jar")
+
+    set(JACKSON_JAXRS_JSON_PROVIDER_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-jaxrs-json-provider-${JACKSON_CORE_VERSION}.jar")
+    set(JACKSON_JAXRS_JSON_PROVIDER_LINK "jackson-jaxrs-json-provider-${JACKSON_CORE_VERSION}.jar")
+
+    set(JACKSON_MODULE_JAXB_ANNOTATIONS_JAR "${CMAKE_SOURCE_DIR}/base/common/lib/jackson-module-jaxb-annotations-${JACKSON_CORE_VERSION}.jar")
+    set(JACKSON_MODULE_JAXB_ANNOTATIONS_LINK "jackson-module-jaxb-annotations-${JACKSON_CORE_VERSION}.jar")
+
+else()
+    # use system JARs
 
     find_file(JACKSON_CORE_JAR
         NAMES
@@ -483,7 +500,7 @@ else()
     )
     set(JACKSON_MODULE_JAXB_ANNOTATIONS_LINK "../../../..${JACKSON_MODULE_JAXB_ANNOTATIONS_JAR}")
 
-endif (JACKSON_VERSION)
+endif (JACKSON_CORE_VERSION)
 
 if (EXISTS "${CMAKE_SOURCE_DIR}/base/common/lib")
     execute_process(

--- a/pki.spec
+++ b/pki.spec
@@ -1144,7 +1144,8 @@ then
     JAKARTA_ACTIVATION_API_VERSION=$(ls jakarta.activation-api-*.jar | sed 's/^jakarta\.activation-api-\(.*\)\.jar$/\1/')
     JAKARTA_ANNOTATION_API_VERSION=$(ls jakarta.annotation-api-*.jar | sed 's/^jakarta\.annotation-api-\(.*\)\.jar$/\1/')
     JAXB_API_VERSION=$(ls jakarta.xml.bind-api-*.jar | sed 's/^jakarta\.xml\.bind-api-\(.*\)\.jar$/\1/')
-    JACKSON_VERSION=$(ls jackson-annotations-*.jar | sed 's/^jackson-annotations-\(.*\)\.jar$/\1/')
+    JACKSON_ANNOTATIONS_VERSION=$(ls jackson-annotations-*.jar | sed 's/^jackson-annotations-\(.*\)\.jar$/\1/')
+    JACKSON_CORE_VERSION=$(ls jackson-core-*.jar | sed 's/^jackson-core-\(.*\)\.jar$/\1/')
 %if %{build_api_v1}
     JAXRS_VERSION=$(ls jboss-jaxrs-api_2.0_spec-*.jar | sed 's/^jboss-jaxrs-api_2\.0_spec-\(.*\)\.jar$/\1/')
     JBOSS_LOGGING_VERSION=$(ls jboss-logging-*.jar| sed 's/^jboss-logging-\(.*\)\.jar$/\1/')
@@ -1170,7 +1171,8 @@ else
     JAKARTA_ACTIVATION_API_VERSION=$(rpm -q jakarta-activation | sed -n 's/^jakarta-activation-\([^-]*\)-.*$/\1/p')
     JAKARTA_ANNOTATION_API_VERSION=$(rpm -q jakarta-annotations | sed -n 's/^jakarta-annotations-\([^-]*\)-.*$/\1/p')
     JAXB_API_VERSION=$(rpm -q jaxb-api | sed -n 's/^jaxb-api-\([^-]*\)-.*$/\1/p')
-    JACKSON_VERSION=$(rpm -q jackson-annotations | sed -n 's/^jackson-annotations-\([^-]*\)-.*$/\1/p')
+    JACKSON_ANNOTATIONS_VERSION=$(rpm -q jackson-annotations | sed -n 's/^jackson-annotations-\([^-]*\)-.*$/\1/p')
+    JACKSON_CORE_VERSION=$(rpm -q jackson-core | sed -n 's/^jackson-core-\([^-]*\)-.*$/\1/p')
 %if %{build_api_v1}
     JAXRS_VERSION=$(rpm -q jboss-jaxrs-2.0-api | sed -n 's/^jboss-jaxrs-2.0-api-\([^-]*\)-.*$/\1.Final/p')
     JBOSS_LOGGING_VERSION=$(rpm -q jboss-logging | sed -n 's/^jboss-logging-\([^-]*\)-.*$/\1.Final/p')
@@ -1199,13 +1201,13 @@ else
         cp /usr/share/java/jaxb-api/jakarta.xml.bind-api.jar jakarta.xml.bind-api-$JAXB_API_VERSION.jar
     fi
 
-    cp /usr/share/java/jackson-annotations.jar jackson-annotations-$JACKSON_VERSION.jar
-    cp /usr/share/java/jackson-core.jar jackson-core-$JACKSON_VERSION.jar
-    cp /usr/share/java/jackson-databind.jar jackson-databind-$JACKSON_VERSION.jar
-    cp /usr/share/java/jackson-modules/jackson-module-jaxb-annotations.jar jackson-module-jaxb-annotations-$JACKSON_VERSION.jar
+    cp /usr/share/java/jackson-annotations.jar jackson-annotations-$JACKSON_ANNOTATIONS_VERSION.jar
+    cp /usr/share/java/jackson-core.jar jackson-core-$JACKSON_CORE_VERSION.jar
+    cp /usr/share/java/jackson-databind.jar jackson-databind-$JACKSON_CORE_VERSION.jar
+    cp /usr/share/java/jackson-modules/jackson-module-jaxb-annotations.jar jackson-module-jaxb-annotations-$JACKSON_CORE_VERSION.jar
 %if %{build_api_v1}
-    cp /usr/share/java/jackson-jaxrs-providers/jackson-jaxrs-base.jar jackson-jaxrs-base-$JACKSON_VERSION.jar
-    cp /usr/share/java/jackson-jaxrs-providers/jackson-jaxrs-json-provider.jar jackson-jaxrs-json-provider-$JACKSON_VERSION.jar
+    cp /usr/share/java/jackson-jaxrs-providers/jackson-jaxrs-base.jar jackson-jaxrs-base-$JACKSON_CORE_VERSION.jar
+    cp /usr/share/java/jackson-jaxrs-providers/jackson-jaxrs-json-provider.jar jackson-jaxrs-json-provider-$JACKSON_CORE_VERSION.jar
     cp /usr/share/java/jboss-jaxrs-2.0-api.jar jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
     cp /usr/share/java/jboss-logging/jboss-logging.jar jboss-logging-$JBOSS_LOGGING_VERSION.jar
     cp /usr/share/java/resteasy/resteasy-jaxrs.jar resteasy-jaxrs-$RESTEASY_VERSION.jar
@@ -1282,7 +1284,7 @@ then
         jakarta.xml.bind-api-$JAXB_API_VERSION.jar
 
     # migrate com.fasterxml.jackson.annotation
-    jar tvf jackson-annotations-$JACKSON_VERSION.jar \
+    jar tvf jackson-annotations-$JACKSON_ANNOTATIONS_VERSION.jar \
         | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
         | sort \
         | uniq
@@ -1290,11 +1292,11 @@ then
     javax2jakarta \
         -logLevel=FINE \
         -profile=EE \
-        jackson-annotations-$JACKSON_VERSION.jar \
-        jackson-annotations-$JACKSON_VERSION.jar
+        jackson-annotations-$JACKSON_ANNOTATIONS_VERSION.jar \
+        jackson-annotations-$JACKSON_ANNOTATIONS_VERSION.jar
 
     # migrate com.fasterxml.jackson.core
-    jar tvf jackson-core-$JACKSON_VERSION.jar \
+    jar tvf jackson-core-$JACKSON_CORE_VERSION.jar \
         | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
         | sort \
         | uniq
@@ -1302,11 +1304,11 @@ then
     javax2jakarta \
         -logLevel=FINE \
         -profile=EE \
-        jackson-core-$JACKSON_VERSION.jar \
-        jackson-core-$JACKSON_VERSION.jar
+        jackson-core-$JACKSON_CORE_VERSION.jar \
+        jackson-core-$JACKSON_CORE_VERSION.jar
 
     # migrate com.fasterxml.jackson.databind
-    jar tvf jackson-databind-$JACKSON_VERSION.jar \
+    jar tvf jackson-databind-$JACKSON_CORE_VERSION.jar \
         | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
         | sort \
         | uniq
@@ -1314,11 +1316,11 @@ then
     javax2jakarta \
         -logLevel=FINE \
         -profile=EE \
-        jackson-databind-$JACKSON_VERSION.jar \
-        jackson-databind-$JACKSON_VERSION.jar
+        jackson-databind-$JACKSON_CORE_VERSION.jar \
+        jackson-databind-$JACKSON_CORE_VERSION.jar
 
     # migrate com.fasterxml.jackson.module.jaxb
-    jar tvf jackson-module-jaxb-annotations-$JACKSON_VERSION.jar \
+    jar tvf jackson-module-jaxb-annotations-$JACKSON_CORE_VERSION.jar \
         | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
         | sort \
         | uniq
@@ -1326,8 +1328,8 @@ then
     javax2jakarta \
         -logLevel=FINE \
         -profile=EE \
-        jackson-module-jaxb-annotations-$JACKSON_VERSION.jar \
-        jackson-module-jaxb-annotations-$JACKSON_VERSION.jar
+        jackson-module-jaxb-annotations-$JACKSON_CORE_VERSION.jar \
+        jackson-module-jaxb-annotations-$JACKSON_CORE_VERSION.jar
 
 %if %{build_api_v1}
     # migrate javax.ws.rs to jakarta.ws.rs
@@ -1344,7 +1346,7 @@ then
         jboss-jaxrs-api_2.0_spec-$JAXRS_VERSION.jar
 
     # migrate com.fasterxml.jackson.jaxrs
-    jar tvf jackson-jaxrs-base-$JACKSON_VERSION.jar \
+    jar tvf jackson-jaxrs-base-$JACKSON_CORE_VERSION.jar \
         | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
         | sort \
         | uniq
@@ -1352,11 +1354,11 @@ then
     javax2jakarta \
         -logLevel=FINE \
         -profile=EE \
-        jackson-jaxrs-base-$JACKSON_VERSION.jar \
-        jackson-jaxrs-base-$JACKSON_VERSION.jar
+        jackson-jaxrs-base-$JACKSON_CORE_VERSION.jar \
+        jackson-jaxrs-base-$JACKSON_CORE_VERSION.jar
 
     # migrate com.fasterxml.jackson.jaxrs.json
-    jar tvf jackson-jaxrs-json-provider-$JACKSON_VERSION.jar \
+    jar tvf jackson-jaxrs-json-provider-$JACKSON_CORE_VERSION.jar \
         | sed -n 's/.* \([^ ]\+\)\/[^\/]*\.class$/\1/p' \
         | sort \
         | uniq
@@ -1364,8 +1366,8 @@ then
     javax2jakarta \
         -logLevel=FINE \
         -profile=EE \
-        jackson-jaxrs-json-provider-$JACKSON_VERSION.jar \
-        jackson-jaxrs-json-provider-$JACKSON_VERSION.jar
+        jackson-jaxrs-json-provider-$JACKSON_CORE_VERSION.jar \
+        jackson-jaxrs-json-provider-$JACKSON_CORE_VERSION.jar
 
     # migrate org.jboss.resteasy.client.jaxrs
     jar tvf resteasy-client-$RESTEASY_VERSION.jar \


### PR DESCRIPTION
New versions of jackson (>2.20) uses a major.minor version for the jackson-annotations package but it keep the same major.minor.update for the other modules. Since the cmake script will retrieve the version from the jackson-annotations the compilation is failing when 2.21.4 is bundled.

This change will consider the jackson-annotation separately from the other modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when Jackson components use different versions.
  * Corrected packaging and migration of Jackson libraries, including annotation, core, databind, and JAX-RS components.
  * Added more reliable fallback handling when specific Jackson libraries are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->