### PR TITLE
Add JSP and template files to fapolicy trust database

### DIFF
--- a/base/server/etc/fapolicy.rules
+++ b/base/server/etc/fapolicy.rules
@@ -1,1 +1,3 @@
 allow perm=open dir=/usr/lib/jvm/ : dir=[WORK_DIR]/
+allow perm=open exe=/usr/lib/jvm/ uid=[USER] : path=glob:/usr/share/pki/**/*.jsp
+allow perm=open exe=/usr/lib/jvm/ uid=[USER] : path=glob:/usr/share/pki/**/*.template

--- a/base/server/python/pki/server/__init__.py
+++ b/base/server/python/pki/server/__init__.py
@@ -1846,7 +1846,8 @@ grant codeBase "file:%s" {
             'fapolicy.rules')
 
         params = {
-            'WORK_DIR': self.work_dir
+            'WORK_DIR': self.work_dir,
+            'USER': self.user
         }
 
         uid = pwd.getpwnam('root').pw_uid


### PR DESCRIPTION
On RHEL 10, libmagic classifies JSP files as "JavaScript source" instead of "HTML document" like in RHEL 8. This puts them in fapolicyd's %languages group, and since the RPM trust backend does not include .jsp files, they are denied by the default fapolicyd ruleset. This causes pkispawn to fail with a JSP compilation error when fapolicyd is enabled.

The fix adds JSP and template files to the fapolicy file trust backend during RPM post-install.

This fix is for DOGTAG-4549, DOGTAG-4548 and DOGTAG-4547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application policy handling so the PKI Java runtime can open required JSP and template files.
  * Ensured these permissions apply to the configured instance user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->