### PR TITLE
Add ML-KEM Proof of Possession note for CRMFPopClient

### DIFF
--- a/docs/changes/v11.10.1/Server-Changes.adoc
+++ b/docs/changes/v11.10.1/Server-Changes.adoc
@@ -16,3 +16,6 @@ A new sample deployment configuration is provided at
 
 The `CRMFPopClient` tool can be used to generate an ML-KEM certificate
 enrollment request with the key archival option.
+
+See the CRMFPopClient section in the Tools Changes document for important
+information about Proof of Possession for ML-KEM enrollment requests.

--- a/docs/changes/v11.10.1/Tools-Changes.adoc
+++ b/docs/changes/v11.10.1/Tools-Changes.adoc
@@ -6,3 +6,18 @@ The `hsmCompatVerifyServ` and `hsmCompatVerifyClnt` tools now support
 post-quantum cryptography (PQC). Both tools accept the `--pqc` flag to
 enable ML-DSA (FIPS 204) and ML-KEM (FIPS 203) workflows for HSM
 compatibility verification of key archival and recovery operations.
+
+== ML-KEM Support in CRMFPopClient ==
+
+The `CRMFPopClient` tool can now generate ML-KEM (FIPS 203) certificate
+enrollment requests, including requests that use the key archival option.
+
+NOTE: ML-KEM keys cannot sign, so `CRMFPopClient` automatically uses
+`POP_NONE` when generating an ML-KEM request (including requests used for
+KRA key archival). The request therefore includes no Proof of Possession,
+and the CA cannot verify that the requester owns the ML-KEM private key.
+Run `CRMFPopClient` and submit these requests only from a trusted,
+authenticated environment (for example, a secure enrollment portal or an
+operator-controlled host on a trusted network). Support for Proof of
+Possession with ML-KEM keys is planned and will be added in a future
+release.


### PR DESCRIPTION
Document that CRMFPopClient uses POP_NONE for ML-KEM enrollment requests (no Proof of Possession) and advise generating and submitting such requests from a trusted, authenticated environment. Add a cross reference from Server-Changes to the Tools-Changes note.

Assisted-by: Claude
IDM-8026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented support for generating ML-KEM (FIPS 203) certificate enrollment requests with `CRMFPopClient`, including key archival requests.
  * Clarified that these requests do not include Proof of Possession and should be run only in trusted, authenticated environments.
  * Added guidance directing readers to the relevant tool documentation for important ML-KEM enrollment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->