### PR TITLE
Fix NPE in TPSServlet.getAuthorizedProfiles() when user has no profileID

### DIFF
--- a/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/TPSServlet.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/rest/v2/TPSServlet.java
@@ -51,7 +51,11 @@ public class TPSServlet extends PKIServlet {
         if (user == null) {
             return Collections.emptyList();
         }
-        return user.getTpsProfiles();
+        List<String> profiles = user.getTpsProfiles();
+        if (profiles == null) {
+            return Collections.emptyList();
+        }
+        return profiles;
     }
 
     protected void audit(String message, String scope, String type, String id, Map<String, String> params, String status) {


### PR DESCRIPTION
TPSServlet.getAuthorizedProfiles() returns user.getTpsProfiles() directly, which is null when the LDAP user entry has no profileID attribute. All v2 servlet callers (ActivityServlet, TokenServlet, TPSCertServlet, TPSProfileServlet) call .isEmpty() on the result, causing a NullPointerException.

The v1 API handled this by checking for null at every call site. The v2 API already normalizes the user == null case to Collections.emptyList() in this method but missed the getTpsProfiles() == null case. Add the missing null check so the method fully normalizes null to empty list, consistent with the v2 contract that callers never receive null. Resolves: 

Resolves: DOGTAG-4417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authorized TPS profiles.
  * Returns an empty list when no profiles are available, preventing errors and ensuring consistent responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->