### PR TITLE
FIX: return proper badNonce error type and Replay-Nonce

### DIFF
--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEEngine.java
@@ -602,16 +602,14 @@ public class ACMEEngine extends CMSEngine {
         }
 
         if (nonce == null) {
-            // TODO: generate proper exception
-            throw new Exception("Invalid nonce: " + value);
+            throw createBadNonceException("Invalid nonce: " + value);
         }
 
         long currentTime = System.currentTimeMillis();
         long expirationTime = nonce.getExpirationTime().getTime();
 
         if (expirationTime <= currentTime) {
-            // TODO: generate proper exception
-            throw new Exception("Expired nonce: " + value);
+            throw createBadNonceException("Expired nonce: "+ value);
         }
 
         logger.info("Valid nonce: " + value);
@@ -793,6 +791,14 @@ public class ACMEEngine extends CMSEngine {
         error.setDetail("Malformed request: " + desc);
 
         throw new ACMEException(HttpServletResponse.SC_BAD_REQUEST, error);
+    }
+    
+    public Exception createBadNonceException(String detail) {
+        ACMEError error = new ACMEError();
+        error.setType("urn:ietf:params:acme:error:badNonce");
+        error.setDetail(detail);
+        
+        throw new ACMEException(HttpServletResponse.SC_BAD_REQUEST,error);
     }
 
     public void updateAccount(ACMEAccount account) throws Exception {

--- a/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEServlet.java
+++ b/base/acme/src/main/java/org/dogtagpki/acme/server/ACMEServlet.java
@@ -5,6 +5,7 @@
 //
 package org.dogtagpki.acme.server;
 
+import java.io.IOException;
 import java.net.URISyntaxException;
 
 import javax.servlet.ServletContext;
@@ -13,11 +14,18 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.client.utils.URIBuilder;
+import org.dogtagpki.acme.ACMENonce;
 import org.dogtagpki.server.rest.v2.PKIServlet;
+
+import com.netscape.certsrv.base.PKIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ACMEServlet extends PKIServlet {
 
     private static final long serialVersionUID = 1L;
+
+    private static Logger logger = LoggerFactory.getLogger(ACMEServlet.class);
 
     protected ACMEEngine engine;
 
@@ -30,6 +38,29 @@ public class ACMEServlet extends PKIServlet {
     public ACMEEngine getACMEEngine() {
         ServletContext servletContext = getServletContext();
         return (ACMEEngine) servletContext.getAttribute("engine");
+    }
+
+    @Override
+    protected void handlePKIException(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            PKIException exception) throws IOException {
+
+        try {
+            ACMENonce nonce = engine.createNonce();
+            response.setHeader("Replay-Nonce", nonce.getID());
+
+        } catch (Exception e) {
+            logger.error("Unable to create nonce: " + e.getMessage(), e);
+            
+            response.sendError(
+                HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                "Unable to generate replacement nonce"
+            );
+            return;
+        }
+
+        super.handlePKIException(request, response, exception);
     }
 
     protected void addIndex(HttpServletRequest request, HttpServletResponse response) throws URISyntaxException {

--- a/base/server/src/main/java/org/dogtagpki/server/rest/v2/PKIServlet.java
+++ b/base/server/src/main/java/org/dogtagpki/server/rest/v2/PKIServlet.java
@@ -148,10 +148,7 @@ public abstract class PKIServlet extends HttpServlet {
         } catch (InvocationTargetException ite) {
 
             if (ite.getCause() instanceof PKIException pkie) {
-                response.setStatus(pkie.getCode());
-                response.setContentType(pkie.getSerializedFormat());
-                PrintWriter out = response.getWriter();
-                out.print(pkie.getSerializedError());
+                handlePKIException(request, response, pkie);
             } else {
                 logger.error("Unable to process request: {}", ite.getMessage(), ite);
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, ite.getCause().getMessage());
@@ -161,6 +158,15 @@ public abstract class PKIServlet extends HttpServlet {
             logger.error("Unable to process request: {}", e.getMessage(), e);
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         }
+    }
+    
+    protected void handlePKIException(HttpServletRequest request,
+                                      HttpServletResponse response,
+                                      PKIException exception) throws IOException {
+        response.setStatus(exception.getCode());
+        response.setContentType(exception.getSerializedFormat());
+        PrintWriter out = response.getWriter();
+        out.print(exception.getSerializedError());
     }
 
     public Method getActionMethod(HttpMethod met, String path) {


### PR DESCRIPTION
**Description**
When an ACME client sends a request with an invalid or reused nonce, the server returns a generic HTTP 500 error instead of the proper ACME error type. This forces clients to fetch a new nonce before retrying, which is inefficient.
This fix ensures the server returns:
- The correct urn:ietf:params:acme:error:badNonce error type (HTTP 400)
- A fresh Replay-Nonce header in error responses so clients can retry immediately

**Changes**
| File | Change |
| :--- | :--- |
| `PKIServlet.java` | Extract `PKIException` handling into overridable `handlePKIException()` method |
| `ACMEServlet.java` | Override `handlePKIException()` to add `Replay-Nonce` header before delegating to parent |
| `ACMEEngine.java` | Add `createBadNonceException()` for proper ACME error type; update `validateNonce()` to use it |

Test Procedure
1. Build and run the pki-acme container:
Using Docker to deploy and build the ACME service.

2. Verify basic endpoints:
curl http://localhost:8080/acme/directory
<img width="1106" height="114" alt="image" src="https://github.com/user-attachments/assets/6363e54b-cdd3-429f-b111-b7c6a02fea08" />

Should return 200 with Replay-Nonce header
curl -I http://localhost:8080/acme/new-nonce
<img width="1101" height="147" alt="image" src="https://github.com/user-attachments/assets/8692d874-71c9-4403-b4ab-4a875d01f9e9" />


3. Test invalid nonce (requires JWS-signed request):
Invalid nonce should return:
- HTTP 400
- Error type: urn:ietf:params:acme:error:badNonce
- Replay-Nonce header present

Using the Python script to test the invalid nonce.
```#!/usr/bin/env python3

import requests
import json
import sys
import base64
from cryptography.hazmat.primitives import hashes
from cryptography.hazmat.primitives.asymmetric import rsa, padding
from cryptography.hazmat.backends import default_backend

BASE = "http://localhost:8080/acme"
PASS = FAIL = 0


def b64url(data):
    if isinstance(data, int):
        data = data.to_bytes((data.bit_length() + 7) // 8, 'big')
    return base64.urlsafe_b64encode(data).rstrip(b'=').decode('ascii')


def test(name, condition, detail=""):
    global PASS, FAIL
    if condition:
        PASS += 1
        print(f"  [PASS] {name}")
    else:
        FAIL += 1
        print(f"  [FAIL] {name} {detail}")


def sign_jws(protected, payload, key):
    protected_b64 = b64url(json.dumps(protected, separators=(',', ':')).encode())
    payload_b64 = b64url(payload.encode() if isinstance(payload, str) else payload)
    msg = f"{protected_b64}.{payload_b64}".encode()
    sig = key.sign(msg, padding.PKCS1v15(), hashes.SHA256())
    return {"protected": protected_b64, "payload": payload_b64, "signature": b64url(sig)}


def get_nonce():
    r = requests.head(f"{BASE}/new-nonce", verify=False)
    return r.headers.get("Replay-Nonce")


def post_jws(path, nonce, payload, key, jwk_obj=None):
    protected = {"alg": "RS256", "nonce": nonce, "url": f"{BASE}{path}"}
    if jwk_obj:
        protected["jwk"] = jwk_obj
    return requests.post(
        f"{BASE}{path}",
        json=sign_jws(protected, payload, key),
        headers={"Content-Type": "application/jose+json"},
        verify=False
    )


private_key = rsa.generate_private_key(65537, 2048, default_backend())
jwk = {"kty": "RSA", "n": b64url(private_key.public_key().public_numbers().n),
        "e": b64url(private_key.public_key().public_numbers().e)}



# --- Test 1: Basic endpoints ---
r = requests.get(f"{BASE}/directory", verify=False)
test("GET /directory returns 200", r.status_code == 200)
test("Directory has newNonce", "newNonce" in r.json())

nonce = get_nonce()
test("HEAD /new-nonce returns Replay-Nonce", nonce is not None)
print()

# --- Test 2: Invalid nonce → badNonce error ---
print("[Test 2] Invalid nonce")
r = post_jws("/new-account", "totally-fake-nonce", '{"termsOfServiceAgreed":true}', private_key, jwk)
test("Returns 400", r.status_code == 400)
test("Error type is badNonce", "badNonce" in r.json().get("type", ""))
test("Response has Replay-Nonce", r.headers.get("Replay-Nonce") is not None)
print(f"  Error: {r.json().get('detail', 'N/A')}")
print()

# --- Test 3: Reused nonce → badNonce error ---
print("[Test 3] Reused nonce")
nonce = get_nonce()
r1 = post_jws("/new-account", nonce, '{"termsOfServiceAgreed":true}', private_key, jwk)
test("First request succeeds", r1.status_code in [200, 201])

r2 = post_jws("/new-account", nonce, '{"termsOfServiceAgreed":true}', private_key, jwk)
test("Reused nonce returns error", r2.status_code == 400)
test("Error type is badNonce", "badNonce" in r2.json().get("type", ""))
test("Response has Replay-Nonce", r2.headers.get("Replay-Nonce") is not None)
print()

# --- Test 4: Valid request (happy path) ---
print("[Test 4] Valid JWS")
nonce = get_nonce()
r = post_jws("/new-account", nonce, '{"termsOfServiceAgreed":true}', private_key, jwk)
test("Returns 200/201", r.status_code in [200, 201])
test("Response has Replay-Nonce", r.headers.get("Replay-Nonce") is not None)
test("Response has Location", "Location" in r.headers)
print(f"  Account: {r.headers.get('Location', 'N/A')}")
print() 
```
Test result:
<img width="1089" height="428" alt="image" src="https://github.com/user-attachments/assets/a5e2f1cd-bc6d-4e1b-b05c-f810456bd6b7" />

Additional Notes
- Follows RFC 8555 Section 6.5 (Replay-Nonce) and Section 6.7 (Error Responses)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or expired ACME nonces now return standardized `badNonce` errors with HTTP 400 responses.
  * ACME error responses now include a fresh replay nonce when available.
  * REST API error responses consistently preserve the appropriate status, content type, and error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->