### PR TITLE
Add v11.10.1 changes docs for ml-kem support

### DIFF
--- a/docs/changes/v11.10.1/Server-Changes.adoc
+++ b/docs/changes/v11.10.1/Server-Changes.adoc
@@ -1,0 +1,18 @@
+= Server Changes =
+
+== ML-KEM Key Archival and Recovery in KRA ==
+
+The KRA now supports ML-KEM (FIPS 203) key archival and recovery.
+Transport and storage certificates may use ML-KEM-512, ML-KEM-768,
+or ML-KEM-1024. Other KRA system certificates (signing, audit signing,
+subsystem, SSL server) use ML-DSA (FIPS 204).
+
+=== Installation via pkispawn ===
+
+A new sample deployment configuration is provided at
+`/usr/share/pki/server/examples/installation/kra-pqc.cfg`.
+
+=== Key Enrollment with Archival ===
+
+The `CRMFPopClient` tool can be used to generate an ML-KEM certificate
+enrollment request with the key archival option.

--- a/docs/changes/v11.10.1/Tools-Changes.adoc
+++ b/docs/changes/v11.10.1/Tools-Changes.adoc
@@ -1,0 +1,8 @@
+= Tools Changes =
+
+== Changes in hsmCompatVerify ==
+
+The `hsmCompatVerifyServ` and `hsmCompatVerifyClnt` tools now support
+post-quantum cryptography (PQC). Both tools accept the `--pqc` flag to
+enable ML-DSA (FIPS 204) and ML-KEM (FIPS 203) workflows for HSM
+compatibility verification of key archival and recovery operations.


### PR DESCRIPTION
Add Tools-Changes.adoc and Server-Changes.adoc under docs/changes/v11.10.1/ documenting PQC ml-kem support added in PKI 11.10.1:
- hsmCompatVerify tools now support ML-DSA/ML-KEM (with focus on ml-kem) workflows
- KRA supports ML-KEM key archival and recovery via pkispawn and CRMFPopClient

Assisted-by: Claude
IDM-8026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for ML-KEM support in KRA key archival and recovery workflows.
  * Added a sample post-quantum deployment configuration for KRA.
  * Documented ML-KEM certificate enrollment support through `CRMFPopClient`.
  * Added documentation for enabling ML-DSA and ML-KEM workflows in HSM compatibility verification tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->