### PR TITLE
KRATool: Update DES3 key size documentation to recommend 192 bits

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -821,7 +821,7 @@ public class KRATool {
                                                                              "        " + "   (must match target KRA's configured algorithm)";
 
     private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE = "-source_payload_wrap_keysize";
-    private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|168|192|256> Source payload wrapping key size in bits (default: 128, use 168 for DES3)";
+    private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Source payload wrapping key size in bits (default: 128, use 192 for DES3)";
 
     private static final String TARGET_PAYLOAD_WRAP_KEYSIZE = "-target_payload_wrap_keysize";
     private static final String TARGET_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Target payload wrapping key size in bits (default: 128, AES only)";
@@ -2742,7 +2742,8 @@ public class KRATool {
      *
      * Reference: JSS_ExportEncryptedPrivKeyInfoV2 -> JSS_KeyExchange in jssutil.c:1146-1241
      *
-     * @param sessionKey Source session key
+     * @param sessionKey Session key to import (from source token)
+     * @param keyType Type of the session key (SymmetricKey.Type - DES3 or AES)
      * @param processingToken Token for processing (HSM or NSS DB)
      * @return Session key in processing token
      */
@@ -7274,7 +7275,7 @@ public class KRATool {
                     mSourcePayloadWrapKeySize = Integer.parseInt(args[i + 1]);
                     if (mSourcePayloadWrapKeySize != 128 && mSourcePayloadWrapKeySize != 168 &&
                         mSourcePayloadWrapKeySize != 192 && mSourcePayloadWrapKeySize != 256) {
-                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 168, 192, or 256" + NEWLINE);
+                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 192, or 256" + NEWLINE);
                         System.exit(1);
                     }
                 } catch (NumberFormatException e) {


### PR DESCRIPTION
The previous documentation recommended users specify 168 for DES3, but the code internally uses 192 bits for PKCS#11 operations. This caused confusion when users saw "192-bit DES3" in logs after specifying 168.

Changes:
- Update help text to recommend 192 for DES3 (was 168)
- Remove 168 from documented options (still accepted for backward compatibility)
- Update error message to list only documented options (128, 192, 256)
- Add missing javadoc @param keyType in importSessionKeyToToken()

Users can still specify 168 if needed (it works the same), but 192 is now the recommended and documented value.

Assisted-by: Claude
Related to: IDM-4508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated command-line validation to reject the unsupported `168` source payload wrapping key size.
  * Help text now lists only the supported key sizes: `128`, `192`, and `256`.

* **Documentation**
  * Clarified that the key type parameter accepts DES3 or AES symmetric key types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->