### PR TITLE
Add post-installation config section for ML-KEM KRA

### DIFF
--- a/docs/installation/kra/installing-kra-with-pqc.adoc
+++ b/docs/installation/kra/installing-kra-with-pqc.adoc
@@ -33,6 +33,8 @@ To start the installation execute the following command:
 $ pkispawn -f kra-pqc.cfg -s KRA
 ....
 
+NOTE: For ML-KEM configuration and recommended security settings, see xref:post-installation-configuration[].
+
 == KRA system certificates
 
 After installation the KRA system certificates and keys are stored in the server NSS database (i.e. `/var/lib/pki/pki-tomcat/conf/alias`):
@@ -113,4 +115,35 @@ User "kraadmin"
   Email: kraadmin@example.com
   Type: adminType
   State: 1
+....
+
+[id="post-installation-configuration"]
+== Post-installation Configuration
+
+=== ML-KEM Configuration
+
+When installing a KRA with ML-KEM storage certificates, pkispawn automatically selects wrapping.2 configuration (instead of wrapping.1 for RSA/EC). This is reflected in `/var/lib/pki/pki-tomcat/conf/kra/CS.cfg` with `kra.storageUnit.wrapping.choice=2`.
+
+Key differences from RSA/EC storage:
+
+* ML-KEM uses key encapsulation instead of key wrapping (parameters `sessionKeyWrapAlgorithm` and `sessionKeyKeyGenAlgorithm` are unused)
+* ML-KEM currently does *not* support `kra.allowEncDecrypt.archival=true`
+
+=== Recommended Security Settings
+
+For improved PKCS#12 security (applies to all storage cert types), edit `/var/lib/pki/pki-tomcat/conf/kra/CS.cfg` and uncomment:
+
+[literal]
+....
+kra.legacyPKCS12=false
+kra.nonLegacyAlg=AES/None/PKCS5Padding/Kwp/256
+....
+
+This replaces legacy DES3-CBC PKCS#12 encryption with AES-256-KWP.
+
+After making changes, restart the instance:
+
+[literal]
+....
+$ systemctl restart pki-tomcatd@<pki_instance_name>.service
 ....


### PR DESCRIPTION
- Document ML-KEM wrapping.2 configuration differences
- Add recommended security settings (AES-KWP for PKCS#12)
- Note that ML-KEM doesn't support kra.allowEncDecrypt.archival

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added post-installation guidance for configuring ML-KEM after KRA installation.
  * Documented ML-KEM wrapping behavior and unsupported archival encryption and decryption.
  * Added recommendations for PKCS#12 AES-256-KWP settings and noted the required instance restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->