### PR TITLE
Fix:DOGTAG-4585  SSKG Fails on Thales HSM with error CKR_ATTRIBUTE_VALUE_INVALID(RHCS 10.4).

### DIFF
--- a/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
+++ b/base/kra/src/main/java/com/netscape/kra/RecoveryService.java
@@ -196,10 +196,9 @@ public class RecoveryService implements IService {
                 if(useOAEPKeyWrap == true) {
                     wrapAlg = KeyWrapAlgorithm.RSA_OAEP;
                 }
-
                 SymmetricKey unwrappedSessionKey =
                         CryptoUtil.unwrap(token,  SymmetricKey.AES, 128,
-                        SymmetricKey.Usage.UNWRAP,
+                        SymmetricKey.Usage.DECRYPT,
                         transPrivateKey,
                         transWrappedSessionKey,
                         wrapAlg);


### PR DESCRIPTION

When decrypting the p12 password in the KRA with a session key, we must unwrap the session key with DECRYPT usage, since the next operation does a decryption with the key.