### PR TITLE
pki-core: Add missing EC/ML-DSA profiles to EnableEST upgrade scriptlet

### DIFF
--- a/base/server/upgrade/11.9.0/01-EnableEST.py
+++ b/base/server/upgrade/11.9.0/01-EnableEST.py
@@ -90,7 +90,10 @@ class EnableEST(pki.server.upgrade.PKIServerUpgradeScriptlet):
         profiles_to_update = [
             'caECInternalAuthSubsystemCert',
             'caInternalAuthServerCert',
-            'caInternalAuthSubsystemCert'
+            'caInternalAuthSubsystemCert',
+            'caECInternalAuthServerCert',        # Add EC Server profile (Fixes 403 Forbidden on EC EST)
+            'caMLDSAInternalAuthServerCert',     # Add ML-DSA Server profile
+            'caMLDSAInternalAuthSubsystemCert'   # Add ML-DSA Subsystem profile
         ]
 
         for profile in profiles_to_update:


### PR DESCRIPTION
EST deployments using EC or Post-Quantum (ML-DSA) algorithms fail system certificate enrollment with 403 Forbidden because 01-EnableEST.py misses these profiles from ACL updates. This patch adds caECInternalAuthServerCert and the ML-DSA server/subsystem profiles to the upgrade scriptlet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Upgrade processing now includes additional internal authentication certificate profiles.
  - Internal profile access controls and configuration remain consistent across supported certificate types after upgrading to version 11.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->