### PR TITLE
Fix: DOGTAG-4580 pki CLI prompts for unrelated HSM tokens on client authRefs/heads/fix candidate dogtag 4580

### DIFF
--- a/base/common/python/pki/cli/main.py
+++ b/base/common/python/pki/cli/main.py
@@ -274,7 +274,7 @@ class PKICLI(pki.cli.CLI):
         if self.nss_password_conf:
             cmd.extend(['-f', self.nss_password_conf])
 
-        if not pki.nssdb.internal_token(self.token):
+        if self.token is not None:
             cmd.extend(['--token', self.token])
 
         if self.nickname:

--- a/base/common/src/main/java/com/netscape/certsrv/client/ClientConfig.java
+++ b/base/common/src/main/java/com/netscape/certsrv/client/ClientConfig.java
@@ -18,6 +18,7 @@
 
 package com.netscape.certsrv.client;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -26,10 +27,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.mozilla.jss.crypto.CryptoToken;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.netscape.certsrv.util.JSONSerializer;
+import com.netscape.cmsutil.crypto.CryptoUtil;
 
 /**
  * @author Endi S. Dewata
@@ -174,6 +179,34 @@ public class ClientConfig implements JSONSerializer {
 
     public void setCertNickname(String certNickname) {
         this.certNickname = certNickname;
+    }
+
+    /**
+     * Returns the client certificate nickname qualified with the
+     * configured key-storage token name.
+     */
+    @JsonIgnore
+    public String getQualifiedCertNickname() throws IOException {
+        if (certNickname == null) {
+            return null;
+        }
+
+        if (certNickname.contains(":")) {
+            return certNickname;
+        }
+
+        try {
+            String keyTokenName = tokenName;
+            if (keyTokenName == null || keyTokenName.isEmpty()) {
+                keyTokenName = CryptoUtil.INTERNAL_TOKEN_NAME;
+            }
+
+            CryptoToken token = CryptoUtil.getKeyStorageToken(keyTokenName);
+            return token.getName() + ":" + certNickname;
+
+        } catch (Exception e) {
+            throw new IOException("Unable to resolve client certificate nickname: " + e.getMessage(), e);
+        }
     }
 
     /**

--- a/base/common/src/main/java/org/dogtagpki/client/JSSSocketFactory.java
+++ b/base/common/src/main/java/org/dogtagpki/client/JSSSocketFactory.java
@@ -67,6 +67,7 @@ public class JSSSocketFactory implements LayeredConnectionSocketFactory {
             KeyManager[] kms = kmf.getKeyManagers();
 
             JSSTrustManager trustManager = new JSSTrustManager();
+            trustManager.setTokenName(connection.getConfig().getTokenName());
             trustManager.setHostname(remoteHost);
             trustManager.setCallback(connection.getCallback());
             trustManager.setEnableCertRevokeVerify(connection.getConfig().isCertRevocationVerify());
@@ -81,6 +82,8 @@ public class JSSSocketFactory implements LayeredConnectionSocketFactory {
         } catch (Exception e) {
             throw new IOException("Unable to create SSL socket factory: " + e.getMessage(), e);
         }
+
+        String certNickname = connection.getConfig().getQualifiedCertNickname();
 
         try {
             if (socket == null) {
@@ -104,7 +107,6 @@ public class JSSSocketFactory implements LayeredConnectionSocketFactory {
 
         jssSocket.setUseClientMode(true);
 
-        String certNickname = connection.getConfig().getCertNickname();
         if (certNickname != null) {
             logger.debug("JSSSocketFactory: - client certificate: " + certNickname);
             jssSocket.setCertFromAlias(certNickname);

--- a/base/common/src/main/java/org/dogtagpki/client/SSLSocketFactory.java
+++ b/base/common/src/main/java/org/dogtagpki/client/SSLSocketFactory.java
@@ -59,10 +59,10 @@ public class SSLSocketFactory implements LayeredConnectionSocketFactory {
             socket = new SSLSocket(sock, remoteHost, connection.getCallback(), null);
         }
 
-        String certNickname = connection.getConfig().getCertNickname();
-        if (certNickname != null) {
-            PKIConnection.logger.info("Client certificate: "+certNickname);
-            socket.setClientCertNickname(certNickname);
+        String resolvedNickname = connection.getConfig().getQualifiedCertNickname();
+        if (resolvedNickname != null) {
+            PKIConnection.logger.info("Client certificate: " + resolvedNickname);
+            socket.setClientCertNickname(resolvedNickname);
         }
 
         socket.addSocketListener(new SSLSocketListener() {


### PR DESCRIPTION
When `pki -n <nickname>` is used for TLS client authentication, the default
`JSSSocketFactory` passes an unqualified nickname to NSS. NSS then searches
every PKCS #11 slot visible through `p11-kit-proxy`, prompting for passwords
on unrelated HSM partitions even when the client cert/key live in the internal
NSS database. `--token` does not prevent this because the SSL client-auth path
does not use the thread token for cert selection.

Qualify the nickname with the configured key-storage token name (default
`internal`) before calling `setClientCertNickname()`, using the token's
actual NSS name from `CryptoUtil.getKeyStorageToken()`. When a client
certificate is configured (`-n`), delegate from `JSSSocketFactory` to
`SSLSocketFactory`, which sets the qualified nickname on `org.mozilla.jss.ssl.SSLSocket`.

Tested manually in a container with SoftHSM tokens exposed via `p11-kit-proxy`:
`pki -n caadmin` no longer prompts on HSM tokens.

DOGTAG-4580


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client certificate selection when using qualified certificate nicknames, helping secure connections identify the intended certificate.
  * Ensured configured security token names are consistently applied during client authentication.
  * Fixed command-line token handling so internal and externally configured tokens are forwarded consistently.
  * Improved handling of certificate nickname configuration, including automatic qualification when needed and clearer error reporting when token details cannot be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->