### PR TITLE
Fix: DOGTAG-4608  [RHCS 9.7.z] TPS Not closing connections.

### DIFF
--- a/base/tps/src/main/java/org/dogtagpki/server/tps/main/PKCS11Obj.java
+++ b/base/tps/src/main/java/org/dogtagpki/server/tps/main/PKCS11Obj.java
@@ -502,21 +502,30 @@ public class PKCS11Obj {
         byte[] data = compressedData.toBytesArray();
 
         Inflater inflater = new Inflater();
-        inflater.setInput(data);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
-        byte[] buffer = new byte[1024];
-        while (!inflater.finished()) {
-            int count = inflater.inflate(buffer);
-            outputStream.write(buffer, 0, count);
+
+        try {
+            inflater.setInput(data);
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
+            byte[] buffer = new byte[1024];
+            while (!inflater.finished()) {
+                int count = inflater.inflate(buffer);
+                //Prevent possible spinning on corrupted data.
+                if (count == 0 && !inflater.finished()) {
+                    throw new TPSException("PKCS11Obj.uncompress: incomplete or corrupted compressed data");
+                }
+                outputStream.write(buffer, 0, count);
+            }
+            outputStream.close();
+            byte[] output = outputStream.toByteArray();
+            logger.debug("Original: " + data.length);
+            logger.debug("Uncompressed: " + output.length);
+
+            TPSBuffer result = new TPSBuffer(output);
+
+            return result;
+        } finally {
+            inflater.end();
         }
-        outputStream.close();
-        byte[] output = outputStream.toByteArray();
-        logger.debug("Original: " + data.length);
-        logger.debug("Uncompressed: " + output.length);
-
-        TPSBuffer result = new TPSBuffer(output);
-
-        return result;
     }
 
     public static void main(String[] args) throws TPSException, DataFormatException, IOException {


### PR DESCRIPTION
This simple fix prevents a malformed compressed PKCS11 Object on the token from going into an endless loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or corrupted compressed data.
  * The system now reports an error instead of potentially becoming unresponsive when compressed input cannot be processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->