### PR TITLE
Allow Tomcat JULI to delete expired subsystem debug logs

### DIFF
--- a/base/server/share/conf/pki.policy
+++ b/base/server/share/conf/pki.policy
@@ -23,14 +23,14 @@ grant codeBase "file:${catalina.home}/bin/tomcat-juli.jar" {
         permission java.io.FilePermission "/usr/share/pki/-", "read";
 
         // Allow Tomcat JULI to generate subsystem log files.
-        permission java.io.FilePermission "${catalina.base}/logs/-", "read,write";
+        permission java.io.FilePermission "${catalina.base}/logs/-", "read,write,delete";
 };
 
 // If log rotate is initiated by a log call using slf4j-impl
 // the library need to have read/write access to log folder or
 // the policy will denied access and the rotation fails
 grant codeBase "file:/usr/share/java/slf4j/-" {
-        permission java.io.FilePermission "${catalina.base}/logs/-", "read,write";
+        permission java.io.FilePermission "${catalina.base}/logs/-", "read,write,delete";
 };
 
 // According to /etc/tomcat/catalina.policy:


### PR DESCRIPTION
Summary : 
PKI FileHandler.maxDays never removes CA debug logs because the Java SecurityManager grant for tomcat-juli.jar only allows read,write on ${catalina.base}/logs/-. Files.delete() requires the delete action. Tomcat's own logs/* grant does not apply to logs/ca/.

Change : 
base/server/share/conf/pki.policy: read,write → read,write,delete on ${catalina.base}/logs/- (tomcat-juli and slf4j grants).

Test plan :  On an IPA server:
1. Create /var/log/pki/pki-tomcat/ca/debug.2020-01-01.log as pkiuser with the same SELinux context as today's debug log.
2. Restart pki-tomcatd@pki-tomcat.
3. Confirm the 2020 file is gone and the service stays active.

Fixes https://github.com/dogtagpki/pki/issues/3731 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log rotation by allowing outdated log files to be deleted automatically.
  * Prevented log directories from accumulating obsolete files over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->