### PR TITLE
KRATool: Fix DES3 key size for PKCS#11 unwrap operations

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -2422,18 +2422,21 @@ public class KRATool {
 
     /**
      * cross-scheme support: Determines the appropriate key strength in bits
-     * for a given algorithm.
+     * for a given algorithm for PKCS#11 operations.
      *
      * @param algName Algorithm name (e.g., "DES3/CBC/Padding", "AES/CBC/PKCS5Padding")
      * @param userSpecifiedSize User-specified key size from command-line parameter
-     * @return Key strength in bits (168 for DES3, or userSpecifiedSize for AES)
+     * @return Key strength in bits (192 for DES3, or userSpecifiedSize for AES)
      */
     private static int getKeyStrength(String algName, int userSpecifiedSize) {
         String baseAlg = getBaseAlgorithm(algName);
 
         if (baseAlg != null && (baseAlg.equalsIgnoreCase("DES3") || baseAlg.equalsIgnoreCase("DESede"))) {
-            // DES3 always uses 168-bit keys (3 * 56-bit keys with parity)
-            return 168;
+            // DES3 PKCS#11 key length must be 192 bits (24 bytes: 3 * 64-bit keys with parity)
+            // Note: User may specify 168 (effective security strength) but we must use 192
+            // for C_UnwrapKey. NSS pk11mech.c expects: len==16 for DES2, len==24 for DES3.
+            // Passing 21 bytes (168/8) causes error -8152 "key does not support operation"
+            return 192;
         } else {
             // For AES and other algorithms, use user-specified size
             return userSpecifiedSize;
@@ -2605,7 +2608,7 @@ public class KRATool {
         String sourceBase = getBaseAlgorithm(mSourcePayloadWrapAlgName);
         String targetBase = getBaseAlgorithm(mTargetPayloadWrapAlgName);
 
-        // Determine actual key strengths (DES3 is always 168, AES uses user-specified size)
+        // Determine actual key strengths (DES3 is always 192 for PKCS#11, AES uses user-specified size)
         int sourceWrapKeySize = getKeyStrength(mSourcePayloadWrapAlgName, mSourcePayloadWrapKeySize);
         int targetWrapKeySize = mTargetPayloadWrapKeySize;  // Target is always AES (user-specified)
 


### PR DESCRIPTION
The previous fix used 168 bits for DES3 key strength, which caused PKCS#11 C_UnwrapKey to fail with error -8152 "The key does not support the requested operation."

Root cause: DES3 has an effective security strength of 168 bits (3 × 56-bit keys), but the actual PKCS#11 key length must be 192 bits (24 bytes: 3 × 64-bit keys including parity bits).

When getKeyStrength() returned 168, CryptoUtil.unwrap() divided by 8 to get 21 bytes, but NSS pk11mech.c:PK11_GetKeyType() expects exactly 24 bytes for DES3 (or 16 bytes for DES2).

Changes:
- Update getKeyStrength() to return 192 for DES3 (was 168)
- Add detailed comment explaining the 168 vs 192 distinction
- Update inline comments to reflect 192-bit PKCS#11 requirement

Users can still specify -source_payload_wrap_keysize 168 (the commonly cited effective strength), but internally we now use 192 for all PKCS#11 operations.

Fixes: DES3 to AES-KWP migration in cross-scheme mode
Reported-by: QE
Assisted-by: Claude

DOGTAG-4496 DOGTAG-4508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DES3 key-strength handling for PKCS#11 operations.
  * Ensured key unwrapping uses the required 192-bit length while preserving support for 168-bit effective security specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->