### PR TITLE
DOGTAG-4540: Fix pkispawn EST deployment ModuleNotFoundError

### DIFF
--- a/base/server/python/pki/server/subsystem.py
+++ b/base/server/python/pki/server/subsystem.py
@@ -3679,6 +3679,14 @@ class ESTSubsystem(PKISubsystem):
         super().__init__(instance, 'est')
 
     @property
+    def db_create_module(self):
+        return 'est-create'
+ 
+    @property
+    def db_remove_module(self):
+        return 'est-remove'
+
+    @property
     def backend_conf(self):
         return os.path.join(self.conf_dir, 'backend.conf')
 


### PR DESCRIPTION
Override db_create_module and db_remove_module properties in ESTSubsystem to point to 'est-create' and 'est-remove' since EST is database-less.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added support for identifying the EST database creation and removal operations.
  * Improved EST subsystem database lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->