### PR TITLE
KRATool: Fix cloneKey fallback and add validation improvements

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -2807,8 +2807,20 @@ public class KRATool {
 
                 // Fall through to Stage 2
             } catch (Exception e) {
-                logger.error("Unexpected error during direct clone: " + e.getMessage());
-                throw new Exception("Failed to clone session key", e);
+                // Generic exception during cloneKey (e.g., FIPS restrictions, token limitations)
+                // Cache the failure and fall through to Stage 2 RSA keypair method
+                mCloneKeyCapability = CloneKeyCapability.UNSUPPORTED;
+
+                if (mVerboseFlag) {
+                    logger.info("Direct clone failed: " + e.getMessage());
+                    logger.info("Will use RSA keypair method for all subsequent records");
+                    logger.info("Stage 2: Falling back to JSS_KeyExchange-style temporary RSA keypair approach...");
+                } else {
+                    // Important: Log this once even without verbose
+                    logger.info("Note: Direct clone not supported (" + e.getMessage() + ") - using RSA keypair transfer method for all records");
+                }
+
+                // Fall through to Stage 2
             }
         } else {
             // mCloneKeyCapability == UNSUPPORTED OR mForceRSAKeypairTransfer == true: Skip Stage 1 entirely
@@ -3196,6 +3208,15 @@ public class KRATool {
                 processingToken = mSourceToken;
                 if (mVerboseFlag) {
                     logger.info("Using same HSM for payload processing");
+                }
+            }
+
+            // Verify token is logged in (required in FIPS mode)
+            if (CryptoManager.getInstance().FIPSEnabled()) {
+                if (processingToken.needsLogin() && !processingToken.isLoggedIn()) {
+                    logger.error("FIPS mode requires processing token to be logged in, but it is not.");
+                    logger.error("Token state may be inconsistent.");
+                    throw new Exception("FIPS mode: Processing token requires login but is not logged in");
                 }
             }
 
@@ -7275,7 +7296,8 @@ public class KRATool {
                     mSourcePayloadWrapKeySize = Integer.parseInt(args[i + 1]);
                     if (mSourcePayloadWrapKeySize != 128 && mSourcePayloadWrapKeySize != 168 &&
                         mSourcePayloadWrapKeySize != 192 && mSourcePayloadWrapKeySize != 256) {
-                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 192, or 256" + NEWLINE);
+                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 168, 192, or 256" + NEWLINE);
+                        System.err.println("        Note: 168 is only valid for DES3/DESede algorithms (use 192 for better PKCS#11 compatibility)" + NEWLINE);
                         System.exit(1);
                     }
                 } catch (NumberFormatException e) {
@@ -7709,6 +7731,19 @@ public class KRATool {
         }
         if (mTargetPayloadWrapAlgName != null) {
             System.out.println("Target payload wrap algorithm: " + mTargetPayloadWrapAlgName);
+        }
+
+        // Validate source keysize 168 is only used with DES3
+        if (mSourcePayloadWrapKeySize == 168) {
+            if (mSourcePayloadWrapAlgName == null) {
+                System.err.println("ERROR: Source payload wrap algorithm must be specified when using keysize 168" + NEWLINE);
+                System.exit(1);
+            }
+            String sourceBase = getBaseAlgorithm(mSourcePayloadWrapAlgName);
+            if (sourceBase == null || (!sourceBase.equalsIgnoreCase("DES3") && !sourceBase.equalsIgnoreCase("DESede"))) {
+                System.err.println("ERROR: Keysize 168 is only valid for DES3/DESede algorithms" + NEWLINE);
+                System.exit(1);
+            }
         }
 
         // Build cross-scheme parameters string for logging


### PR DESCRIPTION
Three improvements for KRATool cross-scheme migration:

1. Fix cloneKey fallback to support FIPS mode restrictions
   - When importSessionKeyToToken() attempts Stage 1 (direct cloneKey), it may fail with a generic Exception in FIPS mode
   - Ensure ANY exception during cloneKey (not just NotExtractableException) will fall through to Stage 2 (RSA keypair transfer method)
   - Cache the failure to avoid retrying cloneKey on subsequent records
   - This allows KRATool to work in FIPS mode with -use_nss_for_payload_processing

2. Validate keysize 168 is only used with DES3/DESede algorithms
   - The code accepts 168 (effective key strength) but silently converts to 192 (PKCS#11 representation with parity bits) for DES3
   - Reject 168 for AES or other algorithms to prevent invalid key sizes
   - We intentionally don't document 168 in help text; 192 is preferred

3. Add FIPS-mode-only token login verification
   - After login fallback attempt, verify token is logged in when CryptoManager.FIPSEnabled() is true
   - Catches unexpected token states in FIPS mode
   - Non-FIPS mode skips the check to preserve existing behavior
   - Non-invasive check won't break working code

Assisted-by: Claude
DOGTAG-4555 IDM-5560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session key import recovery when key extraction is unsupported, allowing RSA keypair transfer to continue.
  * Added validation to ensure required token login before cross-algorithm key rewrapping, especially in FIPS mode.
  * Restricted 168-bit source keys to supported DES3/DESede algorithms.
  * Required the source payload algorithm during command-line validation to prevent ambiguous or invalid key transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->