### PR TITLE
Kratool cross scheme fixes.v10.13.13

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -2488,18 +2488,21 @@ public class KRATool {
 
     /**
      * cross-scheme support: Determines the appropriate key strength in bits
-     * for a given algorithm.
+     * for a given algorithm for PKCS#11 operations.
      *
      * @param algName Algorithm name (e.g., "DES3/CBC/Padding", "AES/CBC/PKCS5Padding")
      * @param userSpecifiedSize User-specified key size from command-line parameter
-     * @return Key strength in bits (168 for DES3, or userSpecifiedSize for AES)
+     * @return Key strength in bits (192 for DES3, or userSpecifiedSize for AES)
      */
     private static int getKeyStrength(String algName, int userSpecifiedSize) {
         String baseAlg = getBaseAlgorithm(algName);
 
         if (baseAlg != null && (baseAlg.equalsIgnoreCase("DES3") || baseAlg.equalsIgnoreCase("DESede"))) {
-            // DES3 always uses 168-bit keys (3 * 56-bit keys with parity)
-            return 168;
+            // DES3 PKCS#11 key length must be 192 bits (24 bytes: 3 * 64-bit keys with parity)
+            // Note: User may specify 168 (effective security strength) but we must use 192
+            // for C_UnwrapKey. NSS pk11mech.c expects: len==16 for DES2, len==24 for DES3.
+            // Passing 21 bytes (168/8) causes error -8152 "key does not support operation"
+            return 192;
         } else {
             // For AES and other algorithms, use user-specified size
             return userSpecifiedSize;
@@ -2670,7 +2673,7 @@ public class KRATool {
         String sourceBase = getBaseAlgorithm(mSourcePayloadWrapAlgName);
         String targetBase = getBaseAlgorithm(mTargetPayloadWrapAlgName);
 
-        // Determine actual key strengths (DES3 is always 168, AES uses user-specified size)
+        // Determine actual key strengths (DES3 is always 192 for PKCS#11, AES uses user-specified size)
         int sourceWrapKeySize = getKeyStrength(mSourcePayloadWrapAlgName, mSourcePayloadWrapKeySize);
         int targetWrapKeySize = mTargetPayloadWrapKeySize;  // Target is always AES (user-specified)
 

--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -800,22 +800,21 @@ public class KRATool {
                                                                              "        " + "   (must match source KRA's payloadWrapAlgorithm metaInfo)";
 
     private static final String TARGET_PAYLOAD_WRAP_ALGORITHM = "-target_payload_wrap_algorithm";
-    private static final String TARGET_PAYLOAD_WRAP_ALGORITHM_DESCRIPTION = "  <algorithm> Target payload wrap algorithm (without key size)" + NEWLINE +
+    private static final String TARGET_PAYLOAD_WRAP_ALGORITHM_DESCRIPTION = "  <algorithm> Target payload wrap algorithm (AES only, DES3 not supported)" + NEWLINE +
                                                                              "        " + "   Supported:" + NEWLINE +
-                                                                             "        " + "     \"AES KeyWrap/Wrapped\"   - uses CKM_AES_KEY_WRAP_KWP (0x210B) (recommended for HSM/FIPS)" + NEWLINE +
-                                                                             "        " + "     \"AES KeyWrap/Padding\"   - uses CKM_AES_KEY_WRAP_PAD (0x210A)" + NEWLINE +
-                                                                             "        " + "     \"AES KeyWrap/NoPadding\" - uses CKM_AES_KEY_WRAP (0x2109)" + NEWLINE +
-                                                                             "        " + "     \"AES/CBC/PKCS5Padding\"  - uses CKM_AES_CBC_PAD (0x1085)" + NEWLINE +
-                                                                             "        " + "     \"DES3/CBC/Padding\"      - uses CKM_DES3_CBC_PAD" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/Wrapped\"   - CKM_AES_KEY_WRAP_KWP (0x210B) (recommended for HSM/FIPS)" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/Padding\"   - CKM_AES_KEY_WRAP_PAD (0x210A)" + NEWLINE +
+                                                                             "        " + "     \"AES KeyWrap/NoPadding\" - CKM_AES_KEY_WRAP (0x2109)" + NEWLINE +
+                                                                             "        " + "     \"AES/CBC/PKCS5Padding\"  - CKM_AES_CBC_PAD (0x1085)" + NEWLINE +
                                                                              "        " + "   Note: Use the quoted strings above, not the CKM_* mechanism names" + NEWLINE +
                                                                              "        " + "   Note: Key size is specified separately with -target_payload_wrap_key_size" + NEWLINE +
                                                                              "        " + "   (must match target KRA's configured algorithm)";
 
     private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE = "-source_payload_wrap_keysize";
-    private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Source payload wrapping key size in bits (default: 128)";
+    private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|168|192|256> Source payload wrapping key size in bits (default: 128, use 168 for DES3)";
 
     private static final String TARGET_PAYLOAD_WRAP_KEYSIZE = "-target_payload_wrap_keysize";
-    private static final String TARGET_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Target payload wrapping key size in bits (default: 128)";
+    private static final String TARGET_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Target payload wrapping key size in bits (default: 128, AES only)";
 
     private static final String USE_NSS_FOR_PAYLOAD_PROCESSING = "-use_nss_for_payload_processing";
     private static final String USE_NSS_FOR_PAYLOAD_PROCESSING_DESCRIPTION = "  Use NSS DB (software token) for payload unwrap/rewrap" + NEWLINE +
@@ -2463,23 +2462,48 @@ public class KRATool {
     }
 
     /**
-     * cross-scheme support: Get key size for payload wrap algorithm.
-     * For source/target algorithms, uses the explicit size parameters.
-     * For other algorithms, returns default of 128 for AES.
+     * cross-scheme support: Maps algorithm name to JSS SymmetricKey.Type.
+     * Extracts the base algorithm (e.g., "DES3" from "DES3/CBC/Padding")
+     * and returns the corresponding SymmetricKey type constant.
+     *
+     * @param algName Full algorithm name (e.g., "DES3/CBC/Padding", "AES/CBC/PKCS5Padding")
+     * @return SymmetricKey.Type constant (DES3, AES, etc.)
+     * @throws Exception if algorithm is null or unsupported
      */
-    private static int getKeySizeFromAlgorithm(String algorithm) {
-        if (algorithm == null) return 128;
-
-        // For source/target payload algorithms, use explicit size parameters
-        if (algorithm.equals(mSourcePayloadWrapAlgName)) {
-            return mSourcePayloadWrapKeySize;
-        }
-        if (algorithm.equals(mTargetPayloadWrapAlgName)) {
-            return mTargetPayloadWrapKeySize;
+    private static SymmetricKey.Type getSymmetricKeyType(String algName) throws Exception {
+        if (algName == null) {
+            throw new Exception("Algorithm name is null");
         }
 
-        // Default to 128 for AES (all algorithms are just names like "AES KeyWrap/Wrapped", no embedded sizes)
-        return 128;
+        String baseAlg = getBaseAlgorithm(algName);
+
+        if (baseAlg.equalsIgnoreCase("DES3") || baseAlg.equalsIgnoreCase("DESede")) {
+            return SymmetricKey.DES3;
+        } else if (baseAlg.equalsIgnoreCase("AES")) {
+            return SymmetricKey.AES;
+        } else {
+            throw new Exception("Unsupported symmetric key algorithm: " + baseAlg + " (from " + algName + ")");
+        }
+    }
+
+    /**
+     * cross-scheme support: Determines the appropriate key strength in bits
+     * for a given algorithm.
+     *
+     * @param algName Algorithm name (e.g., "DES3/CBC/Padding", "AES/CBC/PKCS5Padding")
+     * @param userSpecifiedSize User-specified key size from command-line parameter
+     * @return Key strength in bits (168 for DES3, or userSpecifiedSize for AES)
+     */
+    private static int getKeyStrength(String algName, int userSpecifiedSize) {
+        String baseAlg = getBaseAlgorithm(algName);
+
+        if (baseAlg != null && (baseAlg.equalsIgnoreCase("DES3") || baseAlg.equalsIgnoreCase("DESede"))) {
+            // DES3 always uses 168-bit keys (3 * 56-bit keys with parity)
+            return 168;
+        } else {
+            // For AES and other algorithms, use user-specified size
+            return userSpecifiedSize;
+        }
     }
 
     /**
@@ -2646,9 +2670,9 @@ public class KRATool {
         String sourceBase = getBaseAlgorithm(mSourcePayloadWrapAlgName);
         String targetBase = getBaseAlgorithm(mTargetPayloadWrapAlgName);
 
-        // Use explicit key size parameters (default to 128 if not specified)
-        int sourceWrapKeySize = mSourcePayloadWrapKeySize;
-        int targetWrapKeySize = mTargetPayloadWrapKeySize;
+        // Determine actual key strengths (DES3 is always 168, AES uses user-specified size)
+        int sourceWrapKeySize = getKeyStrength(mSourcePayloadWrapAlgName, mSourcePayloadWrapKeySize);
+        int targetWrapKeySize = mTargetPayloadWrapKeySize;  // Target is always AES (user-specified)
 
         // Determine the change type and prompt accordingly
         boolean isRequired = false;
@@ -2781,11 +2805,13 @@ public class KRATool {
      * Reference: JSS_ExportEncryptedPrivKeyInfoV2 -> JSS_KeyExchange in jssutil.c:1146-1241
      *
      * @param sessionKey Session key to import (from source token)
+     * @param keyType Type of the session key (SymmetricKey.Type - DES3 or AES)
      * @param processingToken Token for processing (HSM or NSS DB)
      * @return Session key in processing token
      */
     private static SymmetricKey importSessionKeyToToken(
             SymmetricKey sessionKey,
+            SymmetricKey.Type keyType,
             CryptoToken processingToken) throws Exception {
 
         if (mVerboseFlag) {
@@ -2893,7 +2919,7 @@ public class KRATool {
             // Use same RSA algorithm as the wrap operation
             SymmetricKey importedKey = CryptoUtil.unwrap(
                 processingToken,
-                SymmetricKey.AES,
+                keyType,  // Use actual key type (DES3 or AES) instead of hardcoded AES
                 sessionKeyLength * 8,  // Convert bytes to bits
                 SymmetricKey.Usage.UNWRAP,
                 (PrivateKey)mTempRSAKeyPair.getPrivate(),
@@ -3160,13 +3186,20 @@ public class KRATool {
         // cloned to the processing token (software token when using -use_nss_for_payload_processing).
         // If the HSM doesn't allow extractable session keys, the importSessionKeyToToken() method
         // in Step 3 will automatically fall back to using a temporary RSA keypair approach.
+
+        // Determine source session key type and strength from algorithm (needed in Steps 2 and 3)
+        SymmetricKey.Type sourceKeyType = getSymmetricKeyType(mSourcePayloadWrapAlgName);
+        int sourceKeyStrength = getKeyStrength(mSourcePayloadWrapAlgName, mSourcePayloadWrapKeySize);
+
         SymmetricKey sessionKey;
 
         try {
             CryptoToken sourceToken = mSourceToken;
+
             if (mVerboseFlag) {
                 log("Unwrapping session key from source HSM using " + mSourceRSAWrapAlgName +
                     " (enum: " + mSourceRSAWrapAlg + ")" + NEWLINE, false);
+                log("Source session key type: " + sourceKeyType + ", strength: " + sourceKeyStrength + " bits" + NEWLINE, false);
 
                 // Debug: Log private key information
                 log("DEBUG: Private key owner token: " + mUnwrapPrivateKey.getOwningToken().getName() + NEWLINE, false);
@@ -3179,11 +3212,11 @@ public class KRATool {
                 log("DEBUG: Private key ID: " + hexString.toString() + NEWLINE, false);
             }
 
-            // Note: strength parameter is in BITS (128), CryptoUtil divides by 8 internally
+            // Note: strength parameter is in BITS, CryptoUtil divides by 8 internally
             sessionKey = CryptoUtil.unwrap(
                 sourceToken,              // CryptoToken
-                SymmetricKey.AES,         // key type
-                128,                      // key strength in BITS
+                sourceKeyType,            // key type (derived from source algorithm)
+                sourceKeyStrength,        // key strength in BITS (derived from source algorithm)
                 SymmetricKey.Usage.UNWRAP,  // usage
                 mUnwrapPrivateKey,        // unwrapping key (PrivateKey)
                 wrappedSessionKey,        // wrapped data
@@ -3250,7 +3283,7 @@ public class KRATool {
             }
 
             // Import session key to processing token
-            targetSessionKey = importSessionKeyToToken(sessionKey, processingToken);
+            targetSessionKey = importSessionKeyToToken(sessionKey, sourceKeyType, processingToken);
             if (mVerboseFlag) {
                 log("Session key imported to processing token" + NEWLINE, false);
             }
@@ -3323,13 +3356,12 @@ public class KRATool {
 
         try {
             if (needNewSessionKey()) {
-                // Generate new session key in processing token
+                // Generate new AES session key in processing token
+                // Note: We only support AES for target (no DES3 - legacy algorithm)
                 KeyGenerator kg = processingToken.getKeyGenerator(KeyGenAlgorithm.AES);
 
-                int targetKeySize = getKeySizeFromAlgorithm(mTargetPayloadWrapAlgName);
-                if (targetKeySize == 0) {
-                    targetKeySize = 128;  // Default
-                }
+                // Use target key size from command-line parameter
+                int targetKeySize = mTargetPayloadWrapKeySize;
 
                 kg.initialize(targetKeySize);
                 kg.setKeyUsages(new SymmetricKey.Usage[] { SymmetricKey.Usage.WRAP, SymmetricKey.Usage.UNWRAP });
@@ -7105,10 +7137,8 @@ public class KRATool {
             else if (metaInfo.startsWith("sessionKeyLength:")) {
                 // Check if we regenerated the session key
                 if (mSessionKeyDecisionMade != null && mSessionKeyDecisionMade) {
-                    int targetKeySize = getKeySizeFromAlgorithm(mTargetPayloadWrapAlgName);
-                    if (targetKeySize == 0) {
-                        targetKeySize = 128;  // Default
-                    }
+                    // Use target key size from command-line parameter
+                    int targetKeySize = mTargetPayloadWrapKeySize;
                     updatedInfo = "sessionKeyLength:" + targetKeySize;
                     log("Updated sessionKeyLength: " + targetKeySize + NEWLINE, false);
                 }
@@ -7354,8 +7384,8 @@ public class KRATool {
         if (args.length < 2) {
             System.err.println("ERROR:  Insufficient arguments!"
                               + NEWLINE);
-            printUsage();
-            System.exit(0);
+
+            System.exit(1);
         }
 
         // Process command-line arguments
@@ -7424,33 +7454,42 @@ public class KRATool {
             } else if (args[i].contentEquals(TARGET_PAYLOAD_WRAP_ALGORITHM)) {
                 // cross-scheme
                 mTargetPayloadWrapAlgName = args[i + 1];
+                // Validate: reject non-AES algorithms for target (DES3, etc.)
+                String targetBase = getBaseAlgorithm(mTargetPayloadWrapAlgName);
+                if (targetBase != null && !targetBase.equalsIgnoreCase("AES")) {
+                    System.err.println("ERROR: Only AES is supported as a target algorithm" + NEWLINE);
+                    System.err.println("       Target algorithm '" + mTargetPayloadWrapAlgName + "' is not supported (detected: " + targetBase + ")" + NEWLINE);
+                    System.err.println("       Use AES-based algorithms (e.g., 'AES KeyWrap/Padding')" + NEWLINE);
+                    System.exit(1);
+                }
             } else if (args[i].contentEquals(SOURCE_PAYLOAD_WRAP_KEYSIZE)) {
                 // cross-scheme
                 try {
                     mSourcePayloadWrapKeySize = Integer.parseInt(args[i + 1]);
-                    if (mSourcePayloadWrapKeySize != 128 && mSourcePayloadWrapKeySize != 192 && mSourcePayloadWrapKeySize != 256) {
-                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 192, or 256" + NEWLINE);
-                        printUsage();
-                        System.exit(0);
+                    if (mSourcePayloadWrapKeySize != 128 && mSourcePayloadWrapKeySize != 168 &&
+                        mSourcePayloadWrapKeySize != 192 && mSourcePayloadWrapKeySize != 256) {
+                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 168, 192, or 256" + NEWLINE);
+
+                        System.exit(1);
                     }
                 } catch (NumberFormatException e) {
                     System.err.println("ERROR:  Invalid source payload wrapping key size: " + args[i + 1] + NEWLINE);
-                    printUsage();
-                    System.exit(0);
+
+                    System.exit(1);
                 }
             } else if (args[i].contentEquals(TARGET_PAYLOAD_WRAP_KEYSIZE)) {
                 // cross-scheme
                 try {
                     mTargetPayloadWrapKeySize = Integer.parseInt(args[i + 1]);
                     if (mTargetPayloadWrapKeySize != 128 && mTargetPayloadWrapKeySize != 192 && mTargetPayloadWrapKeySize != 256) {
-                        System.err.println("ERROR:  Target payload wrapping key size must be 128, 192, or 256" + NEWLINE);
-                        printUsage();
-                        System.exit(0);
+                        System.err.println("ERROR:  Target payload wrapping key size must be 128, 192, or 256 (AES only)" + NEWLINE);
+
+                        System.exit(1);
                     }
                 } catch (NumberFormatException e) {
                     System.err.println("ERROR:  Invalid target payload wrapping key size: " + args[i + 1] + NEWLINE);
-                    printUsage();
-                    System.exit(0);
+
+                    System.exit(1);
                 }
             } else if (args[i].contentEquals(USE_NSS_FOR_PAYLOAD_PROCESSING)) {
                 // cross-scheme: boolean flag, compensate for loop's i+=2
@@ -7472,20 +7511,20 @@ public class KRATool {
                 // cross-scheme: split output into multiple files
                 if (i + 1 >= args.length || args[i + 1].startsWith("-")) {
                     System.err.println("ERROR:  " + SPLIT_TARGET_LDIF_PER_RECORDS + " requires a numeric value" + NEWLINE);
-                    printUsage();
-                    System.exit(0);
+
+                    System.exit(1);
                 }
                 try {
                     mSplitTargetLdifPerRecords = Integer.parseInt(args[i + 1]);
                     if (mSplitTargetLdifPerRecords <= 0) {
                         System.err.println("ERROR:  Split records count must be greater than 0" + NEWLINE);
-                        printUsage();
-                        System.exit(0);
+
+                        System.exit(1);
                     }
                 } catch (NumberFormatException e) {
                     System.err.println("ERROR:  Invalid split records count: " + args[i + 1] + NEWLINE);
-                    printUsage();
-                    System.exit(0);
+
+                    System.exit(1);
                 }
             } else if (args[i].contentEquals(USE_CROSS_SCHEME)) {
                 // cross-scheme: boolean flag, compensate for loop's i+=2
@@ -7496,8 +7535,8 @@ public class KRATool {
                                   + args[i]
                                   + "'!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             }
         }
 
@@ -7514,8 +7553,8 @@ public class KRATool {
                 mLogFilename.length() == 0) {
             System.err.println("ERROR:  Missing mandatory arguments!"
                               + NEWLINE);
-            printUsage();
-            System.exit(0);
+
+            System.exit(1);
         } else {
             // Check for a valid KRATOOL config file
             cfgFile = new File(mKratoolCfgFilename);
@@ -7527,8 +7566,8 @@ public class KRATool {
                                   + "' does NOT exist, is NOT a file, "
                                   + "or is empty!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             }
 
             // Check for a valid source LDIF file
@@ -7541,8 +7580,8 @@ public class KRATool {
                                   + "' does NOT exist, is NOT a file, "
                                   + "or is empty!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             }
 
             // Check that the target LDIF file does NOT exist
@@ -7552,8 +7591,8 @@ public class KRATool {
                                   + mTargetLdifFilename
                                   + "' ALREADY exists!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             }
 
             // Check that the log file does NOT exist
@@ -7563,8 +7602,8 @@ public class KRATool {
                                   + mLogFilename
                                   + "' ALREADY exists!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             }
         }
 
@@ -7582,8 +7621,8 @@ public class KRATool {
                     mTargetStorageCertificateFilename.length() == 0) {
                 System.err.println("ERROR:  Missing 'Rewrap' arguments!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             } else {
                 // Check for a valid path to the PKI security databases
                 sourceDBPath = new File(mSourcePKISecurityDatabasePath);
@@ -7594,8 +7633,8 @@ public class KRATool {
                                       + "' does NOT exist or "
                                       + "'is NOT a directory!"
                                       + NEWLINE);
-                    printUsage();
-                    System.exit(0);
+
+                    System.exit(1);
                 }
 
                 // Check for a valid target storage certificate file
@@ -7609,8 +7648,8 @@ public class KRATool {
                                       + "' does NOT exist, is NOT a file, "
                                       + "or is empty!"
                                       + NEWLINE);
-                    printUsage();
-                    System.exit(0);
+
+                    System.exit(1);
                 }
 
                 // Mark the 'Rewrap' flag true
@@ -7627,8 +7666,8 @@ public class KRATool {
                                   + "and the 'remove ID Offset' option are "
                                   + "mutually exclusive!"
                                   + NEWLINE);
-            printUsage();
-            System.exit(0);
+
+            System.exit(1);
         }
 
         // Check to see that if the 'append ID Offset' command-line options
@@ -7644,8 +7683,8 @@ public class KRATool {
                                           + "' contains non-numeric "
                                           + "characters!"
                                           + NEWLINE);
-                        printUsage();
-                        System.exit(0);
+
+                        System.exit(1);
                     } else {
                         mAppendIdOffset = new BigInteger(
                                               append_id_offset);
@@ -7660,14 +7699,14 @@ public class KRATool {
                                       + exAppendPattern.toString()
                                       + "'"
                                       + NEWLINE);
-                    System.exit(0);
+                    System.exit(1);
                 }
             } else {
                 System.err.println("ERROR:  Missing "
                                   + "'append ID Offset' arguments!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             }
         }
 
@@ -7684,8 +7723,8 @@ public class KRATool {
                                           + "' contains non-numeric "
                                           + "characters!"
                                           + NEWLINE);
-                        printUsage();
-                        System.exit(0);
+
+                        System.exit(1);
                     } else {
                         mRemoveIdOffset = new BigInteger(
                                               remove_id_offset);
@@ -7700,14 +7739,14 @@ public class KRATool {
                                       + exRemovePattern.toString()
                                       + "'"
                                       + NEWLINE);
-                    System.exit(0);
+                    System.exit(1);
                 }
             } else {
                 System.err.println("ERROR:  Missing "
                                   + "'remove ID Offset' arguments!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             }
         }
 
@@ -7720,8 +7759,8 @@ public class KRATool {
                               + "'append ID Offset', or 'remove ID Offset' "
                               + "options MUST be specified!"
                               + NEWLINE);
-            printUsage();
-            System.exit(0);
+
+            System.exit(1);
         }
 
         // Check to see that if the OPTIONAL
@@ -7736,8 +7775,8 @@ public class KRATool {
                 System.err.println("ERROR:  Missing 'Password File' "
                                   + "arguments!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             } else {
                 if (mRewrapFlag) {
                     // Check for a valid source PKI
@@ -7752,8 +7791,8 @@ public class KRATool {
                                           + "' does NOT exist, is NOT a file, "
                                           + "or is empty!"
                                           + NEWLINE);
-                        printUsage();
-                        System.exit(0);
+
+                        System.exit(1);
                     }
 
                     use_PKI_security_database_pwdfile = SPACE
@@ -7778,8 +7817,8 @@ public class KRATool {
                                       + " option is ONLY valid when "
                                       + "performing rewrapping."
                                       + NEWLINE);
-                    printUsage();
-                    System.exit(0);
+
+                    System.exit(1);
                 }
             }
         } else {
@@ -7800,8 +7839,8 @@ public class KRATool {
                                   + "and 'target KRA naming context' "
                                   + "options MUST be specified!"
                                   + NEWLINE);
-                printUsage();
-                System.exit(0);
+
+                System.exit(1);
             } else {
                 process_kra_naming_context_fields = SPACE
                                                   + SOURCE_KRA_NAMING_CONTEXT

--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -2872,8 +2872,20 @@ public class KRATool {
 
                 // Fall through to Stage 2
             } catch (Exception e) {
-                log("ERROR: Unexpected error during direct clone: " + e.getMessage() + NEWLINE, true);
-                throw new Exception("Failed to clone session key", e);
+                // Generic exception during cloneKey (e.g., FIPS restrictions, token limitations)
+                // Cache the failure and fall through to Stage 2 RSA keypair method
+                mCloneKeyCapability = CloneKeyCapability.UNSUPPORTED;
+
+                if (mVerboseFlag) {
+                    log("Direct clone failed: " + e.getMessage() + NEWLINE, false);
+                    log("Will use RSA keypair method for all subsequent records" + NEWLINE, false);
+                    log("Stage 2: Falling back to JSS_KeyExchange-style temporary RSA keypair approach..." + NEWLINE, false);
+                } else {
+                    // Important: Log this once even without verbose
+                    log("Note: Direct clone not supported (" + e.getMessage() + ") - using RSA keypair transfer method for all records" + NEWLINE, false);
+                }
+
+                // Fall through to Stage 2
             }
         } else {
             // mCloneKeyCapability == UNSUPPORTED OR mForceRSAKeypairTransfer == true: Skip Stage 1 entirely
@@ -3239,40 +3251,9 @@ public class KRATool {
         try {
             if (mUseNssForPayloadProcessing) {
                 // Use NSS DB (software token) for payload unwrap/rewrap operations
+                // Note: In FIPS mode, the token is already logged in from CryptoManager initialization.
+                // In non-FIPS mode, explicit login is not required for key operations.
                 processingToken = CryptoManager.getInstance().getInternalKeyStorageToken();
-
-                // Login to Internal Key Storage Token if not already logged in
-                if (processingToken.isLoggedIn() == false && processingToken.passwordIsInitialized()) {
-                    BufferedReader in = null;
-                    String pwd = null;
-                    try {
-                        in = new BufferedReader(new FileReader(mSourcePKISecurityDatabasePwdfile));
-                        pwd = in.readLine();
-                        if (pwd == null) {
-                            pwd = "";
-                        }
-                    } catch (IOException exReadPwd) {
-                        log("ERROR: Failed to read NSS DB password from file '" + mSourcePKISecurityDatabasePwdfile + "': " + exReadPwd.getMessage() + NEWLINE, true);
-                        throw exReadPwd;
-                    } finally {
-                        if (in != null) {
-                            try {
-                                in.close();
-                            } catch (IOException exClosePwd) {
-                            }
-                        }
-                    }
-
-                    Password mPwd = new Password(pwd.toCharArray());
-                    try {
-                        processingToken.login(mPwd);
-                        if (mVerboseFlag) {
-                            log("Logged in to Internal Key Storage Token" + NEWLINE, false);
-                        }
-                    } finally {
-                        mPwd.clear();
-                    }
-                }
 
                 if (mVerboseFlag) {
                     log("Using NSS DB (software token) for payload processing" + NEWLINE, false);
@@ -3282,6 +3263,15 @@ public class KRATool {
                 processingToken = mSourceToken;
                 if (mVerboseFlag) {
                     log("Using same HSM for payload processing" + NEWLINE, false);
+                }
+            }
+
+            // Verify token is logged in (required in FIPS mode)
+            if (CryptoManager.getInstance().FIPSEnabled()) {
+                if (processingToken.needsLogin() && !processingToken.isLoggedIn()) {
+                    log("ERROR: FIPS mode requires processing token to be logged in, but it is not." + NEWLINE +
+                        "       Token state may be inconsistent." + NEWLINE, true);
+                    throw new Exception("FIPS mode: Processing token requires login but is not logged in");
                 }
             }
 
@@ -7962,6 +7952,19 @@ public class KRATool {
         }
         if (mTargetPayloadWrapAlgName != null) {
             System.out.println("Target payload wrap algorithm: " + mTargetPayloadWrapAlgName);
+        }
+
+        // Validate source keysize 168 is only used with DES3
+        if (mSourcePayloadWrapKeySize == 168) {
+            if (mSourcePayloadWrapAlgName == null) {
+                System.err.println("ERROR: Source payload wrap algorithm must be specified when using keysize 168" + NEWLINE);
+                System.exit(1);
+            }
+            String sourceBase = getBaseAlgorithm(mSourcePayloadWrapAlgName);
+            if (sourceBase == null || (!sourceBase.equalsIgnoreCase("DES3") && !sourceBase.equalsIgnoreCase("DESede"))) {
+                System.err.println("ERROR: Keysize 168 is only valid for DES3/DESede algorithms" + NEWLINE);
+                System.exit(1);
+            }
         }
 
         // Build cross-scheme parameters string for logging

--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -811,7 +811,7 @@ public class KRATool {
                                                                              "        " + "   (must match target KRA's configured algorithm)";
 
     private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE = "-source_payload_wrap_keysize";
-    private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|168|192|256> Source payload wrapping key size in bits (default: 128, use 168 for DES3)";
+    private static final String SOURCE_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Source payload wrapping key size in bits (default: 128, use 192 for DES3)";
 
     private static final String TARGET_PAYLOAD_WRAP_KEYSIZE = "-target_payload_wrap_keysize";
     private static final String TARGET_PAYLOAD_WRAP_KEYSIZE_DESCRIPTION = "  <128|192|256> Target payload wrapping key size in bits (default: 128, AES only)";
@@ -7471,7 +7471,7 @@ public class KRATool {
                     mSourcePayloadWrapKeySize = Integer.parseInt(args[i + 1]);
                     if (mSourcePayloadWrapKeySize != 128 && mSourcePayloadWrapKeySize != 168 &&
                         mSourcePayloadWrapKeySize != 192 && mSourcePayloadWrapKeySize != 256) {
-                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 168, 192, or 256" + NEWLINE);
+                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 192, or 256" + NEWLINE);
 
                         System.exit(1);
                     }


### PR DESCRIPTION
  ## Summary

  This PR contains multiple fixes for KRATool cross-scheme migration
  functionality, addressing issues with FIPS mode compatibility, key size
  handling, and NSS DB authentication.

  ## Fixes Included

  ### 1. Fix KRATool session key size generation (#5400)
  - Corrected session key size generation in cross-scheme migration
  - Ensures proper key size is used when regenerating session keys

  ### 2. Fix DES3 key size for PKCS#11 unwrap operations (#5402)
  - Fixed DES3 key size handling in PKCS#11 unwrap operations
  - Updated documentation to recommend 192-bit DES3 keys

  ### 3. Fix KRATool cloneKey fallback to support FIPS mode restrictions
  - When `importSessionKeyToToken()` attempts direct `cloneKey()` in FIPS
  mode, it may fail with "Failed to create new symmetric key object"
  - Previously this caused the entire operation to fail
  - Now properly falls through to Stage 2 (RSA keypair transfer method) when
   direct cloning fails
  - Allows cross-scheme migration to work in FIPS mode

  ### 4. Remove unnecessary NSS DB login in KRATool cross-scheme migration
  - Previous code attempted to login to Internal Key Storage Token using HSM
   password file
  - This caused failures in non-FIPS mode where NSS DB and HSM use different
   passwords
  - Investigation showed:
    - FIPS mode: Token already logged in from CryptoManager initialization
    - Non-FIPS mode: Explicit login not required for key operations
  - Removed login code to support both modes

  ## Testing

  All fixes have been tested on RHEL 8.6 in both FIPS and non-FIPS modes
  with `-use_nss_for_payload_processing` flag.

  ## Related Issues

  IDM-5560

  Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Target payload encryption now supports AES algorithms with configured key sizes.
  * Source key processing supports DES3 keys using a 168-bit key size.
  * Key metadata and session-key handling now reflect the selected algorithms and sizes.

* **Bug Fixes**
  * Improved fallback handling when importing session keys.
  * Corrected command-line error handling so invalid arguments exit with status 1 without displaying usage text.

* **Documentation**
  * Updated command-line help to describe AES-only target payload support and revised key-size requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->