### PR TITLE
KRATool: Update error message to include keysize 168

### DIFF
--- a/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
+++ b/base/tools/src/main/java/com/netscape/cmstools/KRATool.java
@@ -7461,7 +7461,8 @@ public class KRATool {
                     mSourcePayloadWrapKeySize = Integer.parseInt(args[i + 1]);
                     if (mSourcePayloadWrapKeySize != 128 && mSourcePayloadWrapKeySize != 168 &&
                         mSourcePayloadWrapKeySize != 192 && mSourcePayloadWrapKeySize != 256) {
-                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 192, or 256" + NEWLINE);
+                        System.err.println("ERROR:  Source payload wrapping key size must be 128, 168, 192, or 256" + NEWLINE);
+                        System.err.println("        Note: 168 is only valid for DES3/DESede algorithms (use 192 for better PKCS#11 compatibility)" + NEWLINE);
 
                         System.exit(1);
                     }


### PR DESCRIPTION
Updates the error message for source payload wrapping key size validation to accurately reflect that 168 is an accepted value (for DES3/DESede only). The error message now lists all valid values (128, 168, 192, 256) with a note explaining that 168 is DES3-specific and 192 is recommended for better PKCS#11 compatibility.

This addresses reviewer feedback that the previous error message was misleading when operators entered a valid DES3 keysize of 168.

Assisted-by: Claude
DOGTAG-4555