### PR TITLE
Fix: DOGTAG-4408 SSKG Fails on Thales HSM with error CKR_ATTRIBUTE_VA…

### DIFF
--- a/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
+++ b/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
@@ -203,10 +203,9 @@ public class RecoveryService implements IService {
                 if(useOAEPKeyWrap == true) {
                     wrapAlg = KeyWrapAlgorithm.RSA_OAEP;
                 }
-
                 SymmetricKey unwrappedSessionKey =
                         CryptoUtil.unwrap(token,  SymmetricKey.AES, 128,
-                        SymmetricKey.Usage.UNWRAP,
+                        SymmetricKey.Usage.DECRYPT,
                         transPrivateKey,
                         transWrappedSessionKey,
                         wrapAlg);


### PR DESCRIPTION
Fix: DOGTAG-4408 SSKG  Fails on Thales HSM with error CKR_ATTRIBUTE_VALUE_INVALID.

When decrypting the p12 password in the KRA with a session key, we must unwrap the session key with DECRYPT usage, since the next operation does a decryption with the key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side session-key processing during key generation to ensure encrypted keys are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->