### PR TITLE
Updated documentation for configuring EST fullcmc - example

### DIFF
--- a/docs/installation/est/configuring-est-fullcmc-example.adoc
+++ b/docs/installation/est/configuring-est-fullcmc-example.adoc
@@ -170,6 +170,7 @@ Create `/root/dogtag/pki-ca/ca.cfg`:
 [source,ini]
 ----
 [DEFAULT]
+pki_hostname=pki.example.com
 pki_instance_name=pki-ca
 pki_https_port=8443
 pki_http_port=8080
@@ -283,7 +284,7 @@ You can verify the constraint is present:
 
 [source,bash]
 ----
-grep constraint /var/lib/pki/pki-ca/ca/profiles/ca/estFullcmcDeviceCert.cfg"
+grep constraint /var/lib/pki/pki-ca/ca/profiles/ca/estFullcmcDeviceCert.cfg
 ----
 
 You should see
@@ -700,6 +701,18 @@ CRMFPopClient -d nssdb-nonrole -p Secret.123 \
 ----
 
 Then in the CMCRequest configuration file, set `format=crmf` and `input=<input_file_name>.crmf`.
+====
+
+[NOTE]
+====
+The examples below use `pk12util` to import PKCS#12 files into NSS databases. `p12tool` can be used as a drop-in replacement, as `pk12util` does not properly handle AES Key Wrap (aes-kwp). To use `p12tool` instead:
+
+[source,bash]
+----
+p12tool -i <file>.p12 -d <nssdb_path> -K <nssdb_password> -W <p12_password>
+----
+
+Ensure the `dogtag-jss-tools` package is installed (`dnf install -y dogtag-jss-tools`).
 ====
 
 === Step 21: Test Non-Agent Enrollment (Matching Subject)


### PR DESCRIPTION
Updates:
- ca.cfg contents to include/define pki_hostname as pki.example.com to align with the rest of the guide
- Removed stray ' " ' 
- Added a note to specify how to use p12tool and shortcomings of using pk12util

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the CA configuration example with a PKI hostname.
  - Corrected the certificate constraint verification command.
  - Added guidance for using `p12tool` instead of `pk12util` for PKCS#12 imports, including syntax and package requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->